### PR TITLE
use editline (--with-libedit) if possible

### DIFF
--- a/src/PhpBrew/Variants.php
+++ b/src/PhpBrew/Variants.php
@@ -157,6 +157,9 @@ class Variants
         if( $prefix = $this->checkHeader('libintl.h') ) {
             $opts[] = '--with-gettext=' . $prefix;
         }
+        if( $prefix = $this->checkHeader('editline' . DIRECTORY_SEPARATOR . 'readline.h') ) {
+            $opts[] = '--with-libedit=' . $prefix;
+        }
         return $opts;
     }
 


### PR DESCRIPTION
according to this link https://bugs.php.net/bug.php?id=48608

The default libreadline comes with Mac OS X is not GNU readline, It
is BSD version of GNU readline called editline, it provides wrapper
for readline, but not fully compatible with GNU readline.
