### PR TITLE
Build PHP 5.5.0 alpha1 support

### DIFF
--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -11,7 +11,10 @@ class KnownCommand extends \CLIFramework\Command
     {
         $opts->add('svn','list subversion phps');
         $opts->add('old','list old phps (less than 5.3)');
-        $opts->add('stas','list stas phps');
+        $managers = PhpSource::getReleaseManagers();
+        foreach($managers as $id => $fullName) {
+            $opts->add($id,"list $id phps");
+        }
     }
 
     public function execute()
@@ -30,11 +33,16 @@ class KnownCommand extends \CLIFramework\Command
             }
         }
 
-        if( $this->options->stas ) {
-            $versions = \PhpBrew\PhpSource::getStasVersions();
-            echo $this->formatter->format("Available versions from PhpStas:\n",'yellow');
-            foreach( $versions as $version => $arg ) {
-                echo "\t" . $version . "\n";
+        $managers = PhpSource::getReleaseManagers();
+        foreach($managers as $id => $fullName) {
+            if( $this->options->$id ) {
+                $versions = \PhpBrew\PhpSource::getReleaseManagerVersions($id);
+                echo $this->formatter->format(
+                    "Available versions from PHP Release Manager: $fullName\n",
+                    'yellow');
+                foreach( $versions as $version => $arg ) {
+                    echo "\t" . $version . "\n";
+                }
             }
         }
     }

--- a/src/PhpBrew/PhpSource.php
+++ b/src/PhpBrew/PhpSource.php
@@ -16,9 +16,17 @@ class PhpSource
         return version_compare($verion1, $verion2, '>') ? -1 : 1;
     }
 
-    static function getStasVersions()
+    static function getReleaseManagers()
     {
-        $baseUrl = 'http://downloads.php.net/stas/';
+        return array(
+            'stas' => 'Stanislav Malyshev',
+            'dsp' => 'David Soria Parra',
+        );
+    }
+
+    static function getReleaseManagerVersions($id)
+    {
+        $baseUrl = "http://downloads.php.net/$id/";
         $html = file_get_contents($baseUrl);
         $dom = new DOMDocument;
         $dom->loadHtml( $html );
@@ -103,9 +111,12 @@ class PhpSource
         if( isset($versions[$version]) )
             return $versions[ $version ];
 
-        $versions = self::getStasVersions();
-        if( isset($versions[$version]) )
-            return $versions[ $version ];
+        $managers = self::getReleaseManagers();
+        foreach($managers as $id => $fullName) {
+            $versions = self::getReleaseManagerVersions($id);
+            if( isset($versions[$version]) )
+                return $versions[ $version ];
+        }
     }
 
 }


### PR DESCRIPTION
Add --dsp option and refactor 'known' command 

PHP 5.5.0 alpha1 was released few days ago, and released under dsp
downloads page.
