### PR TITLE
Fixed +default+pgsql+mysql+sqlite not configure with pdo drivers issue.

### DIFF
--- a/tests/PhpBrew/VariantsTest.php
+++ b/tests/PhpBrew/VariantsTest.php
@@ -12,6 +12,17 @@ class VariantsTest extends PHPUnit_Framework_TestCase
         $options = $v->build();
         ok( in_array( '--enable-pdo' , $options ) );
         ok( $v->getVariantNames() );
+
+        $v = new PhpBrew\Variants;
+        ok( $v );
+        $v->enable('default');
+        $v->enable('sqlite');
+
+        $options = $v->build();
+        ok( in_array( '--enable-pdo' , $options ) );
+        ok( in_array( '--with-pdo-sqlite' , $options ) );
+        ok( $v->getVariantNames() );
+
     }
 }
 


### PR DESCRIPTION
NOW +default+pgsql will configure with  --enable-pdo --with-pgsql --with-pdo-pgsql correctly.
And virtual variants (ex. default , dbs .....)  will execute 'buildVariant' firstly. 
