### PR TITLE
Fixed +default+pgsql will not configure with pdo drivers issue

### DIFF
--- a/tests/PhpBrew/VariantsTest.php
+++ b/tests/PhpBrew/VariantsTest.php
@@ -12,6 +12,17 @@ class VariantsTest extends PHPUnit_Framework_TestCase
         $options = $v->build();
         ok( in_array( '--enable-pdo' , $options ) );
         ok( $v->getVariantNames() );
+
+        $v = new PhpBrew\Variants;
+        ok( $v );
+        $v->enable('default');
+        $v->enable('sqlite');
+
+        $options = $v->build();
+        ok( in_array( '--enable-pdo' , $options ) );
+        ok( in_array( '--with-pdo-sqlite' , $options ) );
+        ok( $v->getVariantNames() );
+
     }
 }
 


### PR DESCRIPTION
1. Fixed +default+sqlite or +dbs+sqlite will now configure --with-pdo-sqlite correctly.
2. +default or +dbs virtual variants will add combined variants to 'use' array, and support recursive buildVariant .

Ex.

```
phpbrew +sqlite+default+sqlite+sqlite+sqlite+dbs
```

will generate bellow and without duplicate arguments

```
--enable-pdo --with-sqlite3 --with-pdo-sqlite
```

Signed-off-by: Rack Lin racklin@gmail.com
