### PR TITLE
Added -variant to disable php feature.

### DIFF
--- a/src/PhpBrew/Builder.php
+++ b/src/PhpBrew/Builder.php
@@ -69,12 +69,12 @@ class Builder
     public function clean()
     {
         /**
-         * xxx: 
+         * xxx:
          * PHP_AUTOCONF=autoconf213 ./buildconf --force
          */
         if( file_exists('Makefile') ) {
             $this->logger->info('===> Cleaning...');
-            system('make clean > /dev/null') !== false 
+            system('make clean > /dev/null') !== false
                 or die('make clean error');
         }
     }
@@ -91,6 +91,10 @@ class Builder
         }
     }
 
+    public function disableVariant($variant)
+    {
+        $this->variants->disable( $variant );
+    }
 
     public function configure( $extra = array() )
     {
@@ -158,7 +162,7 @@ EOS;
 
 
             // patch for OVERALL_TARGET=libphp$PHP_MAJOR_VERSION.la
-            // libphp$(PHP_VERSION).la: 
+            // libphp$(PHP_VERSION).la:
             // replace .la files
             $patch=<<<'EOS'
 perl -i.bak -pe 's#
@@ -181,7 +185,7 @@ EOS;
         foreach( $extra as $a ) {
             $args[] = $a;
         }
-        
+
         $cmd->args($args);
 
         $this->logger->info("===> Configuring {$this->version}...");

--- a/tests/PhpBrew/VariantsTest.php
+++ b/tests/PhpBrew/VariantsTest.php
@@ -23,6 +23,18 @@ class VariantsTest extends PHPUnit_Framework_TestCase
         ok( in_array( '--with-pdo-sqlite' , $options ) );
         ok( $v->getVariantNames() );
 
+
+        $v = new PhpBrew\Variants;
+        ok( $v );
+        $v->enable('default');
+        $v->enable('sqlite');
+        $v->disable('pdo');
+
+        $options = $v->build();
+        ok( in_array( '--disable-pdo' , $options ) );
+        ok( in_array( '--with-sqlite3' , $options ) );
+        ok( $v->getVariantNames() );
+
     }
 }
 


### PR DESCRIPTION
Implemented -variant for removing variant.

Ex1. build php with default variant and sqlite support but without pdo and pdo-sqlite driver

```
phpbrew install php-5.3.21 +default+sqlite-pdo
```

Ex2. build php enable all features but without pdo and sqlite

```
phpbrew install php-5.3.21 +all-sqlite-pdo
```

Ref: #32

Signed-off-by: Rack Lin racklin@gmail.com
