### PR TITLE
Fixed #51 EnvCommand display and save error messages to init file bug

### DIFF
--- a/src/PhpBrew/Command/EnvCommand.php
+++ b/src/PhpBrew/Command/EnvCommand.php
@@ -18,20 +18,22 @@ class EnvCommand extends \CLIFramework\Command
         $home = Config::getPhpbrewHome();
         $buildDir = Config::getBuildDir();
 
-        // checking php version exists
-        $targetPhpBinPath = Config::getVersionBinPath($version);
-        if (!is_dir($targetPhpBinPath)) {
-            throw new Exception("php version: " . $version . " not exists.");
-        }
-
         // $versionBuildPrefix = Config::getVersionBuildPrefix($version);
         // $versionBinPath     = Config::getVersionBinPath($version);
 
         echo 'export PHPBREW_ROOT=' . $root . "\n";
         echo 'export PHPBREW_HOME=' . $home . "\n";
 
-        echo 'export PHPBREW_PHP='  . $version . "\n";
-        echo 'export PHPBREW_PATH=' . ($version ? Config::getVersionBinPath($version) : '') . "\n";
+        if ($version !== false) {
+            // checking php version exists
+            $targetPhpBinPath = Config::getVersionBinPath($version);
+            if (!is_dir($targetPhpBinPath)) {
+                throw new Exception("# php version: " . $version . " not exists.");
+            }
+            echo 'export PHPBREW_PHP='  . $version . "\n";
+            echo 'export PHPBREW_PATH=' . ($version ? Config::getVersionBinPath($version) : '') . "\n";
+        }
+
     }
 
 }


### PR DESCRIPTION
if $version and PHPBREW_PHP env not exists, EnvCommand will throw exception, but exception message will been saved to ~/.phpbrew/init file.

This is cause phpbrew switch-off always display 'Could not open input file: version:' message or each time user logined and ~/.phpbrew/bashrc loaded.

Signed-off-by: Rack Lin racklin@gmail.com
