### PR TITLE
Installing older versions requires --old, this is not intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ With debug messages:
 $ phpbrew -d install --test php-5.4.0
 ```
 
+To install older versions (less than 5.3):
+
+```bash
+$ phpbrew install --old php-5.2.13
+```
 
 
 ## Variants


### PR DESCRIPTION
I was having no luck installing older versions, eventually checked-out the source and added debug statements to find out I need to specify --old for the install command as well.

Easiest improvement is probably to add a note in the Readme about it.
