### PR TITLE
Debian Squeeze updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ brew link icu4c
 **Please note that you need to disable suhosin patch to run phpbrew.**
 
 ```bash
-sudo apt-get install autoconf automake curl build-essential libxslt1-dev re2c libxml2-dev php5-cli
+sudo apt-get install autoconf automake curl build-essential libxslt1-dev re2c libxml2-dev php5-cli bison libbz2-dev
 sudo apt-get build-dep php5
 ```
 


### PR DESCRIPTION
I was getting some error wbout bison and:
configure: error: Please reinstall the BZip2 distribution

solution:
apt-get install bison libbz2-dev
