### PR TITLE
Use ROOT instead of HOME

### DIFF
--- a/phpbrew.sh
+++ b/phpbrew.sh
@@ -174,9 +174,9 @@ function __phpbrew_remove_purge ()
         return 1
     fi
 
-    _PHP_BIN_PATH=$PHPBREW_HOME/php/$_PHP_VERSION
-    _PHP_SOURCE_FILE=$PHPBREW_HOME/build/$_PHP_VERSION.tar.bz2
-    _PHP_BUILD_PATH=$PHPBREW_HOME/build/$_PHP_VERSION
+    _PHP_BIN_PATH=$PHPBREW_ROOT/php/$_PHP_VERSION
+    _PHP_SOURCE_FILE=$PHPBREW_ROOT/build/$_PHP_VERSION.tar.bz2
+    _PHP_BUILD_PATH=$PHPBREW_ROOT/build/$_PHP_VERSION
 
     if [ -d $_PHP_BIN_PATH ]; then
 


### PR DESCRIPTION
The remove/purge command should use PHPBREW_ROOT instead of PHPBREW_HOME. This affects system wide installations.
