### PR TITLE
Change the url for downloading php source archive from php.net

### DIFF
--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -18,11 +18,11 @@ class UrlDownloader
     public function download($url)
     {
         $this->logger->info("===> Downloading from $url");
-        $ret = preg_match('/php-.+\.tar\.bz2/', $url, $parts);
-        if ( false === $ret ) {
+        
+        $basename = $this->resolveDownloadFileName($url);
+        if (false === $basename) {
             throw new RuntimeException("Can not parse url: $url");
         }
-        $basename = $parts[0];
 
         // check for wget or curl for downloading the php source archive
         if( exec( 'command -v wget' ) ) {
@@ -39,6 +39,28 @@ class UrlDownloader
             throw new \Exception("Download failed.");
         }
         return $basename; // return the filename
+    }
+    
+    /**
+     *
+     * @param string $url
+     * @return string|boolean the resolved download file name or false it
+     * the url string can't be parsed
+     */
+    protected function resolveDownloadFileName($url)
+    {
+        // check if the url is for php source archive
+        if (preg_match('/php-.+\.tar\.bz2/', $url, $parts)) {
+            return $parts[0];
+        }
+
+        // try to get the filename through parse_url
+        $path = parse_url($url, PHP_URL_PATH);
+        if ( false === $path || false === strpos($path, ".") ) {
+            return false;
+        }
+
+        return basename( $path );
     }
 
 }


### PR DESCRIPTION
http://www.php.net/distributions/php_version.tar.bz2  adresses don't seem to work after the php.net design update 
