### PR TITLE
Bash completion

### DIFF
--- a/completion/bash/_phpbrew
+++ b/completion/bash/_phpbrew
@@ -19,7 +19,7 @@ _phpbrew_comp()
     esac
 
     case "${prev}" in
-        use|switch|clean|remove|purge)
+        use|switch|download|clean|remove|purge)
         # list installed php versions (system wide not included)
         opts="$(ls $PHPBREW_HOME/php/ | cut -d '-' -f 2)"
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )


### PR DESCRIPTION
Phpbrew bash completion  featuring:
- phpbrew [tab tab]
- phpbrew use|switch|clean|remove|purge|download [tab tab]
- phpbrew ext [tab tab]
- phpbrew ext install|disable|enable [tab tab]
- phpbrew help [tab tab]

TODO:
- `phpbrew install [tab tab]` completion for php versions and variants

PS: tested on Fedora for more than a month and totally forgot to commit and pull request. I guess this will probably work for other environments too.
