### PR TITLE
Infinite loop when running phpbrew ext install xxx

### DIFF
--- a/phpbrew.sh
+++ b/phpbrew.sh
@@ -26,7 +26,7 @@ function phpbrew ()
     if [[ -e bin/phpbrew ]] ; then
         BIN='bin/phpbrew'
     else
-        BIN='phpbrew'
+        BIN=$(which -p phpbrew)
     fi
 
     local exit_status

--- a/src/PhpBrew/Command/InitCommand.php
+++ b/src/PhpBrew/Command/InitCommand.php
@@ -85,7 +85,7 @@ function phpbrew ()
     if [[ -e bin/phpbrew ]] ; then
         BIN='bin/phpbrew'
     else
-        BIN='phpbrew'
+        BIN=$(which -p phpbrew)
     fi
 
     local exit_status
@@ -398,6 +398,8 @@ function __phpbrew_remove_purge ()
 
 EOS;
 // SHBLOCK }}}
+
+
 
 
 


### PR DESCRIPTION
I installed phpbrew globaly, and the bin is at /usr/local/bin/phpbrew.
When I run `phpbrew ext install any-ext-here`, nothing happens and
terminal complains about recursive level exceeded.

That's because when bin/phpbrew does not exist, BIN take phpbrew as
value. But as phpbrew is also the function name when `$BIN ${*:1}` (phpbrew.sh L141) is run, it runs the phpbrew function, not the binary, leading to the infinite loop.

To counter this, BIN should equal to `which -p phpbrew` which will look
for the binary file path specificaly, excluding the function.
