### PR TITLE
Fix the include path to the autoloader in bin/phpbrew

### DIFF
--- a/bin/phpbrew
+++ b/bin/phpbrew
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
 <?php
-$loader = require 'vendor/autoload.php';
+$loader = require __DIR__ . '/../vendor/autoload.php';
 $console = new PhpBrew\Console;
 $console->run( $argv );


### PR DESCRIPTION
The inclusion of the autoloader leads to an error if the script is not called from the main phpbrew directory.
