### PR TITLE
allow variants inheritance

### DIFF
--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -22,11 +22,11 @@ use CLIFramework\Command;
  * TODO: refactor tasks to Task class.
  */
 
-class InstallCommand extends Command 
+class InstallCommand extends Command
 {
     public function brief() { return 'install php'; }
 
-    public function usage() 
+    public function usage()
     {
         return 'phpbrew install [php-version] ([+variant...])';
     }
@@ -42,6 +42,7 @@ class InstallCommand extends Command
         $opts->add('patch:',  'apply patch before build');
         $opts->add('old','install old phps (less than 5.3)');
         $opts->add('f|force','force');
+        $opts->add('like:', 'inherit variants from previous build');
     }
 
     public function execute($version)
@@ -59,10 +60,16 @@ class InstallCommand extends Command
 
         $name = $this->options->name ?: $version;
 
+        // find inherited variants
+        $inheritedVariants = array();
+        if ($this->options->like) {
+        	$inheritedVariants = VariantParser::getInheritedVariants($this->options->like);
+        }
+
         // ['extra_options'] => the extra options to be passed to ./configure command
         // ['enabled_variants'] => enabeld variants
         // ['disabled_variants'] => disabled variants
-        $variantInfo = VariantParser::parseCommandArguments($args);
+        $variantInfo = VariantParser::parseCommandArguments($args, $inheritedVariants);
 
 
         $info = PhpSource::getVersionInfo( $version, $this->options->old );

--- a/src/PhpBrew/VariantParser.php
+++ b/src/PhpBrew/VariantParser.php
@@ -16,7 +16,7 @@ class VariantParser
     }
 
 
-    static function parseCommandArguments($args)
+    static function parseCommandArguments($args, array $inheritedVariants = array())
     {
         $extra = array();
 
@@ -62,39 +62,33 @@ class VariantParser
         }
 
         // inherit variants
-        if (!empty($enabledVariants['inherit'])) {
-            $inheritedVariants = self::getInheritedVariants($enabledVariants['inherit']);
-
-            if (isset($inheritedVariants['enabled_variants'])
-                && is_array($inheritedVariants['enabled_variants'])
-            ) {
-            	$enabledVariants = array_merge(
-            	    $inheritedVariants['enabled_variants'],
-            	    $enabledVariants
-                );
-            }
-
-            if (isset($inheritedVariants['disabled_variants'])
-                && is_array($inheritedVariants['disabled_variants'])
-            ) {
-                $disabledVariants = array_merge(
-                    $inheritedVariants['disabled_variants'],
-                    $disabledVariants
-                );
-            }
-
-            if (isset($inheritedVariants['extra_options'])
-                && is_array($inheritedVariants['extra_options'])
-            ) {
-                $extra = array_merge(
-                    $inheritedVariants['extra_options'],
-                    $extra
-                );
-            }
-
-            unset($enabledVariants['inherit']);
-
+        if (isset($inheritedVariants['enabled_variants'])
+            && is_array($inheritedVariants['enabled_variants'])
+        ) {
+        	$enabledVariants = array_merge(
+        	    $inheritedVariants['enabled_variants'],
+        	    $enabledVariants
+            );
         }
+
+        if (isset($inheritedVariants['disabled_variants'])
+            && is_array($inheritedVariants['disabled_variants'])
+        ) {
+            $disabledVariants = array_merge(
+                $inheritedVariants['disabled_variants'],
+                $disabledVariants
+            );
+        }
+
+        if (isset($inheritedVariants['extra_options'])
+            && is_array($inheritedVariants['extra_options'])
+        ) {
+            $extra = array_merge(
+                $inheritedVariants['extra_options'],
+                $extra
+            );
+        }
+
 
         return array(
             'enabled_variants' => $enabledVariants,


### PR DESCRIPTION
Allow inheritance of variants from previously installed version.
Example: phpbrew install 5.5.6 +inherit=5.4.21+...
    This would get the variants from 5.4.21 and merge them with the other given variants in the command
