### PR TITLE
Use cliframework v1.5.* as 1.6 doesn't seem to work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "corneltek\/cliframework": "~1.5",
+        "corneltek\/cliframework": "1.5.*",
         "corneltek\/pearx": "~1.3",
         "symfony\/process": "~2.3"
     },


### PR DESCRIPTION
With cliframework I run into the following error:

```
PHP Notice:  Trying to get property of non-object in /Users/chadrien/projects/chadrien/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Command/HelpCommand.php on line 97

Notice: Trying to get property of non-object in /Users/chadrien/projects/chadrien/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Command/HelpCommand.php on line 97
PHP Warning:  Invalid argument supplied for foreach() in /Users/chadrien/projects/chadrien/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Command/HelpCommand.php on line 97

Warning: Invalid argument supplied for foreach() in /Users/chadrien/projects/chadrien/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Command/HelpCommand.php on line 97
```
