### PR TITLE
Install phpunit.phar as phpunit into PHPBREW_BIN via "phpbrew install-phpunit"

### DIFF
--- a/phpbrew.sh
+++ b/phpbrew.sh
@@ -151,8 +151,11 @@ function phpbrew ()
             hash -r
             ;;
         install-phpunit)
-            pear channel-discover pear.phpunit.de
-            pear install -a phpunit/PHPUnit
+            echo "Installing phpunit..."
+            cd $PHPBREW_BIN && \
+                wget --no-check-certificate -c https://phar.phpunit.de/phpunit.phar -O phpunit && \
+                chmod +x phpunit && \
+                cd -
             hash -r
             ;;
         install-composer)


### PR DESCRIPTION
Hi, all.

I fixed the issue #240. By this pull request, we'll install phpunit via phpunit.phar not pear when you execute `phpbrew install-phpunit`.
