### PR TITLE
Made reference to autoload.php independent of the working directory

### DIFF
--- a/bin/phpbrew
+++ b/bin/phpbrew
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
 <?php
-$loader = require 'vendor/autoload.php';
+$loader = require __DIR__.'/../vendor/autoload.php';
 $console = new PhpBrew\Console;
 $console->run( $argv );


### PR DESCRIPTION
With the current code, autoloading only works when calling phpbrew as

```
bin/phpbrew
```

from the project's directory.
