### PR TITLE
Fixed non-working --patch option

### DIFF
--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -107,10 +107,11 @@ class InstallCommand extends Command
             $patchPaths = array();
 
             foreach ($this->options->patch as $patch) {
+                /** @var \SplFileInfo $patch */
                 $patchPath = realpath($patch);
 
                 if ($patchPath !== false) {
-                    $patchPaths[$patch] = $patchPath;
+                    $patchPaths[(string) $patch] = $patchPath;
                 }
 
             }

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -61,10 +61,10 @@ class ConfigureTask extends BaseTask
         $this->debug('Enabled variants: ' . join(', ', array_keys($build->getVariants())));
         $this->debug('Disabled variants: ' . join(', ', array_keys($build->getDisabledVariants())));
 
-        if ($patchFile = $options->patch) {
+        foreach ((array) $options->patch as $patchPath) {
             // copy patch file to here
-            $this->info("===> Applying patch file from $patchFile ...");
-            system("patch -p0 < $patchFile");
+            $this->info("===> Applying patch file from $patchPath ...");
+            system("patch -p0 < $patchPath");
         }
 
         // let's apply patch for libphp{php version}.so (apxs)


### PR DESCRIPTION
InstallCommand accepts multiple values for the --patch option, but fails at storing them in the $patchPaths array because $patch is a SplFileInfo object.

Furthermore, ConfigureTask only supports a single patch, whereas the patches are stored as array.
