### PR TITLE
Fix php 5.3 patch for 64bit systems

### DIFF
--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -101,7 +101,7 @@ class ConfigureTask extends BaseTask
             $cmd->execute() !== false or die('Configure failed.');
         }
 
-        $patch64bit = new \PhpBrew\Tasks\Patch64BitSupportTask($this->logger);
+        $patch64bit = new \PhpBrew\Tasks\Patch64BitSupportTask($this->logger, $options);
         $patch64bit->patch($build, $options);
     }
 }

--- a/src/PhpBrew/Tasks/Patch64BitSupportTask.php
+++ b/src/PhpBrew/Tasks/Patch64BitSupportTask.php
@@ -8,7 +8,9 @@ class Patch64BitSupportTask extends BaseTask
 
     public function match($build)
     {
-        return ( Utils::support64bit() && $build->compareVersion('5.4') == -1);
+        $currentVersion = preg_replace('/[^\d]*(\d+).(\d+).*/i', '$1.$2', $build->version);
+
+        return (Utils::support64bit() && version_compare($currentVersion, '5.3', '=='));
     }
 
     public function patch($build, $options)


### PR DESCRIPTION
There was a missing parameter and also the match function didn't worked correctly. That would break php 5.2  builds again and was previously fixed, see https://github.com/phpbrew/phpbrew/commit/827fba520ec3e0afd21b54b83bcdca82fcbf9da9. An other thing is that we have the code twice in the _Builder.php_ file, which should removed.
