### PR TITLE
Autodetect strip parameter for the patch operation

### DIFF
--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -72,7 +72,7 @@ class ConfigureTask extends BaseTask
                 ob_clean();
 
                 if ($return === 0) {
-                    system("patch -p$i --dry-run < $patchPath");
+                    system("patch -p$i < $patchPath");
                     break;
                 }
             }


### PR DESCRIPTION
Some patches require an other option than p0. This one will auto detect the right one. ;)
