### PR TITLE
Use getPhpbrewRoot function instead of env var

### DIFF
--- a/src/PhpBrew/Config.php
+++ b/src/PhpBrew/Config.php
@@ -119,7 +119,7 @@ class Config
 
     public static function getCurrentPhpDir()
     {
-        return getenv('PHPBREW_ROOT') . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR . self::getCurrentPhpName();
+        return self::getPhpbrewRoot() . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR . self::getCurrentPhpName();
     }
 
     public static function useSystemPhpVersion()


### PR DESCRIPTION
We used in the past the env var instead of the function so that could result in two different paths...
