### PR TITLE
Fix unstable PHP installation

### DIFF
--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -70,7 +70,10 @@ class InstallCommand extends Command
             $version = 'php-' . $version;
         }
 
-        $version = $this->getLatestMinorVersion($version, $this->options->old);
+        $latestMinorVersion = $this->getLatestMinorVersion($version, $this->options->old);
+        if (!empty($latestMinorVersion)) {
+            $version = $latestMinorVersion;
+        }
 
         $options = $this->options;
         $logger = $this->logger;


### PR DESCRIPTION
If install PHP with unstable version, we were get unexpected result like below.

```
$ phpbrew install php-5.6.0RC4
Version  not found.
```

Because $version in InstallCommand class will be overwritten to empty string by
getLatestMinorVersion()
