### PR TITLE
Fixed __phpbrew_reinit function when called with no arguments

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -389,7 +389,10 @@ function __phpbrew_update_config ()
 
 function __phpbrew_reinit () 
 {
-    if [[ $1 =~ ^php- ]]
+    if [[ -z "$1" ]]
+    then
+        local _PHP_VERSION=""
+    elif [[ $1 =~ ^php- ]]
     then
         local _PHP_VERSION=$1
     else


### PR DESCRIPTION
This fixes the behavior of `__phpbrew_reinit()` function when called with no php version argument (like when trying to switch-off phpbrew), the old behavior was preventing `phpbrew switch-off` from functioning normally.
