### PR TITLE
Support for .phpbrewrc

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -467,6 +467,7 @@ function _phpbrewrc_load ()
             if [[ -r .phpbrewrc ]]; then
                 # check if it's not the same .phpbrewrc which was previously loaded
                 if [[ "$PWD" != "$PHPBREW_LAST_RC_DIR" ]]; then
+                    __phpbrew_load_user_config
                     PHPBREW_LAST_RC_DIR="$PWD"
                     source .phpbrewrc
                 fi


### PR DESCRIPTION
This is a proof-of-concept which works with Bash on Ubuntu 14.10 x64. I didn't test any other configurations.

The `echo` statements may be useful for testing, but I believe they are worth removing after the implementation is approved.

The original idea was borrowed from https://github.com/phpbrew/phpbrew/pull/233.
