### PR TITLE
Allow usage as dependency of another project.

### DIFF
--- a/bin/phpbrew
+++ b/bin/phpbrew
@@ -1,6 +1,21 @@
 #!/usr/bin/env php
 <?php
-require __DIR__.'/../vendor/autoload.php';
+
+$includeIfExists = function($file)
+{
+    return file_exists($file) ? include $file : false;
+};
+
+if (
+    (!$loader = $includeIfExists(__DIR__.'/../vendor/autoload.php'))
+    && (!$loader = $includeIfExists(__DIR__.'/../../../autoload.php'))
+) {
+    echo 'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+        'curl -sS https://getcomposer.org/installer | php'.PHP_EOL.
+        'php composer.phar install'.PHP_EOL;
+    exit(1);
+}
+
 $console = new PhpBrew\Console;
 if (isset($argv)) {
     if (!$console->run($argv)) {


### PR DESCRIPTION
If installed as dependency, the `autoload.php` is not located in the phpmd root dir.
The snipped is stolen from the composer executable, see https://github.com/composer/composer/blob/master/src/bootstrap.php#L13-L23
