### PR TITLE
Fixed zsh comptability issue

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -108,7 +108,7 @@ function phpbrew ()
                     echo "Currently using $PHPBREW_PHP"
                 fi
             else
-                if [[ $2 =~ ^([[:digit:]]+\.){2}[[:digit:]]+$ ]]
+                if [[ $2 =~ "^([[:digit:]]+\.){2}[[:digit:]]+$" ]]
                 then
                     _PHP_VERSION="php-$2"
                 else
@@ -366,7 +366,7 @@ function __phpbrew_set_path ()
 function __phpbrew_update_config ()
 {
     local VERSION
-    if [[ $2 =~ ^([[:digit:]]+\.){2}[[:digit:]]+$ ]]
+    if [[ $2 =~ "^([[:digit:]]+\.){2}[[:digit:]]+$" ]]
     then
         VERSION="php-$1"
     else


### PR DESCRIPTION
ZSH shows the following errors when sourcing `phpbrew/bashrc` file:

```
/opt/phpbrew/bashrc:111: parse error near `('
```

```
/opt/phpbrew/bashrc:369: parse error near `('
```

I have managed to fix this by adding double quotes around regex strings.
