### PR TITLE
Fixes a bug that applying patches to apxs2 always fails.

### DIFF
--- a/src/PhpBrew/Tasks/Apxs2PatchTask.php
+++ b/src/PhpBrew/Tasks/Apxs2PatchTask.php
@@ -19,14 +19,14 @@ class Apxs2PatchTask extends BaseTask
 perl -i.bak -pe 's#
 libphp\$\(PHP_MAJOR_VERSION\)\.#libphp\$\(PHP_VERSION\)\.#gx' configure Makefile.global
 EOS;
-        if(Utils::system($patch) !== false) $this->fail();
+        $this->applyPatch($patch);
 
         $patch=<<<'EOS'
 perl -i.bak -pe 's#
 libs/libphp\$PHP_MAJOR_VERSION\.
 #libs/libphp\$PHP_VERSION\.#gx' configure Makefile.global
 EOS;
-        if(Utils::system($patch) !== false) $this->fail();
+        $this->applyPatch($patch);
 
         // replace .so files
         $patch=<<<'EOS'
@@ -34,7 +34,7 @@ perl -i.bak -pe 's#
 libs/libphp5.so
 #libs/libphp\$PHP_VERSION\.so#gx' configure Makefile.global
 EOS;
-        if(Utils::system($patch) !== false) $this->fail();
+        $this->applyPatch($patch);
 
         // patch for OVERALL_TARGET=libphp$PHP_MAJOR_VERSION.la
         // libphp$(PHP_VERSION).la:
@@ -44,17 +44,21 @@ perl -i.bak -pe 's#
 libs/libphp5.la
 #libs/libphp\$PHP_VERSION\.la#gx' configure Makefile.global
 EOS;
-        if(Utils::system($patch) !== false) $this->fail();
+        $this->applyPatch($patch);
 
         $patch=<<<'EOS'
 perl -i.bak -pe 's#
 libphp\$PHP_MAJOR_VERSION\.#libphp\$PHP_VERSION\.#gx' configure Makefile.global
 EOS;
-        if(Utils::system($patch) !== false) $this->fail();
+        $this->applyPatch($patch);
     }
 
-    public function fail()
+    private function applyPatch($patch)
     {
-        throw new RuntimeException('apxs2 patch failed.');
+        try {
+            Utils::system($patch);
+        } catch (Exception $e) {
+            throw new RuntimeException('apxs2 patch failed.', 0, $e);
+        }
     }
 }

--- a/tests/PhpBrew/UtilsTest.php
+++ b/tests/PhpBrew/UtilsTest.php
@@ -28,4 +28,17 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         ok(Utils::findBin('ls'));
         ok(Utils::findBin('psql'));
     }
+
+    public function testSystemReturnValueWhenSuccess()
+    {
+        $this->assertSame(0, Utils::system('true'));
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testSystemShouldThrowAnException()
+    {
+        Utils::system('false');
+    }
 }


### PR DESCRIPTION
Hi.

I found that `Apxs2PatchTask` always failed and fixed the issue.
The error message I caught is here:

```
% ./phpbrew install http://museum.php.net/php5/php-5.4.19.tar.bz2 +default +phar +pcre +zlib +dbs +openssl +pcre +mb +apxs2=/usr/bin/apxs
===> phpbrew will now build 5.4.19
===> Loading and resolving variants...
Checking distribution checksum...
Checksum matched:
===> Distribution file was successfully extracted, skipping...
===> Applying patch - apxs2 module version name ...
apxs2 patch failed. 
```

I manually tried `perl -i.bak -pe 's#libphp\$\(PHP_MAJOR_VERSION\)\.#libphp\$\(PHP_VERSION\)\.#gx' ~/.phpbrew/build/php-5.4.19/configure`(this command was executed in Apxs2Task internally) in CLI, but the return value was 0.
I think, the problem is that `Utils::system()` returns 0 when a command succeeds, so comparing the return value with false by `!==` is always true.

Sincerely.
