### PR TITLE
Fixed PATH and PATH_WITHOUT_PHPBREW was broken in ZSH.

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -351,7 +351,7 @@ function __phpbrew_set_path ()
     [[ -n $(alias php 2>/dev/null) ]] && unalias php 2> /dev/null
 
     if [[ -n $PHPBREW_ROOT ]] ; then
-        export PATH_WITHOUT_PHPBREW=$(IFS=":"; AR=(); for i in $PATH ; do [[ `expr "$i" : "$PHPBREW_ROOT"` -eq 0 ]] && AR+=($i); done; echo "${AR[*]}";)
+        export PATH_WITHOUT_PHPBREW=$(sh -c 'IFS=":"; AR=(); for i in $PATH ; do [[ `expr "$i" : "$PHPBREW_ROOT"` -eq 0 ]] && AR+=($i); done; echo "${AR[*]}";')
 
     fi
 


### PR DESCRIPTION
`IFS` not supported in **zsh**, using `sh -c` force using Bourne shell for resolve PATH_WITHOUT_PHPBREW env.

Signed-off-by: Rack Lin racklin@gmail.com
