### PR TITLE
Uses predefined environment variables in ConfigTest.

### DIFF
--- a/src/PhpBrew/Testing/CommandTestCase.php
+++ b/src/PhpBrew/Testing/CommandTestCase.php
@@ -5,18 +5,30 @@ use PhpBrew\Console;
 
 abstract class CommandTestCase extends BaseCommandTestCase
 {
+    private $previousPhpBrewRoot;
+    private $previousPhpBrewHome;
 
-    public function setupApplication() {
+    public function setupApplication()
+    {
         $console = Console::getInstance();
         $console->getLogger()->setQuiet();
         $console->getFormatter()->preferRawOutput();
         return $console;
     }
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
+        $this->previousPhpBrewRoot = getenv('PHPBREW_ROOT');
+        $this->previousPhpBrewHome = getenv('PHPBREW_HOME');
         putenv('PHPBREW_ROOT=' . getcwd() . '/tests/.phpbrew');
         putenv('PHPBREW_HOME=' . getcwd() . '/tests/.phpbrew');
+    }
+
+    public function tearDown()
+    {
+        putenv('PHPBREW_ROOT=' . $this->previousPhpBrewRoot);
+        putenv('PHPBREW_HOME=' . $this->previousPhpBrewHome);
     }
 
     public function runCommand($args)

--- a/tests/PhpBrew/ConfigTest.php
+++ b/tests/PhpBrew/ConfigTest.php
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * You should use predefined $PHPBREW_HOME and $PHPBREW_ROOT (defined
+ * in phpunit.xml), because they are used to create directories in
+ * PhpBrew\Config class. When you want to set $PHPBREW_ROOT, $PHPBREW_HOME
+ * or $HOME, you should get its value by calling `getenv' function and set
+ * the value to the corresponding environment variable.
  * @small
  */
 class ConfigTest extends PHPUnit_Framework_TestCase
@@ -17,201 +22,222 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testGetPhpbrewHomeWhenHOMEIsNotDefined()
     {
-        $this->withEnv(array(), function() {
+        $env = array(
+            'PHPBREW_HOME' => null,
+            'PHPBREW_ROOT' => null,
+            'HOME'         => null
+        );
+        $this->withEnv($env, function() {
             PhpBrew\Config::getPhpbrewHome();
         });
     }
 
     public function testGetPhpbrewHomeWhenHOMEIsDefined()
     {
-        $env = array('HOME' => '/home/phpbrew');
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/.phpbrew', PhpBrew\Config::getPhpbrewHome());
+        $env = array(
+            'HOME'         => getenv('PHPBREW_ROOT'),
+            'PHPBREW_HOME' => null
+        );
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew/.phpbrew', PhpBrew\Config::getPhpbrewHome());
         });
     }
 
     public function testGetPhpbrewHomeWhenPHPBREW_HOMEIsDefined()
     {
-        $env = array('PHPBREW_HOME' => '.phpbrew');
-        $this->withEnv($env, function() {
-            is('.phpbrew', PhpBrew\Config::getPhpbrewHome());
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getPhpbrewHome());
         });
     }
 
     public function testGetPhpbrewRootWhenPHPBREW_ROOTIsDefined()
     {
-        $env = array('PHPBREW_ROOT' => '.phpbrew');
-        $this->withEnv($env, function() {
-            is('.phpbrew', PhpBrew\Config::getPhpbrewRoot());
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getPhpbrewRoot());
         });
     }
 
     public function testGetPhpbrewRootWhenHOMEIsDefined()
     {
-        $env = array('HOME' => '/home/phpbrew');
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/.phpbrew', PhpBrew\Config::getPhpbrewRoot());
+        $env = array(
+            'HOME'         => getenv('PHPBREW_ROOT'),
+            'PHPBREW_ROOT' => null
+        );
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew/.phpbrew', PhpBrew\Config::getPhpbrewRoot());
         });
     }
 
     public function testGetVariants()
     {
-        $env = array(
-            'PHPBREW_HOME' => '/home/phpbrew/home',
-            'PHPBREW_ROOT' => '/home/phpbrew/root'
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/home/variants', PhpBrew\Config::getVariantsDir());
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/variants', PhpBrew\Config::getVariantsDir());
         });
     }
 
     public function testGetBuildDir()
     {
-        $env = array(
-            'PHPBREW_HOME' => '/home/phpbrew/home',
-            'PHPBREW_ROOT' => '/home/phpbrew/root'
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/build', PhpBrew\Config::getBuildDir());
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/build', PhpBrew\Config::getBuildDir());
+        });
+    }
+
+    public function testGetDistFileDir()
+    {
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/distfiles', PhpBrew\Config::getDistFileDir());
+        });
+    }
+
+    public function testGetTempFileDir()
+    {
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/tmp', PhpBrew\Config::getTempFileDir());
         });
     }
 
     public function testGetCurrentPhpName()
     {
         $env = array('PHPBREW_PHP' => '5.6.3');
-        $this->withEnv($env, function() {
-            is('5.6.3', PhpBrew\Config::getCurrentPhpName());
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('5.6.3', PhpBrew\Config::getCurrentPhpName());
         });
     }
 
     public function testGetCurrentBuildDir()
     {
-        $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
-            'PHPBREW_PHP'  => '5.6.3'
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/build/5.6.3', PhpBrew\Config::getCurrentBuildDir());
+        $env = array('PHPBREW_PHP' => '5.6.3');
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew/build/5.6.3', PhpBrew\Config::getCurrentBuildDir());
         });
     }
 
     public function testGetPHPReleaseListPath()
     {
-        $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php-releases.json', PhpBrew\Config::getPHPReleaseListPath());
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/php-releases.json', PhpBrew\Config::getPHPReleaseListPath());
         });
     }
 
     public function testGetInstallPrefix()
     {
-        $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php', PhpBrew\Config::getInstallPrefix());
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/php', PhpBrew\Config::getInstallPrefix());
         });
     }
 
     public function testGetVersionInstallPrefix()
     {
-        $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php/5.5.1', PhpBrew\Config::getVersionInstallPrefix('5.5.1'));
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1', PhpBrew\Config::getVersionInstallPrefix('5.5.1'));
         });
     }
 
     public function testGetVersionEtcPath()
     {
-        $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php/5.5.1/etc', PhpBrew\Config::getVersionEtcPath('5.5.1'));
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/etc', PhpBrew\Config::getVersionEtcPath('5.5.1'));
         });
     }
 
     public function testGetVersionBinPath()
     {
-        $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
-        );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php/5.5.1/bin', PhpBrew\Config::getVersionBinPath('5.5.1'));
+        $this->withEnv(array(), function($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin', PhpBrew\Config::getVersionBinPath('5.5.1'));
         });
     }
 
     public function testGetCurrentPhpConfigBin()
     {
         $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
             'PHPBREW_PHP'  => '5.5.1'
         );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php/5.5.1/bin/php-config', PhpBrew\Config::getCurrentPhpConfigBin());
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin/php-config', PhpBrew\Config::getCurrentPhpConfigBin());
         });
     }
 
     public function testGetCurrentPhpizeBin()
     {
         $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
             'PHPBREW_PHP'  => '5.5.1'
         );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php/5.5.1/bin/phpize', PhpBrew\Config::getCurrentPhpizeBin());
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin/phpize', PhpBrew\Config::getCurrentPhpizeBin());
+        });
+    }
+
+    public function testGetCurrentPhpConfigScanPath()
+    {
+        $env = array(
+            'PHPBREW_PHP'  => '5.5.1'
+        );
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/var/db', PhpBrew\Config::getCurrentPhpConfigScanPath());
         });
     }
 
     public function testGetCurrentPhpDir()
     {
         $env = array(
-            'PHPBREW_ROOT' => '/home/phpbrew/root',
             'PHPBREW_PHP'  => '5.5.1'
         );
-        $this->withEnv($env, function() {
-            is('/home/phpbrew/root/php/5.5.1', PhpBrew\Config::getCurrentPhpDir());
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1', PhpBrew\Config::getCurrentPhpDir());
         });
     }
 
     public function testGetLookupPrefix()
     {
         $env = array(
-            'PHPBREW_LOOKUP_PREFIX' => '/tmp',
+            'PHPBREW_LOOKUP_PREFIX' => getenv('PHPBREW_ROOT'),
         );
-        $this->withEnv($env, function() {
-            is('/tmp', PhpBrew\Config::getLookupPrefix());
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getLookupPrefix());
         });
     }
 
     public function testGetCurrentPhpBin()
     {
         $env = array(
-            'PHPBREW_PATH' => '/opt/bin/php',
+            'PHPBREW_PATH' => getenv('PHPBREW_ROOT'),
         );
-        $this->withEnv($env, function() {
-            is('/opt/bin/php', PhpBrew\Config::getCurrentPhpBin());
+        $this->withEnv($env, function($self) {
+            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getCurrentPhpBin());
         });
     }
 
+    public function testGetConfigParam()
+    {
+        $env = array(
+            'PHPBREW_ROOT' => __DIR__ . '/../fixtures/'
+        );
+        $this->withEnv($env, function($self) {
+            is(array('key1' => 'value1', 'key2' => 'value2'), PhpBrew\Config::getConfigParam());
+            is('value1', PhpBrew\Config::getConfigParam('key1'));
+            is('value2', PhpBrew\Config::getConfigParam('key2'));
+        });
+    }
+
+    /**
+     * PHPBREW_HOME and PHPBREW_ROOT are automatically defined if
+     * the function which invokes this method doesn't set them explicitly.
+     * Set PHPBREW_HOME and PHPBREW_ROOT to null when you want to unset them.
+     */
     public function withEnv($newEnv, $callback)
     {
         // reset environment variables
         $oldEnv = $this->resetEnv($newEnv + array(
             'HOME'                  => null,
-            'PHPBREW_HOME'          => null,
+            'PHPBREW_HOME'          => getenv('PHPBREW_HOME'),
             'PHPBREW_PATH'          => null,
             'PHPBREW_PHP'           => null,
-            'PHPBREW_ROOT'          => null,
+            'PHPBREW_ROOT'          => getenv('PHPBREW_ROOT'),
             'PHPBREW_LOOKUP_PREFIX' => null
         ));
 
         try {
-            $callback();
+            $callback($this);
             $this->resetEnv($oldEnv);
         } catch (\Exception $e) {
             $this->resetEnv($oldEnv);

--- a/tests/fixtures/config.yaml
+++ b/tests/fixtures/config.yaml
@@ -1,0 +1,2 @@
+key1: "value1"
+key2: "value2"


### PR DESCRIPTION
I've fixed ConfigTest to use `PHPBREW_ROOT` and `PHPBREW_HOME` defined in phpunit.xml as dummy data. Then, I've added some test cases for methods in ConfigTest which have side effects.
See https://github.com/phpbrew/phpbrew/pull/417#discussion_r21508756 to understand the background of this PR.
