### PR TITLE
Fixed search for apxs2 binary

### DIFF
--- a/src/PhpBrew/Tasks/Apxs2CheckTask.php
+++ b/src/PhpBrew/Tasks/Apxs2CheckTask.php
@@ -12,13 +12,14 @@ class Apxs2CheckTask extends BaseTask
     {
         $apxs = $build->getVariant('apxs2');
 
+        // trying to find apxs binary in case it wasn't explicitly specified (+apxs variant without path)
         if ($apxs === true) {
             $apxs = Utils::findbin('apxs');
             $this->logger->debug("Found apxs2 binary: $apxs");
         }
 
         if (!is_executable($apxs)) {
-            throw new Exception("apxs binary is not executable");
+            throw new Exception("apxs binary is not executable: $apxs");
         }
 
         // use apxs to check module dir permission


### PR DESCRIPTION
It looks like PhpBrew doesn't properly determine the path to apxs binary when it's not explicitly specified. It causes errors like the following:

```
↪  bin/phpbrew install 5.6.3 +default +apxs2
===> phpbrew will now build 5.6.3
===> Loading and resolving variants...
Checking distribution checksum...
Checksum matched: 13fb79d464b08392703e311778dd7ec0
===> Distribution file was successfully extracted, skipping...
Found existing Makefile, running make clean to ensure everything will be rebuilt.
You can append --no-clean option after the install command if you don't want to rebuild.
===> Cleaning...
make: Entering directory '/home/morozov/.phpbrew/build/php-5.6.3'
find . -name \*.gcno -o -name \*.gcda | xargs rm -f
find . -name \*.lo -o -name \*.o | xargs rm -f
find . -name \*.la -o -name \*.a | xargs rm -f
find . -name \*.so | xargs rm -f
find . -name .libs -a -type d|xargs rm -rf
rm -f libphp5.la sapi/cli/php sapi/cgi/php-cgi     modules/* libs/*
make: Leaving directory '/home/morozov/.phpbrew/build/php-5.6.3'
PHP Warning:  stream_get_contents(): 108 is not a valid stream resource in /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php on line 267
PHP Stack trace:
PHP   1. {main}() /home/morozov/Projects/phpbrew/bin/phpbrew:0
PHP   2. CLIFramework\Application->run() /home/morozov/Projects/phpbrew/bin/phpbrew:6
PHP   3. CLIFramework\CommandBase->executeWrapper() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Application.php:282
PHP   4. call_user_func_array:{/home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658}() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
PHP   5. PhpBrew\Command\InstallCommand->execute() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
PHP   6. PhpBrew\Tasks\ConfigureTask->configure() /home/morozov/Projects/phpbrew/src/PhpBrew/Command/InstallCommand.php:365
PHP   7. PhpBrew\Tasks\Apxs2CheckTask->check() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/ConfigureTask.php:87
PHP   8. PhpBrew\Utils::pipeExecute() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/Apxs2CheckTask.php:22
PHP   9. stream_get_contents() /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php:267

Warning: stream_get_contents(): 108 is not a valid stream resource in /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php on line 267

Call Stack:
    0.0001     238344   1. {main}() /home/morozov/Projects/phpbrew/bin/phpbrew:0
    0.0043     742232   2. CLIFramework\Application->run() /home/morozov/Projects/phpbrew/bin/phpbrew:6
    0.0182    2702336   3. CLIFramework\CommandBase->executeWrapper() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Application.php:282
    0.0185    2741296   4. call_user_func_array:{/home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658}() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
    0.0185    2745000   5. PhpBrew\Command\InstallCommand->execute() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
    0.2283    3321240   6. PhpBrew\Tasks\ConfigureTask->configure() /home/morozov/Projects/phpbrew/src/PhpBrew/Command/InstallCommand.php:365
    0.2389    3867400   7. PhpBrew\Tasks\Apxs2CheckTask->check() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/ConfigureTask.php:87
    0.2389    3867616   8. PhpBrew\Utils::pipeExecute() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/Apxs2CheckTask.php:22
    0.2395    3868288   9. stream_get_contents() /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php:267

PHP Warning:  stream_get_contents(): 112 is not a valid stream resource in /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php on line 267
PHP Stack trace:
PHP   1. {main}() /home/morozov/Projects/phpbrew/bin/phpbrew:0
PHP   2. CLIFramework\Application->run() /home/morozov/Projects/phpbrew/bin/phpbrew:6
PHP   3. CLIFramework\CommandBase->executeWrapper() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Application.php:282
PHP   4. call_user_func_array:{/home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658}() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
PHP   5. PhpBrew\Command\InstallCommand->execute() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
PHP   6. PhpBrew\Tasks\ConfigureTask->configure() /home/morozov/Projects/phpbrew/src/PhpBrew/Command/InstallCommand.php:365
PHP   7. PhpBrew\Tasks\Apxs2CheckTask->check() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/ConfigureTask.php:87
PHP   8. PhpBrew\Utils::pipeExecute() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/Apxs2CheckTask.php:29
PHP   9. stream_get_contents() /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php:267

Warning: stream_get_contents(): 112 is not a valid stream resource in /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php on line 267

Call Stack:
    0.0001     238344   1. {main}() /home/morozov/Projects/phpbrew/bin/phpbrew:0
    0.0043     742232   2. CLIFramework\Application->run() /home/morozov/Projects/phpbrew/bin/phpbrew:6
    0.0182    2702336   3. CLIFramework\CommandBase->executeWrapper() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Application.php:282
    0.0185    2741296   4. call_user_func_array:{/home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658}() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
    0.0185    2745000   5. PhpBrew\Command\InstallCommand->execute() /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:658
    0.2283    3321240   6. PhpBrew\Tasks\ConfigureTask->configure() /home/morozov/Projects/phpbrew/src/PhpBrew/Command/InstallCommand.php:365
    0.2389    3867400   7. PhpBrew\Tasks\Apxs2CheckTask->check() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/ConfigureTask.php:87
    0.2401    3867696   8. PhpBrew\Utils::pipeExecute() /home/morozov/Projects/phpbrew/src/PhpBrew/Tasks/Apxs2CheckTask.php:29
    0.2405    3868368   9. stream_get_contents() /home/morozov/Projects/phpbrew/src/PhpBrew/Utils.php:267

===> Applying patch - apxs2 module version name ...
```

The point is that when `$build->getVariant('apxs2')` returns `TRUE`, the following commands are executed via `Utils::pipeExecute()`: `1 -q LIBEXECDIR`, `1 -q SYSCONFDIR`. They cause the errors above.
