### PR TITLE
Using tr command to instead of bourne shell IFS function.

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -351,7 +351,7 @@ function __phpbrew_set_path ()
     [[ -n $(alias php 2>/dev/null) ]] && unalias php 2> /dev/null
 
     if [[ -n $PHPBREW_ROOT ]] ; then
-        export PATH_WITHOUT_PHPBREW=$(sh -c 'IFS=":"; AR=(); for i in $PATH ; do [[ `expr "$i" : "$PHPBREW_ROOT"` -eq 0 ]] && AR+=($i); done; echo "${AR[*]}";')
+        export PATH_WITHOUT_PHPBREW=$(AR=(); for i in `echo $PATH|tr ':' ' '` ; do [[ `expr "$i" : "$PHPBREW_ROOT" 2>/dev/null` -eq 0 ]] && AR+=($i); done; echo "${AR[*]}"|tr ' ' ':';)
 
     fi
 


### PR DESCRIPTION
Removed Bourne Shell IFS (http://en.wikipedia.org/wiki/Internal_field_separator) , that not compatible with **zsh** and **dash** .

Tested shell:

```
GNU bash, version 3.2.53(1)-release (x86_64-apple-darwin14)
zsh 5.0.5 (x86_64-apple-darwin14.0)
```

Fixed #431 

Signed-off-by: Rack Lin racklin@gmail.com
