### PR TITLE
Make InstallCommandTest faster.

### DIFF
--- a/src/PhpBrew/Machine.php
+++ b/src/PhpBrew/Machine.php
@@ -1,0 +1,64 @@
+<?php
+namespace PhpBrew;
+
+use PhpBrew\Utils;
+
+class Machine
+{
+    private static $instance;
+    private $processorNumber;
+
+    public function __construct()
+    {
+    }
+
+    public static function getInstance()
+    {
+        if (is_null(self::$instance)) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function detectProcessorNumber()
+    {
+        if ($this->processorNumber) {
+            return $this->processorNumber;
+        }
+
+        if ($this->processorNumber = $this->detectProcessorNumberByNproc()) {
+            return $this->processorNumber;
+        }
+
+        if ($this->processorNumber = $this->detectProcessorNumberByGrep()) {
+            return $this->processorNumber;
+        }
+
+        return null;
+    }
+
+    protected function detectProcessorNumberByNproc()
+    {
+        if (Utils::findBin('nproc')) {
+            $process = new Process('nproc');
+            $process->run();
+            $this->processorNumber = intval($process->getOutput());
+            return $this->processorNumber;
+        }
+
+        return null;
+    }
+
+    protected function detectProcessorNumberByGrep()
+    {
+        if (Utils::findBin('grep') && file_exists('/proc/cpuinfo')) {
+            $process = new Process('grep -c ^processor /proc/cpuinfo 2>/dev/null');
+            $process->run();
+            $this->processorNumber = intval($process->getOutput());
+            return $this->processorNumber;
+        }
+
+        return null;
+    }
+}

--- a/tests/PhpBrew/Command/InstallCommandTest.php
+++ b/tests/PhpBrew/Command/InstallCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 use PhpBrew\Testing\CommandTestCase;
+use PhpBrew\Machine;
 
 /**
  * @large
@@ -22,7 +23,9 @@ class InstallCommandTest extends CommandTestCase
      */
     public function testInstallCommand()
     {
-        $this->assertTrue($this->runCommand("phpbrew --quiet install 5.4.35 +default +intl"));
+        $processorNumber = Machine::getInstance()->detectProcessorNumber();
+        $jobs = is_numeric($processorNumber) ? "--jobs $processorNumber" : "";
+        $this->assertTrue($this->runCommand("phpbrew --quiet install $jobs 5.4.35 +default +intl"));
         $this->assertListContains("5.4.35");
     }
 
@@ -49,7 +52,9 @@ class InstallCommandTest extends CommandTestCase
      * @depends testInstallCommand
      */
     public function testInstallLikeCommand() {
-        $this->assertTrue($this->runCommand("phpbrew --quiet install 5.4.35 as myphp +soap"));
+        $processorNumber = Machine::getInstance()->detectProcessorNumber();
+        $jobs = is_numeric($processorNumber) ? "--jobs $processorNumber" : "";
+        $this->assertTrue($this->runCommand("phpbrew --quiet install $jobs 5.4.35 as myphp +soap"));
         $this->assertListContains("myphp");
     }
 

--- a/tests/PhpBrew/MachineTest.php
+++ b/tests/PhpBrew/MachineTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use PhpBrew\Machine;
+
+class MachineTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDetectProcessorNumber()
+    {
+        $machine = new MachineForTest();
+        if (!$machine->detectProcessorNumber()) {
+            skip();
+        }
+
+        ok($machine->detectProcessorNumber() > 0);
+        is(
+            $machine->detectProcessorNumber(),
+            $machine->detectProcessorNumberByNproc() || $machine->detectProcessorNumberByGrep()
+        );
+    }
+}
+
+class MachineForTest extends Machine
+{
+    public function __construct()
+    {
+    }
+
+    public function detectProcessorNumberByNproc()
+    {
+        return parent::detectProcessorNumberByNproc();
+    }
+
+    public function detectProcessorNumberByGrep()
+    {
+        return parent::detectProcessorNumberByGrep();
+    }
+}


### PR DESCRIPTION
# Motivation

`InstallCommandTest` builds PHP multiple times and takes very long time to finish, so we need to wait for a long time to get build status on Travis CI. After applying this PR, the time of running tests on Travis CI decreases from `15 min 15 sec` to `5 min 39 sec`, for example.
# Solution

I've added `--jobs`option in `InstallCommandTest` if we can get the number of CPU processors.
