### PR TITLE
Outputs install logs to stdout.

### DIFF
--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -149,6 +149,7 @@ class InstallCommand extends Command
         $opts->add('j|jobs:', 'Specifies the number of jobs to run build simultaneously (make -jN).')
             ->valueName('concurrent job number')
             ;
+        $opts->add('stdout', 'Outputs install logs to stdout.');
     }
 
     public function execute($version)

--- a/src/PhpBrew/CommandBuilder.php
+++ b/src/PhpBrew/CommandBuilder.php
@@ -65,6 +65,11 @@ class CommandBuilder
         return $this->getCommand();
     }
 
+    public function setStdout($stdout = true)
+    {
+        $this->stdout = $stdout;
+    }
+
     public function setAppendLog($append = true)
     {
         $this->append = $append;
@@ -93,13 +98,16 @@ class CommandBuilder
         }
 
         // redirect stderr to stdout and pipe to the file.
-        if ($this->stdout || $this->logPath) {
+        if ($this->stdout && $this->logPath) {
+            $cmd[] = '| tee';
             if ($this->append) {
-                $cmd[] = '>>';
-            } else {
-                $cmd[] = '>';
+                $cmd[] = '--append';
             }
-            $cmd[] = $this->stdout ?: $this->logPath;
+            $cmd[] = $this->logPath;
+            $cmd[] = '2>&1';
+        } elseif ($this->logPath) {
+            $cmd[] = $this->append ? '>>' : '>';
+            $cmd[] = $this->logPath;
             $cmd[] = '2>&1';
         }
         return join(' ', $cmd);

--- a/src/PhpBrew/Tasks/BuildTask.php
+++ b/src/PhpBrew/Tasks/BuildTask.php
@@ -22,6 +22,7 @@ class BuildTask extends BaseTask
 
         $cmd->setAppendLog(true);
         $cmd->setLogPath($build->getBuildLogPath());
+        $cmd->setStdout($this->options->{'stdout'});
 
         if (!empty($targets)) {
             foreach($targets as $t) {

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -106,6 +106,7 @@ class ConfigureTask extends BaseTask
         $this->info("===> Configuring {$build->version}...");
         $cmd->setAppendLog(true);
         $cmd->setLogPath($buildLogPath);
+        $cmd->setStdout($this->options->{'stdout'});
 
         $this->logger->info("\n");
         $this->logger->info("Use tail command to see what's going on:");

--- a/src/PhpBrew/Tasks/InstallTask.php
+++ b/src/PhpBrew/Tasks/InstallTask.php
@@ -16,6 +16,7 @@ class InstallTask extends BaseTask
         $cmd = new CommandBuilder('make install');
         $cmd->setAppendLog(true);
         $cmd->setLogPath($build->getBuildLogPath());
+        $cmd->setStdout($this->options->{'stdout'});
         if (!$this->options->dryrun) {
             $code = $cmd->execute();
             if ($code != 0) {

--- a/src/PhpBrew/Tasks/TestTask.php
+++ b/src/PhpBrew/Tasks/TestTask.php
@@ -21,6 +21,7 @@ class TestTask extends BaseTask
 
         $cmd->setAppendLog(true);
         $cmd->setLogPath($build->getBuildLogPath());
+        $cmd->setStdout($this->options->{'stdout'});
 
         $this->debug('' .  $cmd);
         $code = $cmd->execute();

--- a/tests/PhpBrew/CommandBuilderTest.php
+++ b/tests/PhpBrew/CommandBuilderTest.php
@@ -12,4 +12,73 @@ class CommandBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $cmd->execute());
         ob_end_clean();
     }
+
+    /**
+     * @dataProvider provideTestGetCommandTestCases
+     */
+    public function testGetCommand($appendLog, $stdout, $logPath, $expected)
+    {
+        $cmd = new PhpBrew\CommandBuilder('ls');
+        $cmd->setAppendLog($appendLog);
+        $cmd->setStdout($stdout);
+        $cmd->setLogPath($logPath);
+        $this->assertEquals($expected, $cmd->getCommand());
+        ob_start();
+        $this->assertEquals(0, $cmd->execute());
+        ob_end_clean();
+    }
+
+    public function provideTestGetCommandTestCases()
+    {
+        return array(
+            array(
+                'appendLog' => true,
+                'stdout'    => true,
+                'logPath'   => '/tmp/build.log',
+                'expected'      => 'ls | tee --append /tmp/build.log 2>&1'
+            ),
+            array(
+                'appendLog' => false,
+                'stdout'    => true,
+                'logPath'   => '/tmp/build.log',
+                'expected'      => 'ls | tee /tmp/build.log 2>&1'
+            ),
+            array(
+                'appendLog' => true,
+                'stdout'    => false,
+                'logPath'   => '/tmp/build.log',
+                'expected'      => 'ls >> /tmp/build.log 2>&1'
+            ),
+            array(
+                'appendLog' => false,
+                'stdout'    => false,
+                'logPath'   => '/tmp/build.log',
+                'expected'      => 'ls > /tmp/build.log 2>&1'
+            ),
+            array(
+                'appendLog' => true,
+                'stdout'    => true,
+                'logPath'   => null,
+                'expected'      => 'ls'
+            ),
+            array(
+                'appendLog' => false,
+                'stdout'    => true,
+                'logPath'   => null,
+                'expected'      => 'ls'
+            ),
+            array(
+                'appendLog' => true,
+                'stdout'    => false,
+                'logPath'   => null,
+                'expected'      => 'ls'
+            ),
+            array(
+                'appendLog' => false,
+                'stdout'    => false,
+                'logPath'   => null,
+                'expected'      => 'ls'
+            ),
+        );
+    }
 }


### PR DESCRIPTION
I fixed #362. Now we can output install logs(generated by `TestTask`, `ConfigureTask`, `InstallTask`, and `BuildTask`) to stdout using `tee` command.
- add --stdout option to InstallCommand.
- use tee command in CommandBuilder when --stdout is given.
