### PR TITLE
Removes redundant if statements in UrlDownloader.

### DIFF
--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -55,14 +55,10 @@ class UrlDownloader
             // check for wget or curl for downloading the php source archive
             if ($this->isWgetCommandAvailable()) {
                 $quiet = $this->logger->isQuiet() ? '--quiet' : '';
-                if (Utils::system("wget --no-check-certificate -c $quiet -O" . $targetFilePath . ' ' . $url)) {
-                    throw new RuntimeException("Download failed.\n");
-                }
+                Utils::system("wget --no-check-certificate -c $quiet -O" . $targetFilePath . ' ' . $url);
             } elseif ($this->isCurlCommandAvailable()) {
                 $silent = $this->logger->isQuiet() ? '--silent ' : '';
-                if (Utils::system("curl -C - -L $silent -o" . $targetFilePath . ' ' . $url)) {
-                    throw new RuntimeException("Download failed.\n");
-                }
+                Utils::system("curl -C - -L $silent -o" . $targetFilePath . ' ' . $url);
             } else {
                 throw new RuntimeException("Download failed - neither wget nor curl was found");
             }


### PR DESCRIPTION
## Purpose
To remove redundant if statements which should be removed in #444 . `Utils::system` method throws an exception if command fails, so there is no need to throw an exception after calling `Utils::system`.