### PR TITLE
'--downloader-connect-timeout' option has been added to several commands

### DIFF
--- a/src/PhpBrew/Command/DownloadCommand.php
+++ b/src/PhpBrew/Command/DownloadCommand.php
@@ -34,8 +34,9 @@ class DownloadCommand extends Command
         $opts->add('old', 'enable old phps (less than 5.3)');
         $opts->add('mirror:', 'Use mirror specific site.');
         
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of a php version not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
     }

--- a/src/PhpBrew/Command/DownloadCommand.php
+++ b/src/PhpBrew/Command/DownloadCommand.php
@@ -33,6 +33,11 @@ class DownloadCommand extends Command
         $opts->add('f|force', 'Force extraction');
         $opts->add('old', 'enable old phps (less than 5.3)');
         $opts->add('mirror:', 'Use mirror specific site.');
+        
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
     }
 
     public function execute($version)

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -140,6 +140,11 @@ class InstallCommand extends Command
             ->valueName('user:pass')
             ;
 
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
+        
         $opts->add('f|force', 'Force the installation.');
 
         $opts->add('d|dryrun', 'Do not build, but run through all the tasks.');

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -140,8 +140,9 @@ class InstallCommand extends Command
             ->valueName('user:pass')
             ;
 
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of a php version not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
         

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -19,8 +19,9 @@ class KnownCommand extends \CLIFramework\Command
         $opts->add('m|more', 'Show more older versions');
         $opts->add('o|old', 'List old phps (less than 5.3)');
         $opts->add('u|update', 'Update release list');
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of the versions list not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
     }

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -19,6 +19,10 @@ class KnownCommand extends \CLIFramework\Command
         $opts->add('m|more', 'Show more older versions');
         $opts->add('o|old', 'List old phps (less than 5.3)');
         $opts->add('u|update', 'Update release list');
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
     }
 
     public function execute()

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -24,6 +24,11 @@ class UpdateCommand extends \CLIFramework\Command
             ;
 
         $opts->add('official', 'Unserialize release information from official site (using `unserialize` function).');
+        
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
     }
 
     public function execute($branchName = 'master')

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -25,8 +25,9 @@ class UpdateCommand extends \CLIFramework\Command
 
         $opts->add('official', 'Unserialize release information from official site (using `unserialize` function).');
         
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of the versions list not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
     }

--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -34,6 +34,9 @@ class UrlDownloader
             $this->logger->debug('---> Found curl extension, using CurlDownloader');
             $downloader = new CurlDownloader;
 
+            if ($seconds = $this->options->{'downloader-connect-timeout'}){
+                $downloader->setConnectionTimeout($seconds);
+            }
             if ($proxy = $this->options->{'http-proxy'}) {
                 $downloader->setProxy($proxy);
             }

--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -34,7 +34,8 @@ class UrlDownloader
             $this->logger->debug('---> Found curl extension, using CurlDownloader');
             $downloader = new CurlDownloader;
 
-            if ($seconds = $this->options->{'downloader-connect-timeout'}){
+            $seconds = $this->options->{'downloader-connect-timeout'};
+            if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
                 $downloader->setConnectionTimeout($seconds);
             }
             if ($proxy = $this->options->{'http-proxy'}) {

--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -34,8 +34,8 @@ class UrlDownloader
             $this->logger->debug('---> Found curl extension, using CurlDownloader');
             $downloader = new CurlDownloader;
 
-            $seconds = $this->options->{'downloader-connect-timeout'};
-            if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
+            $seconds = $this->options->{'connect-timeout'};
+            if ($seconds || $seconds = getenv('CONNECT_TIMEOUT')) {
                 $downloader->setConnectionTimeout($seconds);
             }
             if ($proxy = $this->options->{'http-proxy'}) {

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -116,7 +116,8 @@ class ReleaseList
             }
 
             if ($options) {
-                if ($seconds = $options->{'downloader-connect-timeout'}){
+                $seconds = $options->{'downloader-connect-timeout'};
+                if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
                     $downloader->setConnectionTimeout($seconds);
                 }
                 if ($proxy = $options->{'http-proxy'}) {

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -116,6 +116,9 @@ class ReleaseList
             }
 
             if ($options) {
+                if ($seconds = $options->{'downloader-connect-timeout'}){
+                    $downloader->setConnectionTimeout($seconds);
+                }
                 if ($proxy = $options->{'http-proxy'}) {
                     $downloader->setProxy($proxy);
                 }

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -116,8 +116,8 @@ class ReleaseList
             }
 
             if ($options) {
-                $seconds = $options->{'downloader-connect-timeout'};
-                if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
+                $seconds = $options->{'connect-timeout'};
+                if ($seconds || $seconds = getenv('CONNECT_TIMEOUT')) {
                     $downloader->setConnectionTimeout($seconds);
                 }
                 if ($proxy = $options->{'http-proxy'}) {


### PR DESCRIPTION
`--downloader-connect-timeout` option has been added to these commands `known`, `update`, `install`, `download`.

## Purpose

To fix "name lookup timed out" error #464

## Changes

See changed files below.

## Effect

This option with description will be showed with a help message.

## Tests

Test cases related to this PR had been failing before I made any changes to the code. So I did not write tests.
I need more information about deployment of the development version to run tests.

## Usage

If you get "name lookup timed out" error during execution of any command from the set: `known`, `update`, `install`, `download`. You can set additional option --downloader-connect-timeout=seconds to fix the error.

For example `--downloader-connect-timeout=30`