### PR TITLE
CONNECT_TIMEOUT env variable and --connect_timeout option was added. Fatal Error during tests fixed

### DIFF
--- a/src/PhpBrew/Command/DownloadCommand.php
+++ b/src/PhpBrew/Command/DownloadCommand.php
@@ -34,8 +34,9 @@ class DownloadCommand extends Command
         $opts->add('old', 'enable old phps (less than 5.3)');
         $opts->add('mirror:', 'Use mirror specific site.');
         
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of a php version not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
     }

--- a/src/PhpBrew/Command/DownloadCommand.php
+++ b/src/PhpBrew/Command/DownloadCommand.php
@@ -33,6 +33,11 @@ class DownloadCommand extends Command
         $opts->add('f|force', 'Force extraction');
         $opts->add('old', 'enable old phps (less than 5.3)');
         $opts->add('mirror:', 'Use mirror specific site.');
+        
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
     }
 
     public function execute($version)

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -140,6 +140,11 @@ class InstallCommand extends Command
             ->valueName('user:pass')
             ;
 
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
+        
         $opts->add('f|force', 'Force the installation.');
 
         $opts->add('d|dryrun', 'Do not build, but run through all the tasks.');

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -140,8 +140,9 @@ class InstallCommand extends Command
             ->valueName('user:pass')
             ;
 
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of a php version not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
         

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -19,8 +19,9 @@ class KnownCommand extends \CLIFramework\Command
         $opts->add('m|more', 'Show more older versions');
         $opts->add('o|old', 'List old phps (less than 5.3)');
         $opts->add('u|update', 'Update release list');
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of the versions list not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
     }

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -19,6 +19,10 @@ class KnownCommand extends \CLIFramework\Command
         $opts->add('m|more', 'Show more older versions');
         $opts->add('o|old', 'List old phps (less than 5.3)');
         $opts->add('u|update', 'Update release list');
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
     }
 
     public function execute()

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -24,6 +24,11 @@ class UpdateCommand extends \CLIFramework\Command
             ;
 
         $opts->add('official', 'Unserialize release information from official site (using `unserialize` function).');
+        
+        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
+                . 'CURLOPT_CONNECTTIMEOUT option')
+            ->valueName('seconds')
+            ;
     }
 
     public function execute($branchName = 'master')

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -25,8 +25,9 @@ class UpdateCommand extends \CLIFramework\Command
 
         $opts->add('official', 'Unserialize release information from official site (using `unserialize` function).');
         
-        $opts->add('downloader-connect-timeout:', 'The number of seconds for '
-                . 'CURLOPT_CONNECTTIMEOUT option')
+        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
+                . 'of the versions list not starts during this limit. This option '
+                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
             ->valueName('seconds')
             ;
     }

--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -34,6 +34,9 @@ class UrlDownloader
             $this->logger->debug('---> Found curl extension, using CurlDownloader');
             $downloader = new CurlDownloader;
 
+            if ($seconds = $this->options->{'downloader-connect-timeout'}){
+                $downloader->setConnectionTimeout($seconds);
+            }
             if ($proxy = $this->options->{'http-proxy'}) {
                 $downloader->setProxy($proxy);
             }

--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -34,7 +34,8 @@ class UrlDownloader
             $this->logger->debug('---> Found curl extension, using CurlDownloader');
             $downloader = new CurlDownloader;
 
-            if ($seconds = $this->options->{'downloader-connect-timeout'}){
+            $seconds = $this->options->{'downloader-connect-timeout'};
+            if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
                 $downloader->setConnectionTimeout($seconds);
             }
             if ($proxy = $this->options->{'http-proxy'}) {

--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -34,8 +34,8 @@ class UrlDownloader
             $this->logger->debug('---> Found curl extension, using CurlDownloader');
             $downloader = new CurlDownloader;
 
-            $seconds = $this->options->{'downloader-connect-timeout'};
-            if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
+            $seconds = $this->options->{'connect-timeout'};
+            if ($seconds || $seconds = getenv('CONNECT_TIMEOUT')) {
                 $downloader->setConnectionTimeout($seconds);
             }
             if ($proxy = $this->options->{'http-proxy'}) {

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -116,7 +116,8 @@ class ReleaseList
             }
 
             if ($options) {
-                if ($seconds = $options->{'downloader-connect-timeout'}){
+                $seconds = $options->{'downloader-connect-timeout'};
+                if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
                     $downloader->setConnectionTimeout($seconds);
                 }
                 if ($proxy = $options->{'http-proxy'}) {

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -116,6 +116,9 @@ class ReleaseList
             }
 
             if ($options) {
+                if ($seconds = $options->{'downloader-connect-timeout'}){
+                    $downloader->setConnectionTimeout($seconds);
+                }
                 if ($proxy = $options->{'http-proxy'}) {
                     $downloader->setProxy($proxy);
                 }

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -116,8 +116,8 @@ class ReleaseList
             }
 
             if ($options) {
-                $seconds = $options->{'downloader-connect-timeout'};
-                if ($seconds || $seconds = getenv('DOWNLOADER_CONNECT_TIMEOUT')) {
+                $seconds = $options->{'connect-timeout'};
+                if ($seconds || $seconds = getenv('CONNECT_TIMEOUT')) {
                     $downloader->setConnectionTimeout($seconds);
                 }
                 if ($proxy = $options->{'http-proxy'}) {

--- a/tests/PhpBrew/Tasks/MakeTaskTest.php
+++ b/tests/PhpBrew/Tasks/MakeTaskTest.php
@@ -67,6 +67,11 @@ class MakeTaskTestBuild implements Buildable
     {
         return __DIR__ . '/../../fixtures/make/';
     }
+    
+    public function isBuildable()
+    {
+        return true;
+    }
 }
 
 class MakeTaskTestNoSuchFileBuild implements Buildable
@@ -74,5 +79,10 @@ class MakeTaskTestNoSuchFileBuild implements Buildable
     public function getSourceDirectory()
     {
         return __DIR__ . '/../../fixtures/make/dummy';
+    }
+    
+    public function isBuildable()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
There was an error with the tests execution. 

```
PHP Fatal error:  Class PhpBrew\Tasks\MakeTaskTestBuild contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (PhpBrew\Buildable::isBuildable) in /home/travis/build/phpbrew/phpbrew/tests/PhpBrew/Tasks/MakeTaskTest.php on line 70
```

I've fixed it.