### PR TITLE
export $PHPBREW_LAST_DIR at the bottom of _phpbrewrc_load.

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -494,7 +494,7 @@ function _phpbrewrc_load ()
         OLDPWD="$prev_dir"
     fi
 
-    PHPBREW_LAST_DIR="$PWD"
+    export PHPBREW_LAST_DIR="$PWD"
 }
 
 if [[ -n "$BASH_VERSION" && -z "$PHPBREW_RC_DISABLE" ]]; then


### PR DESCRIPTION
CC @morozov

I think https://github.com/phpbrew/phpbrew/pull/391 has the issue that _phpbrewrc_load is executed on every shell command because the function doesn't export `PHPBREW_LAST_DIR`. https://github.com/phpbrew/phpbrew/issues/487 might be related to this behaviour(?)
To solve this issue, we should export `$PHPBREW_LAST_DIR` after _phpbrewrc_load to prepare for the next call.