### PR TITLE
Add "-p" to $(command which phpbrew) to ensure a default PATH

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -97,7 +97,7 @@ function phpbrew ()
     if [[ -e bin/phpbrew ]] ; then
         BIN='bin/phpbrew'
     else
-        BIN=$(command which phpbrew)
+        BIN=$(command -p which phpbrew)
     fi
 
     local exit_status


### PR DESCRIPTION
The `-p' option means to use a default value for $PATH that is guaranteed to find all of the standard utilities
This also fixes the "env: node: No such file or directory" issue I mentioned at #506 (last comment)