### PR TITLE
Fallback from `command -p` to `command`

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -97,7 +97,7 @@ function phpbrew ()
     if [[ -e bin/phpbrew ]] ; then
         BIN='bin/phpbrew'
     else
-        BIN=$(command which phpbrew)
+        BIN=$(command -p which phpbrew 2> /dev/null || command which phpbrew)
     fi
 
     local exit_status


### PR DESCRIPTION
Fixes my PR #508 

As i mentioned at #506, OSX has a bug that makes it impossible to use the `command which phpbrew` solution. Here's a sample output on OSX with ZSH:
```shell
greensn0w@Mac  ~ 
 ❯ command which phpbrew
env: node: No such file or directory
```

With this PR we create a fallback from my solution (#508) to the one from @protomouse (#507)

This also works if phpbrew is in /usr/local/bin:

```shell
greensn0w@Mac  ~ 
 ❯ BIN=$(command -p which phpbrew 2> /dev/null || command which phpbrew)

 greensn0w@Mac  ~ 
 ❯ echo $BIN
/usr/local/bin/phpbrew
```

Original idea by @marcioAlmada 