### PR TITLE
Extend $PATH instead of overwriting it

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -23,9 +23,9 @@ function __phpbrew_set_path()
 
     if [[ -z "$PHPBREW_PATH" ]]
     then
-        export PATH=$PHPBREW_BIN:$PATH_WITHOUT_PHPBREW
+        export PATH=$PATH:$PHPBREW_BIN:$PATH_WITHOUT_PHPBREW
     else
-        export PATH=$PHPBREW_PATH:$PHPBREW_BIN:$PATH_WITHOUT_PHPBREW
+        export PATH=$PATH:$PHPBREW_PATH:$PHPBREW_BIN:$PATH_WITHOUT_PHPBREW
     fi
 }
 


### PR DESCRIPTION
Before this change phpbrew clears your path and you can do nothing until you remove phpbrew's bashrc