### PR TITLE
PHPBrew loads default configuration when navigating a subtree without .phpbrewrc

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -468,8 +468,11 @@ function _phpbrewrc_load ()
 
             # check if top level directory or filesystem boundary is reached
             if [ "$PWD" == '/' ] || [ -z "$PHPBREW_RC_DISCOVERY_ACROSS_FILESYSTEM" -a $prev_fs -ne 0 -a $curr_fs -ne $prev_fs ]; then
-                unset PHPBREW_LAST_RC_DIR
-                __phpbrew_load_user_config
+                # check if there's a previously loaded .phpbrewrc
+                if [[ ! -z "$PHPBREW_LAST_RC_DIR" ]]; then
+                    unset PHPBREW_LAST_RC_DIR
+                    __phpbrew_load_user_config
+                fi
                 break
             fi
 


### PR DESCRIPTION
There are two projects one of which has `.phpbrewrc` and the other doesn't (see the diagram below):
```
projects
|-- project1
|    |-- subdir
|    +-- .phpbrewrc (phpbrew use 5.4.44)
+-- project2
	+-- subdir
```
For instance, the default PHP version is 5.6.12.

When entering project1, the php version changes to 5.4.44 and is kept during navigation:
```
↪  php -v
PHP 5.6.12
↪  cd projects/project1
↪  php -v
PHP 5.4.44
↪  cd subdir
↪  php -v
PHP 5.4.44
```
If enter project2 and choose a non-default php version, it's reset to default during navigation:
```
↪  php -v
PHP 5.6.12
↪  cd projects/project2
↪  phpbrew use 5.4.44
↪  php -v
PHP 5.4.44
↪  cd subdir
↪  php -v
PHP 5.6.12
```