### PR TITLE
Fix curl error handling when self updating

### DIFF
--- a/src/PhpBrew/Command/SelfUpdateCommand.php
+++ b/src/PhpBrew/Command/SelfUpdateCommand.php
@@ -41,8 +41,8 @@ class SelfUpdateCommand extends Command
             throw new RuntimeException("Fail to create temp file", 2);
         }
         chmod($tempFile, 0755);
-        system("curl -# -L $url > $tempFile", $code);
-        if(! $code == 0) {
+        $lastLine = system("curl -# -L $url > $tempFile", $code);
+        if($lastLine === false || ! $code == 0) {
             throw new RuntimeException("Update Failed", 1);
         }
         //todo we can check the hash here in order to make sure we have download the phar successfully

--- a/src/PhpBrew/Command/SelfUpdateCommand.php
+++ b/src/PhpBrew/Command/SelfUpdateCommand.php
@@ -41,7 +41,7 @@ class SelfUpdateCommand extends Command
             throw new RuntimeException("Fail to create temp file", 2);
         }
         chmod($tempFile, 0755);
-        $code = system("curl -# -L $url > $tempFile");
+        system("curl -# -L $url > $tempFile", $code);
         if(! $code == 0) {
             throw new RuntimeException("Update Failed", 1);
         }


### PR DESCRIPTION
Sometimes, curl fails some reason.
like this

```bash
$ phpbrew self-update

curl: (60) SSL certificate problem: Invalid certificate chain
More details here: http://curl.haxx.se/docs/sslcerts.html
```

But the fail ignored, and overwrite `phpbrew` binary with failed file. 