### PR TITLE
Bugfix/clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ $ phpbrew install next as php-7.0.0
 
 
 ```bash
-$ phpbrew clean
+$ phpbrew clean php-5.4.0
 ```
 
 

--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -66,7 +66,7 @@ class Build implements Serializable, Buildable
      *
      * @param string $version build version
      * @param string $name    build name
-     * @param string $prefix  install prefix
+     * @param string $installPrefix  install prefix
      */
     public function __construct($version, $name = null, $installPrefix = null)
     {

--- a/src/PhpBrew/Command/CleanCommand.php
+++ b/src/PhpBrew/Command/CleanCommand.php
@@ -32,8 +32,8 @@ class CleanCommand extends Command
 
     public function execute($version)
     {
+        $buildDir = Config::getBuildDir() . DIRECTORY_SEPARATOR . $version;
         if ($this->options->all) {
-            $buildDir = Config::getBuildDir() . DIRECTORY_SEPARATOR . $version;
             if (!file_exists($buildDir)) {
                 $this->logger->info("Source directory " . $buildDir . " does not exist.");
             } else {
@@ -44,6 +44,7 @@ class CleanCommand extends Command
             $make = new MakeTask($this->logger);
             $make->setQuiet();
             $build = new Build($version);
+            $build->setSourceDirectory($buildDir);
             if ($make->clean($build)) {
                 $this->logger->info("Distribution is cleaned up. Woof! ");
             }


### PR DESCRIPTION
The clean command is broken in both develop and master, or even the release version. (see #561 for more details)

This pr fix the clean command, and the related section in readme. Btw, it also fix a param warning of phpdoc in Build.php.