### PR TITLE
Import of class PhpBrew\Utils in PhpBrew\Command\CleanCommand

### DIFF
--- a/src/PhpBrew/Command/CleanCommand.php
+++ b/src/PhpBrew/Command/CleanCommand.php
@@ -4,6 +4,7 @@ namespace PhpBrew\Command;
 use PhpBrew\Tasks\MakeTask;
 use PhpBrew\Build;
 use PhpBrew\Config;
+use PhpBrew\Utils;
 
 use CLIFramework\Command;
 


### PR DESCRIPTION
When using ```phpbrew clean --all php-x.y.z```, it looks for ```PhpBrew\Command\Utils``` which doesn’t exists.
```php 
Source directory /Users/Dharma/.phpbrew/build/php-5.6.12 found, deleting...
PHP Fatal error:  Class 'PhpBrew\Command\Utils' not found in phar:///Users/Dharma/bin/phpbrew/PhpBrew/Command/CleanCommand.php on line 2```