### PR TITLE
 Bash prompt, php version was never updated

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -446,7 +446,7 @@ function phpbrew_current_php_version() {
 }
 
 if [[ -n "$PHPBREW_SET_PROMPT" && "$PHPBREW_SET_PROMPT" == "1" ]]; then
-    export PS1="\w > \u@\h [$(phpbrew_current_php_version)]\n\\$ "
+    export PS1="\w > \u@\h [\$(phpbrew_current_php_version)]\n\\$ "
 fi
 
 function _phpbrewrc_load ()


### PR DESCRIPTION
The bash prompt was never updated.

Before the change:

```bash
~ > me@debian [php:5.6.13-system]
$  phpbrew use 5.4.45
~ > me@debian [php:5.6.13-phpbrew]
$ 
```

After the change:

```bash
~ > me@debian [php:5.6.13-system]
$  phpbrew use 5.4.45
~ > me@debian [php:5.4.45-phpbrew]
$ 
```
```