### PR TITLE
Make `tee` call compatible with OSX

### DIFF
--- a/src/PhpBrew/CommandBuilder.php
+++ b/src/PhpBrew/CommandBuilder.php
@@ -75,7 +75,7 @@ class CommandBuilder
         $this->append = $append;
     }
 
-    public function setLogPath($logPath) 
+    public function setLogPath($logPath)
     {
         $this->logPath = $logPath;
     }
@@ -101,7 +101,7 @@ class CommandBuilder
         if ($this->stdout && $this->logPath) {
             $cmd[] = '| tee';
             if ($this->append) {
-                $cmd[] = '--append';
+                $cmd[] = '-a';
             }
             $cmd[] = $this->logPath;
             $cmd[] = '2>&1';

--- a/tests/PhpBrew/CommandBuilderTest.php
+++ b/tests/PhpBrew/CommandBuilderTest.php
@@ -35,7 +35,7 @@ class CommandBuilderTest extends PHPUnit_Framework_TestCase
                 'appendLog' => true,
                 'stdout'    => true,
                 'logPath'   => '/tmp/build.log',
-                'expected'      => 'ls | tee --append /tmp/build.log 2>&1'
+                'expected'      => 'ls | tee -a /tmp/build.log 2>&1'
             ),
             array(
                 'appendLog' => false,


### PR DESCRIPTION
OSX's `tee` command do not accept long option formats like `--append`,
only their short forms. They probably needed to save the memory for some
huge background image, or were just willingly to break stuff (which is
more probably).

The bug occurs on OSX when installing a new PHP version using --stdout
option.