### PR TITLE
Change suggested install location to /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Just download it:
 ```bash
 curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
 chmod +x phpbrew
-sudo mv phpbrew /usr/bin/phpbrew
+sudo mv phpbrew /usr/local/bin/phpbrew
 ```
 
 ## Basic usage


### PR DESCRIPTION
MacOSX 10.11 (El Capitan) introduces extra security that won't let any user (even root) write to /usr, apart from /usr/local. This causes an "Operation not permitted" error when trying to move the executable to /usr/bin.

It seemed to work for me installing to /usr/local/bin, so I've changed the instructions. I don't know if they need changing anywhere else?