### PR TITLE
Does not connect the phpbrew bin path when $PHPBREW_BIN is blank

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -25,7 +25,12 @@ function __phpbrew_set_path()
     then
         export PATH=$PHPBREW_BIN:$PATH_WITHOUT_PHPBREW
     else
-        export PATH=$PHPBREW_PATH:$PHPBREW_BIN:$PATH_WITHOUT_PHPBREW
+        if [[ -z $PHPBREW_BIN ]]
+        then
+            export PATH=$PHPBREW_PATH:$PATH_WITHOUT_PHPBREW
+        else
+            export PATH=$PHPBREW_PATH:$PHPBREW_BIN:$PATH_WITHOUT_PHPBREW
+        fi
     fi
 }
 


### PR DESCRIPTION
Hi,
when I was started terminal and I just run `echo $PATH`.
The PATH is displayed as follows.
```
/Users/kurotaky/.phpbrew/php/php-5.6.3/bin::/Users/kurotaky/.plenv/shims:/Users/kurotaky/.rbenv/shims:/Users/kurotaky/.rbenv/shims:/usr/local/Cellar/emacs/HEAD/bin:/Users/kurotaky/.rbenv/bin:/usr/local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Users/kurotaky/bin
```
Although there is no assigned path to $PHPBREW_BIN, that is connected.
but the empty pathname( like `::`) referred to the current directory in POSIX.
so I fixed problem, the phpbrew bin path is not connected when $PHPBREW_BIN is blank.