### PR TITLE
Do not override explicitly specified values with the default from virtual variants

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -702,7 +702,11 @@ class VariantBuilder
         foreach ($this->virtualVariants as $name => $variantNames) {
             if ($build->isEnabledVariant($name)) {
                 foreach ($variantNames as $subVariantName) {
-                    $build->enableVariant($subVariantName);
+                    // enable the sub-variant only if it's not already enabled
+                    // in order to not override a non-default value with the default
+                    if (!$build->isEnabledVariant($subVariantName)) {
+                        $build->enableVariant($subVariantName);
+                    }
                 }
 
                 // it's a virtual variant, can not be built by buildVariant


### PR DESCRIPTION
When building with a variant which is included into one of virtual variants, the value of the former is ignored:
```shell
↪  phpbrew -d install --dryrun 5.6.16 +default +openssl=/usr/local/opt/openssl
# ./configure --with-openssl=/usr
```

As far as virtual variants do not provide any values by definition, they shouldn't override explicitly specified values:
```shell
↪  phpbrew -d install --dryrun 5.6.16 +default +openssl=/usr/local/opt/openssl
# ./configure --with-openssl=/usr/local/opt/openssl
```
