### PR TITLE
refactor downloading related part ( #571 )

### DIFF
--- a/src/PhpBrew/Command/AppCommand/GetCommand.php
+++ b/src/PhpBrew/Command/AppCommand/GetCommand.php
@@ -1,6 +1,6 @@
 <?php
 namespace PhpBrew\Command\AppCommand;
-use PhpBrew\Downloader\UrlDownloader;
+use PhpBrew\Downloader\Factory as DownloadFactory;
 use PhpBrew\Config;
 use PhpBrew\AppStore;
 use CLIFramework\Command;
@@ -17,6 +17,7 @@ class GetCommand extends Command
     public function options($opts)
     {
         $opts->add('chmod:');
+        DownloadFactory::addOptionsForCommand($opts);
     }
 
     public function arguments($args)
@@ -38,8 +39,7 @@ class GetCommand extends Command
         $targetDir = Config::getPhpbrewRoot() . DIRECTORY_SEPARATOR . 'bin';
         $target = $targetDir . DIRECTORY_SEPARATOR . $app['as'];
 
-        $downloader = new UrlDownloader($this->logger, $this->options);
-        $downloader->download($app['url'], $target);
+        DownloadFactory::getInstance($this->logger, $this->options)->download($app['url'], $target);
 
         $this->logger->info("Changing permissions to 0755");
 

--- a/src/PhpBrew/Command/AppCommand/GetCommand.php
+++ b/src/PhpBrew/Command/AppCommand/GetCommand.php
@@ -1,6 +1,6 @@
 <?php
 namespace PhpBrew\Command\AppCommand;
-use PhpBrew\Downloader\Factory as DownloadFactory;
+use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Config;
 use PhpBrew\AppStore;
 use CLIFramework\Command;

--- a/src/PhpBrew/Command/AppCommand/ListCommand.php
+++ b/src/PhpBrew/Command/AppCommand/ListCommand.php
@@ -1,6 +1,5 @@
 <?php
 namespace PhpBrew\Command\AppCommand;
-use PhpBrew\Downloader\UrlDownloader;
 use PhpBrew\Config;
 use PhpBrew\AppStore;
 use CLIFramework\Command;

--- a/src/PhpBrew/Command/DownloadCommand.php
+++ b/src/PhpBrew/Command/DownloadCommand.php
@@ -2,6 +2,7 @@
 namespace PhpBrew\Command;
 use Exception;
 use PhpBrew\Config;
+use PhpBrew\Downloader\Factory as DownloadFactory;
 use PhpBrew\Tasks\DownloadTask;
 use PhpBrew\Tasks\PrepareDirectoryTask;
 use PhpBrew\ReleaseList;
@@ -44,19 +45,15 @@ class DownloadCommand extends Command
         $opts->add('f|force', 'Force extraction');
         $opts->add('old', 'enable old phps (less than 5.3)');
         $opts->add('mirror:', 'Use mirror specific site.');
-        
-        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
-                . 'of a php version not starts during this limit. This option '
-                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
-            ->valueName('seconds')
-            ;
+
+        DownloadFactory::addOptionsForCommand($opts);
     }
 
     public function execute($version)
     {
 
         $version = preg_replace('/^php-/', '', $version);
-        $releaseList = ReleaseList::getReadyInstance();
+        $releaseList = ReleaseList::getReadyInstance($this->options);
         $releases = $releaseList->getReleases();
         $versionInfo = $releaseList->getVersion($version);
         if (!$versionInfo) {

--- a/src/PhpBrew/Command/DownloadCommand.php
+++ b/src/PhpBrew/Command/DownloadCommand.php
@@ -2,7 +2,7 @@
 namespace PhpBrew\Command;
 use Exception;
 use PhpBrew\Config;
-use PhpBrew\Downloader\Factory as DownloadFactory;
+use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Tasks\DownloadTask;
 use PhpBrew\Tasks\PrepareDirectoryTask;
 use PhpBrew\ReleaseList;

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -3,6 +3,7 @@ namespace PhpBrew\Command;
 
 use Exception;
 use PhpBrew\Config;
+use PhpBrew\Downloader\Factory as DownloadFactory;
 use PhpBrew\VariantParser;
 use PhpBrew\VariantBuilder;
 use PhpBrew\Tasks\DownloadTask;
@@ -138,22 +139,10 @@ class InstallCommand extends Command
 
         $opts->add('old', 'Install phpbrew incompatible phps (< 5.3)');
 
-        $opts->add('http-proxy:', 'The HTTP Proxy to download PHP distributions. e.g. --http-proxy=22.33.44.55:8080')
-            ->valueName('proxy host')
-            ;
-
-        $opts->add('http-proxy-auth:', 'The HTTP Proxy Auth to download PHP distributions. user:pass')
-            ->valueName('user:pass')
-            ;
-
         $opts->add('user-config','Allow users create their own config file (php.ini or extension config init files)');
 
-        $opts->add('connect-timeout:', 'The system aborts the command if downloading '
-                . 'of a php version not starts during this limit. This option '
-                . 'overrides a value of CONNECT_TIMEOUT environment variable.')
-            ->valueName('seconds')
-            ;
-        
+        DownloadFactory::addOptionsForCommand($opts);
+
         $opts->add('f|force', 'Force the installation (redownloads source).')
             ->defaultValue(false)
             ;
@@ -173,7 +162,7 @@ class InstallCommand extends Command
     {
         $distUrl = NULL;
         $versionInfo = array();
-        $releaseList = ReleaseList::getReadyInstance();
+        $releaseList = ReleaseList::getReadyInstance($this->options);
         $versionDslParser = new VersionDslParser();
         $clean = new MakeTask($this->logger, $this->options);
         $clean->setQuiet();

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -3,7 +3,7 @@ namespace PhpBrew\Command;
 
 use Exception;
 use PhpBrew\Config;
-use PhpBrew\Downloader\Factory as DownloadFactory;
+use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\VariantParser;
 use PhpBrew\VariantBuilder;
 use PhpBrew\Tasks\DownloadTask;

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -1,5 +1,6 @@
 <?php
 namespace PhpBrew\Command;
+use PhpBrew\Downloader\Factory as DownloadFactory;
 use PhpBrew\Tasks\FetchReleaseListTask;
 
 class UpdateCommand extends \CLIFramework\Command
@@ -11,21 +12,12 @@ class UpdateCommand extends \CLIFramework\Command
 
     public function options($opts)
     {
-        $opts->add('http-proxy:', 'The HTTP Proxy to download PHP distributions. e.g. --http-proxy=22.33.44.55:8080')
-            ->valueName('proxy host')
-            ;
-
-        $opts->add('http-proxy-auth:', 'The HTTP Proxy Auth to download PHP distributions. user:pass')
-            ->valueName('user:pass')
-            ;
 
         $opts->add('o|old', 'List old phps (less than 5.3)');
 
         $opts->add('official', 'Unserialize release information from official site (using `unserialize` function).');
 
-        $opts->add('connect-timeout:', 'Overrides the CONNECT_TIMEOUT env variable and aborts if download takes longer than specified.')
-            ->valueName('seconds')
-            ;
+        DownloadFactory::addOptionsForCommand($opts);
     }
 
     public function execute()

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -1,6 +1,6 @@
 <?php
 namespace PhpBrew\Command;
-use PhpBrew\Downloader\Factory as DownloadFactory;
+use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Tasks\FetchReleaseListTask;
 
 class UpdateCommand extends \CLIFramework\Command

--- a/src/PhpBrew/Downloader/BaseDownloader.php
+++ b/src/PhpBrew/Downloader/BaseDownloader.php
@@ -26,17 +26,41 @@ abstract class BaseDownloader
     }
 
     /**
-     * @param string $url
+     * @param string $url the url to be downloaded
+     * @param string $targetFilePath the path where file to be saved. null means auto-generated temp path
      *
-     * @return bool|string
+     * @return bool|string if download successfully, return target file path, otherwise return false.
      *
      * @throws \RuntimeException
      */
-    public abstract function download($url, $targetFilePath);
+    public function download($url, $targetFilePath = null)
+    {
+        if(empty($targetFilePath)) {
+            $targetFilePath =  tempnam(sys_get_temp_dir(), 'phpbrew_');
+            if($targetFilePath === false) {
+                throw new RuntimeException("Fail to create temp file");
+            }
+        }else{
+            if(!file_exists($targetFilePath)) {
+                touch($targetFilePath);
+            }
+        }
+        if(!is_writable($targetFilePath)) {
+            throw new \RuntimeException("Target path ($targetFilePath) is not writable!");
+        }
+        if($this->process($url, $targetFilePath)){
+            $this->logger->debug("$url => $targetFilePath");
+            return $targetFilePath;
+        }else{
+            return false;
+        }
+    }
+
+    protected abstract function process($url, $targetFilePath);
 
     /**
      *
-     * @param  string         $url
+     * @param  string $url
      * @return string|boolean the resolved download file name or false it
      *                            the url string can't be parsed
      */

--- a/src/PhpBrew/Downloader/BaseDownloader.php
+++ b/src/PhpBrew/Downloader/BaseDownloader.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xiami
+ * Date: 2015/12/30
+ * Time: 11:55
+ */
+
+namespace PhpBrew\Downloader;
+
+
+use CLIFramework\Logger;
+use GetOptionKit\OptionResult;
+use PhpBrew\Utils;
+
+abstract class BaseDownloader
+{
+    public $logger;
+
+    public $options;
+
+    public function __construct(Logger $logger, OptionResult $options)
+    {
+        $this->logger = $logger;
+        $this->options = $options;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return bool|string
+     *
+     * @throws \RuntimeException
+     */
+    public abstract function download($url, $targetFilePath);
+
+    /**
+     *
+     * @param  string         $url
+     * @return string|boolean the resolved download file name or false it
+     *                            the url string can't be parsed
+     */
+    public function resolveDownloadFileName($url)
+    {
+        // Check if the url is for php source archive
+        if (preg_match('/php-\d.+\.tar\.(bz2|gz|xz)/', $url, $parts)) {
+            return $parts[0];
+        }
+
+        // try to get the filename through parse_url
+        $path = parse_url($url, PHP_URL_PATH);
+        if (false === $path || false === strpos($path, ".")) {
+            return NULL;
+        }
+        return basename($path);
+    }
+
+    public abstract function isMethodAvailable();
+}

--- a/src/PhpBrew/Downloader/CurlCommandDownloader.php
+++ b/src/PhpBrew/Downloader/CurlCommandDownloader.php
@@ -14,19 +14,13 @@ use PhpBrew\Utils;
 class CurlCommandDownloader extends BaseDownloader
 {
 
-    /**
-     * @param string $url
-     *
-     * @return bool|string
-     *
-     * @throws \RuntimeException
-     */
-    public function download($url, $targetFilePath)
+    protected function process($url, $targetFilePath)
     {
         $this->logger->info('downloading via curl command');
         //todo proxy setting
         $silent = $this->logger->isQuiet() ? '--silent ' : '';
-        Utils::system("curl -C - -L $silent -o" . $targetFilePath . ' ' . $url);
+        Utils::system("curl -C - -L $silent -o" . $targetFilePath . ' "' . $url.'"');
+        return true;
     }
 
     public function isMethodAvailable()

--- a/src/PhpBrew/Downloader/CurlCommandDownloader.php
+++ b/src/PhpBrew/Downloader/CurlCommandDownloader.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xiami
+ * Date: 2015/12/30
+ * Time: 11:57
+ */
+
+namespace PhpBrew\Downloader;
+
+
+use PhpBrew\Utils;
+
+class CurlCommandDownloader extends BaseDownloader
+{
+
+    /**
+     * @param string $url
+     *
+     * @return bool|string
+     *
+     * @throws \RuntimeException
+     */
+    public function download($url, $targetFilePath)
+    {
+        $this->logger->info('downloading via curl command');
+        //todo proxy setting
+        $silent = $this->logger->isQuiet() ? '--silent ' : '';
+        Utils::system("curl -C - -L $silent -o" . $targetFilePath . ' ' . $url);
+    }
+
+    public function isMethodAvailable()
+    {
+        return Utils::findbin('curl');
+    }
+}

--- a/src/PhpBrew/Downloader/CurlExtensionDownloader.php
+++ b/src/PhpBrew/Downloader/CurlExtensionDownloader.php
@@ -17,14 +17,7 @@ use RuntimeException;
 class CurlExtensionDownloader extends BaseDownloader
 {
 
-    /**
-     * @param string $url
-     *
-     * @return bool|string
-     *
-     * @throws \RuntimeException
-     */
-    public function download($url, $targetFilePath)
+    protected function process($url, $targetFilePath)
     {
         $this->logger->info('downloading via curl extension');
 
@@ -50,6 +43,7 @@ class CurlExtensionDownloader extends BaseDownloader
         if (false === file_put_contents($targetFilePath, $binary)) {
             throw new RuntimeException("Can't write file $targetFilePath");
         }
+        return true;
     }
 
     public function isMethodAvailable()

--- a/src/PhpBrew/Downloader/CurlExtensionDownloader.php
+++ b/src/PhpBrew/Downloader/CurlExtensionDownloader.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xiami
+ * Date: 2015/12/30
+ * Time: 11:59
+ */
+
+namespace PhpBrew\Downloader;
+
+
+use CurlKit\CurlDownloader;
+use CurlKit\Progress\ProgressBar;
+use PhpBrew\Console;
+use RuntimeException;
+
+class CurlExtensionDownloader extends BaseDownloader
+{
+
+    /**
+     * @param string $url
+     *
+     * @return bool|string
+     *
+     * @throws \RuntimeException
+     */
+    public function download($url, $targetFilePath)
+    {
+        $this->logger->info('downloading via curl extension');
+
+        $downloader = new CurlDownloader;
+
+        $seconds = $this->options->{'connect-timeout'};
+        if ($seconds || $seconds = getenv('CONNECT_TIMEOUT')) {
+            $downloader->setConnectionTimeout($seconds);
+        }
+        if ($proxy = $this->options->{'http-proxy'}) {
+            $downloader->setProxy($proxy);
+        }
+        if ($proxyAuth = $this->options->{'http-proxy-auth'}) {
+            $downloader->setProxyAuth($proxyAuth);
+        }
+
+        // TODO: Get current instance instead of singleton to improve testing output
+        $console = Console::getInstance();
+        if (! $console->options->{'no-progress'} && $this->logger->getLevel() > 2) {
+            $downloader->setProgressHandler(new ProgressBar);
+        }
+        $binary = $downloader->request($url);
+        if (false === file_put_contents($targetFilePath, $binary)) {
+            throw new RuntimeException("Can't write file $targetFilePath");
+        }
+    }
+
+    public function isMethodAvailable()
+    {
+        return extension_loaded('curl');
+    }
+}

--- a/src/PhpBrew/Downloader/DownloadFactory.php
+++ b/src/PhpBrew/Downloader/DownloadFactory.php
@@ -13,7 +13,7 @@ use CLIFramework\Logger;
 use GetOptionKit\OptionCollection;
 use GetOptionKit\OptionResult;
 
-class Factory
+class DownloadFactory
 {
 //    private static $downloader = null;
 

--- a/src/PhpBrew/Downloader/Factory.php
+++ b/src/PhpBrew/Downloader/Factory.php
@@ -15,12 +15,13 @@ use GetOptionKit\OptionResult;
 class Factory
 {
 //    private static $downloader = null;
-    private static $availableDownloader = [
-        CurlExtensionDownloader::class,
-        FileFunctionDownloader::class,
-        WgetCommandDownloader::class,
-        CurlCommandDownloader::class,
-    ];
+
+    private static  $availableDownloader = array(
+        'PhpBrew\Downloader\CurlExtensionDownloader',
+        'PhpBrew\Downloader\FileFunctionDownloader',
+        'PhpBrew\Downloader\WgetCommandDownloader',
+        'PhpBrew\Downloader\CurlCommandDownloader',
+    );
 
     /**
      * @param Logger $logger
@@ -30,8 +31,12 @@ class Factory
      */
     public static function getInstance($logger, $options, $downloader = null)
     {
-        if (!empty($downloader)) { //auto pick download
-            if (class_exists($downloader) && is_subclass_of($downloader, BaseDownloader::class)) {
+        if (empty($downloader) && $options->has('downloader')) {
+            //todo use string alias instead?
+            $downloader = self::$availableDownloader[$options->downloader];
+        }
+        if (!empty($downloader)) {
+            if (class_exists($downloader) && is_subclass_of($downloader, 'PhpBrew\Downloader\BaseDownloader')) {
                 return new $downloader($logger, $options);
             }
         }

--- a/src/PhpBrew/Downloader/Factory.php
+++ b/src/PhpBrew/Downloader/Factory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xiami
+ * Date: 2015/12/30
+ * Time: 12:09
+ */
+
+namespace PhpBrew\Downloader;
+
+
+use CLIFramework\Logger;
+use GetOptionKit\OptionResult;
+
+class Factory
+{
+//    private static $downloader = null;
+    private static $availableDownloader = [
+        CurlExtensionDownloader::class,
+        FileFunctionDownloader::class,
+        WgetCommandDownloader::class,
+        CurlCommandDownloader::class,
+    ];
+
+    /**
+     * @param Logger $logger
+     * @param OptionResult $options
+     * @param string $downloader
+     * @return BaseDownloader
+     */
+    public static function getInstance($logger, $options, $downloader = null)
+    {
+        if (!empty($downloader)) { //auto pick download
+            if (class_exists($downloader) && is_subclass_of($downloader, BaseDownloader::class)) {
+                return new $downloader($logger, $options);
+            }
+        }
+        foreach (self::$availableDownloader as $downloader) {
+            $down = new $downloader($logger, $options);
+            if ($down->isMethodAvailable()) {
+                return $down;
+            }
+        }
+        throw new \RuntimeException('No available downloader found!');
+    }
+}

--- a/src/PhpBrew/Downloader/Factory.php
+++ b/src/PhpBrew/Downloader/Factory.php
@@ -10,13 +10,14 @@ namespace PhpBrew\Downloader;
 
 
 use CLIFramework\Logger;
+use GetOptionKit\OptionCollection;
 use GetOptionKit\OptionResult;
 
 class Factory
 {
 //    private static $downloader = null;
 
-    private static  $availableDownloader = array(
+    private static $availableDownloader = array(
         'PhpBrew\Downloader\CurlExtensionDownloader',
         'PhpBrew\Downloader\FileFunctionDownloader',
         'PhpBrew\Downloader\WgetCommandDownloader',
@@ -29,7 +30,7 @@ class Factory
      * @param string $downloader
      * @return BaseDownloader
      */
-    public static function getInstance($logger, $options, $downloader = null)
+    public static function getInstance(Logger $logger, OptionResult $options, $downloader = null)
     {
         if (empty($downloader) && $options->has('downloader')) {
             //todo use string alias instead?
@@ -47,5 +48,17 @@ class Factory
             }
         }
         throw new \RuntimeException('No available downloader found!');
+    }
+
+    public static function addOptionsForCommand(OptionCollection $opts)
+    {
+        $opts->add('downloader:', 'Downloader switcher');
+        $opts->add('http-proxy:', 'The HTTP Proxy to download PHP distributions. e.g. --http-proxy=22.33.44.55:8080')
+            ->valueName('proxy host');
+        $opts->add('http-proxy-auth:', 'The HTTP Proxy Auth to download PHP distributions. user:pass')
+            ->valueName('user:pass');
+        $opts->add('connect-timeout:', 'Overrides the CONNECT_TIMEOUT env variable and aborts if download takes longer than specified.')
+            ->valueName('seconds');
+        return $opts;
     }
 }

--- a/src/PhpBrew/Downloader/FileFunctionDownloader.php
+++ b/src/PhpBrew/Downloader/FileFunctionDownloader.php
@@ -19,22 +19,21 @@ class FileFunctionDownloader extends BaseDownloader
         $this->logger->info('downloading via pure php functions');
 
         $opts = array();
-        if (!empty($this->options->{'http-proxy'})) {
-            $opts = array(
-                'http' => array(
-                    'proxy' => 'tcp://127.0.0.1:8080',
-                    'request_fulluri' => true,
-                    'header' => array(),
-                )
-            );
-            if($proxyAuth = $this->options->{'http-proxy-auth'}) {
+        if ($proxy = $this->options->{'http-proxy'}) {
+            $opts['http']['proxy'] = $proxy;
+            $opts['http']['request_fulluri'] = true;
+            $opts['http']['header'] = array();
+            if ($proxyAuth = $this->options->{'http-proxy-auth'}) {
                 $opts['http']['header'][] = "Proxy-Authorization: Basic $proxyAuth";
             }
         }
+        if ($timeout = $this->options->{'connect-timeout'}) {
+            $opts['http']['timeout'] = $timeout;
+        }
 
-        if(empty($opts)) {
+        if (empty($opts)) {
             $binary = file_get_contents($url);
-        }else{
+        } else {
             $context = stream_context_create($opts);
             $binary = file_get_contents($url, null, $context);
         }

--- a/src/PhpBrew/Downloader/FileFunctionDownloader.php
+++ b/src/PhpBrew/Downloader/FileFunctionDownloader.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xiami
+ * Date: 2015/12/30
+ * Time: 12:05
+ */
+
+namespace PhpBrew\Downloader;
+
+
+use RuntimeException;
+
+class FileFunctionDownloader extends BaseDownloader
+{
+
+    /**
+     * @param string $url
+     *
+     * @return bool|string
+     *
+     * @throws \RuntimeException
+     */
+    public function download($url, $targetFilePath)
+    {
+        //todo proxy
+        $binary = file_get_contents($url);
+        if ($binary !== false) {
+            file_put_contents($targetFilePath, $binary);
+        } else {
+            throw new RuntimeException("Fail to request $url");
+        }
+    }
+
+    public function isMethodAvailable()
+    {
+        return function_exists('file_get_contents');
+    }
+}

--- a/src/PhpBrew/Downloader/FileFunctionDownloader.php
+++ b/src/PhpBrew/Downloader/FileFunctionDownloader.php
@@ -14,21 +14,36 @@ use RuntimeException;
 class FileFunctionDownloader extends BaseDownloader
 {
 
-    /**
-     * @param string $url
-     *
-     * @return bool|string
-     *
-     * @throws \RuntimeException
-     */
-    public function download($url, $targetFilePath)
+    protected function process($url, $targetFilePath)
     {
-        //todo proxy
-        $binary = file_get_contents($url);
+        $this->logger->info('downloading via pure php functions');
+
+        $opts = array();
+        if (!empty($this->options->{'http-proxy'})) {
+            $opts = array(
+                'http' => array(
+                    'proxy' => 'tcp://127.0.0.1:8080',
+                    'request_fulluri' => true,
+                    'header' => array(),
+                )
+            );
+            if($proxyAuth = $this->options->{'http-proxy-auth'}) {
+                $opts['http']['header'][] = "Proxy-Authorization: Basic $proxyAuth";
+            }
+        }
+
+        if(empty($opts)) {
+            $binary = file_get_contents($url);
+        }else{
+            $context = stream_context_create($opts);
+            $binary = file_get_contents($url, null, $context);
+        }
         if ($binary !== false) {
             file_put_contents($targetFilePath, $binary);
+            return true;
         } else {
-            throw new RuntimeException("Fail to request $url");
+//            throw new RuntimeException("Fail to request $url");
+            return false;
         }
     }
 

--- a/src/PhpBrew/Downloader/UrlDownloader.php
+++ b/src/PhpBrew/Downloader/UrlDownloader.php
@@ -8,12 +8,23 @@ use CurlKit\CurlDownloader;
 use CurlKit\Progress\ProgressBar;
 use GetOptionKit\OptionResult;
 
+/**
+ * Class UrlDownloader
+ * @package PhpBrew\Downloader
+ * @deprecated  use Factory instead
+ */
 class UrlDownloader
 {
     public $logger;
 
     public $options;
 
+    /**
+     * UrlDownloader constructor.
+     * @param Logger $logger
+     * @param OptionResult $options
+     * @deprecated
+     */
     public function __construct(Logger $logger, OptionResult $options)
     {
         $this->logger = $logger;
@@ -26,6 +37,7 @@ class UrlDownloader
      * @return bool|string
      *
      * @throws \RuntimeException
+     * @deprecated
      */
     public function download($url, $targetFilePath)
     {

--- a/src/PhpBrew/Downloader/WgetCommandDownloader.php
+++ b/src/PhpBrew/Downloader/WgetCommandDownloader.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xiami
+ * Date: 2015/12/30
+ * Time: 12:02
+ */
+
+namespace PhpBrew\Downloader;
+
+
+use PhpBrew\Utils;
+
+class WgetCommandDownloader extends BaseDownloader
+{
+
+    /**
+     * @param string $url
+     *
+     * @return bool|string
+     *
+     * @throws \RuntimeException
+     */
+    public function download($url, $targetFilePath)
+    {
+        $this->logger->info('downloading via wget command');
+        //todo proxy setting
+        $quiet = $this->logger->isQuiet() ? '--quiet' : '';
+        Utils::system("wget --no-check-certificate -c $quiet -N -O " . $targetFilePath . ' ' . $url);
+    }
+
+    public function isMethodAvailable()
+    {
+        return Utils::findbin('wget');
+    }
+}

--- a/src/PhpBrew/Downloader/WgetCommandDownloader.php
+++ b/src/PhpBrew/Downloader/WgetCommandDownloader.php
@@ -21,12 +21,13 @@ class WgetCommandDownloader extends BaseDownloader
      *
      * @throws \RuntimeException
      */
-    public function download($url, $targetFilePath)
+    protected function process($url, $targetFilePath)
     {
         $this->logger->info('downloading via wget command');
         //todo proxy setting
         $quiet = $this->logger->isQuiet() ? '--quiet' : '';
-        Utils::system("wget --no-check-certificate -c $quiet -N -O " . $targetFilePath . ' ' . $url);
+        Utils::system("wget --no-check-certificate -c $quiet -N -O \"$targetFilePath\" \"$url\"");
+        return true;
     }
 
     public function isMethodAvailable()

--- a/src/PhpBrew/Extension/ExtensionDownloader.php
+++ b/src/PhpBrew/Extension/ExtensionDownloader.php
@@ -1,11 +1,8 @@
 <?php
 namespace PhpBrew\Extension;
-use PhpBrew\Console;
-use CurlKit\CurlDownloader;
-use CurlKit\Progress\ProgressBar;
 use PhpBrew\Config;
 use PhpBrew\Downloader;
-use PhpBrew\Downloader\Factory as DownloadFactory;
+use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Extension\Provider\Provider;
 use PhpBrew\Utils;
 use PEARX;

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -150,7 +150,7 @@ class ReleaseList
         if ($instance->foundLocalReleaseList()) {
             $instance->setReleases($instance->loadLocalReleaseList());
         } else {
-            $instance->fetchRemoteReleaseList();
+            $instance->fetchRemoteReleaseList($options);
         }
 
         return $instance;

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -1,11 +1,9 @@
 <?php
 namespace PhpBrew;
 use CLIFramework\Logger;
-use CurlKit\CurlDownloader;
-use CurlKit\Progress\ProgressBar;
 use GetOptionKit\OptionResult;
 use Exception;
-use PhpBrew\Downloader\Factory as DownloadFactory;
+use PhpBrew\Downloader\DownloadFactory;
 use RuntimeException;
 
 defined('JSON_UNESCAPED_SLASHES') || define('JSON_UNESCAPED_SLASHES', 0);

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -1,9 +1,11 @@
 <?php
 namespace PhpBrew;
+use CLIFramework\Logger;
 use CurlKit\CurlDownloader;
 use CurlKit\Progress\ProgressBar;
 use GetOptionKit\OptionResult;
 use Exception;
+use PhpBrew\Downloader\Factory as DownloadFactory;
 use RuntimeException;
 
 defined('JSON_UNESCAPED_SLASHES') || define('JSON_UNESCAPED_SLASHES', 0);
@@ -164,31 +166,8 @@ class ReleaseList
         $max = ($options && $options->old) ? 1000 : 100;
         $url = "https://php.net/releases/index.php?json&version={$version}&max={$max}";
 
-        if (extension_loaded('curl')) {
-            $downloader = new CurlDownloader;
-            $downloader->setProgressHandler(new ProgressBar);
-
-            if (! Console::getInstance()->options->{'no-progress'}) {
-                $downloader->setProgressHandler(new ProgressBar);
-            }
-
-            if ($options) {
-                $seconds = $options->{'connect-timeout'};
-                if ($seconds || $seconds = getenv('CONNECT_TIMEOUT')) {
-                    $downloader->setConnectionTimeout($seconds);
-                }
-                if ($proxy = $options->{'http-proxy'}) {
-                    $downloader->setProxy($proxy);
-                }
-                if ($proxyAuth = $options->{'http-proxy-auth'}) {
-                    $downloader->setProxyAuth($proxyAuth);
-                }
-            }
-
-            $json = $downloader->request($url);
-        } else {
-            $json = file_get_contents($url);
-        }
+        $file = DownloadFactory::getInstance(Logger::getInstance(), $options)->download($url);
+        $json = file_get_contents($file);
 
         $obj = json_decode($json, true);
         return $obj;
@@ -197,8 +176,8 @@ class ReleaseList
     public static function buildReleaseListFromOfficialSite(OptionResult $options = null)
     {
         $obj = array_merge(
-            self::downloadReleaseListFromOfficialSite(7),
-            self::downloadReleaseListFromOfficialSite(5)
+            self::downloadReleaseListFromOfficialSite(7, $options),
+            self::downloadReleaseListFromOfficialSite(5, $options)
         );
         $releaseVersions = array();
         foreach ($obj as $k => $v) {

--- a/src/PhpBrew/Tasks/DownloadTask.php
+++ b/src/PhpBrew/Tasks/DownloadTask.php
@@ -1,5 +1,6 @@
 <?php
 namespace PhpBrew\Tasks;
+use PhpBrew\Downloader\Factory;
 use PhpBrew\Downloader\UrlDownloader;
 use Exception;
 
@@ -14,7 +15,7 @@ class DownloadTask extends BaseTask
             throw new Exception("Directory is not writable: $dir");
         }
 
-        $downloader = new UrlDownloader($this->logger, $this->options);
+        $downloader = Factory::getInstance($this->logger, $this->options);
         $basename = $downloader->resolveDownloadFileName($url);
         if (!$basename) {
             throw new Exception("Can not parse url: $url");

--- a/src/PhpBrew/Tasks/DownloadTask.php
+++ b/src/PhpBrew/Tasks/DownloadTask.php
@@ -1,7 +1,7 @@
 <?php
 namespace PhpBrew\Tasks;
 use Exception;
-use PhpBrew\Downloader\Factory as DownloadFactory;
+use PhpBrew\Downloader\DownloadFactory;
 
 /**
  * Task to download php distributions.

--- a/src/PhpBrew/Tasks/DownloadTask.php
+++ b/src/PhpBrew/Tasks/DownloadTask.php
@@ -1,8 +1,7 @@
 <?php
 namespace PhpBrew\Tasks;
-use PhpBrew\Downloader\Factory;
-use PhpBrew\Downloader\UrlDownloader;
 use Exception;
+use PhpBrew\Downloader\Factory as DownloadFactory;
 
 /**
  * Task to download php distributions.
@@ -15,7 +14,7 @@ class DownloadTask extends BaseTask
             throw new Exception("Directory is not writable: $dir");
         }
 
-        $downloader = Factory::getInstance($this->logger, $this->options);
+        $downloader = DownloadFactory::getInstance($this->logger, $this->options);
         $basename = $downloader->resolveDownloadFileName($url);
         if (!$basename) {
             throw new Exception("Can not parse url: $url");

--- a/tests/PhpBrew/Downloader/DownloaderTest.php
+++ b/tests/PhpBrew/Downloader/DownloaderTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: xiami
+ * Date: 2015/12/30
+ * Time: 12:23
+ */
+
+namespace PhpBrew\Downloader;
+
+
+use CLIFramework\Logger;
+use GetOptionKit\OptionResult;
+use PhpBrew\Config;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @large
+ */
+class DownloaderTestextends extends PHPUnit_Framework_TestCase
+{
+    public $logger;
+
+    public function setUp()
+    {
+        $this->logger = Logger::getInstance();
+        $this->logger->setQuiet();
+    }
+
+    public function testDownloadByWgetCommand()
+    {
+        $this->_test(WgetCommandDownloader::class);
+    }
+
+    public function testDownloadByCurlCommand()
+    {
+        $this->_test(CurlCommandDownloader::class);
+    }
+
+    public function testDownloadByCurlExtension()
+    {
+        $this->_test(CurlExtensionDownloader::class);
+    }
+
+    public function testDownloadByFileFunction()
+    {
+        $this->_test(FileFunctionDownloader::class);
+    }
+
+    private function _test($downloader)
+    {
+        $instance = Factory::getInstance($this->logger, new OptionResult, $downloader);
+        if ($instance->isMethodAvailable()) {
+            $actualFilePath = tempnam(Config::getTempFileDir(), '');
+            $instance->download('http://httpbin.org/', $actualFilePath);
+            $this->assertFileExists($actualFilePath);
+        } else {
+            $this->markTestSkipped();
+        }
+    }
+}

--- a/tests/PhpBrew/Downloader/DownloaderTest.php
+++ b/tests/PhpBrew/Downloader/DownloaderTest.php
@@ -29,22 +29,22 @@ class DownloaderTestextends extends PHPUnit_Framework_TestCase
 
     public function testDownloadByWgetCommand()
     {
-        $this->_test(WgetCommandDownloader::class);
+        $this->_test('PhpBrew\Downloader\WgetCommandDownloader');
     }
 
     public function testDownloadByCurlCommand()
     {
-        $this->_test(CurlCommandDownloader::class);
+        $this->_test('PhpBrew\Downloader\CurlCommandDownloader');
     }
 
     public function testDownloadByCurlExtension()
     {
-        $this->_test(CurlExtensionDownloader::class);
+        $this->_test('PhpBrew\Downloader\CurlExtensionDownloader');
     }
 
     public function testDownloadByFileFunction()
     {
-        $this->_test(FileFunctionDownloader::class);
+        $this->_test('PhpBrew\Downloader\FileFunctionDownloader');
     }
 
     private function _test($downloader)

--- a/tests/PhpBrew/Downloader/DownloaderTest.php
+++ b/tests/PhpBrew/Downloader/DownloaderTest.php
@@ -17,7 +17,7 @@ use PHPUnit_Framework_TestCase;
 /**
  * @large
  */
-class DownloaderTestextends extends PHPUnit_Framework_TestCase
+class DownloaderTest extends PHPUnit_Framework_TestCase
 {
     public $logger;
 
@@ -49,7 +49,7 @@ class DownloaderTestextends extends PHPUnit_Framework_TestCase
 
     private function _test($downloader)
     {
-        $instance = Factory::getInstance($this->logger, new OptionResult, $downloader);
+        $instance = DownloadFactory::getInstance($this->logger, new OptionResult, $downloader);
         if ($instance->isMethodAvailable()) {
             $actualFilePath = tempnam(Config::getTempFileDir(), '');
             $instance->download('http://httpbin.org/', $actualFilePath);


### PR DESCRIPTION
this pr includes following features:
1. refactor `PhpBrew\Downloader\UrlDownloader`, use `PhpBrew\Downloader\Factory` and `PhpBrew\Downloader\BaseDownloader` instead. I have provided curl extension / curl command / wget command / pure php function (`file_get_contents`)
2. options `http-proxy`, `http-proxy-auth`, `connect-timeout` now supports both curl extension and pure php function
3. add option `downloader` to choose which downloader to use. (default: curl extension > pure php functon > wget command > curl command)
4. refactor `UpdateCommand`, `DownloadCommand`, `InstallCommand`, `GetCommand` to the new downloader, so all of these commands now support all the above options
5. the test case for new downloaders is `PhpBrew\Downloader\DownloaderTest`, but I haven't add it to phpunit.xml yet.