### PR TITLE
Allow user value of variants contains dot character

### DIFF
--- a/src/PhpBrew/VariantParser.php
+++ b/src/PhpBrew/VariantParser.php
@@ -41,7 +41,7 @@ class VariantParser
                 if (substr($arg, 0, 2) === '--') {
                     throw new InvalidVariantSyntaxException("Invalid variant syntax exception start with '--': " . $arg);
                 }
-                preg_match_all('#[+-][\w_]+(=[\"\'\/\w_-]+)?#', $arg, $variantStrings);
+                preg_match_all('#[+-][\w_]+(=[\"\'\.\/\w_-]+)?#', $arg, $variantStrings);
 
                 if(isset($variantStrings[0])) {
                     $variantStrings = array_filter($variantStrings[0]);

--- a/tests/PhpBrew/VariantParserTest.php
+++ b/tests/PhpBrew/VariantParserTest.php
@@ -73,4 +73,17 @@ class VariantParserTest extends PHPUnit_Framework_TestCase
         );
         $this->assertArraySubset($expected, $variants);
     }
+
+    public function testVariantUserValueContainsVersion()
+    {
+        $variants = $this->makeArgs('+openssl=/usr/local/Cellar/openssl/1.0.2e +gettext=/usr/local/Cellar/gettext/0.19.7');
+        $expected = array(
+            'enabled_variants' => array(
+                'openssl' => '/usr/local/Cellar/openssl/1.0.2e',
+                'gettext' => '/usr/local/Cellar/gettext/0.19.7',
+            ),
+        );
+
+        $this->assertArraySubset($expected, $variants);
+    }
 }


### PR DESCRIPTION
Because the dot character is prohibited in unix-like filesystem, Also
Homebrew the most popular package manager in OS X that install package
in /usr/local/Cellar, If we prefer use keg-only pkgs to link with PHP
(for example: openssl). We have face the problem that user value can't
contains dot characters. This changes against this issue.