### PR TITLE
Proper redirect to STDERR for Fish shell

### DIFF
--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -439,7 +439,7 @@ function _phpbrewrc_load
             set prev_fs $curr_fs
             set curr_fs (stat -c %d . ^/dev/null)  # GNU version
             if [ $status -ne 0 ]; then
-                set curr_fs (stat -f %d . ^>/dev/null)  # BSD version
+                set curr_fs (stat -f %d . ^/dev/null)  # BSD version
             end
 
             # check if top level directory or filesystem boundary is reached


### PR DESCRIPTION
That is breaking the phpbrew support in fish shell.