### PR TITLE
 Object of class SplFileInfo could not be converted to boolean

### DIFF
--- a/src/PhpBrew/Tasks/ExtractTask.php
+++ b/src/PhpBrew/Tasks/ExtractTask.php
@@ -19,7 +19,7 @@ class ExtractTask extends BaseTask
     public function extract(Build $build, $targetFilePath, $extractDir = NULL)
     {
         $extractDirTemp = Config::getTempFileDir();
-        if (!$extractDir) {
+        if (empty($extractDir)) {
             $extractDir = dirname($targetFilePath);
         }
 


### PR DESCRIPTION
Hi! Recently I stuck with the problem:

```
PHP Catchable fatal error:  Object of class SplFileInfo could not be converted to boolean in /tmp/phpbrew/src/PhpBrew/Tasks/ExtractTask.php on line 22
PHP Stack trace:
PHP   1. {main}() /tmp/phpbrew/bin/phpbrew:0
PHP   2. CLIFramework\Application->run() /tmp/phpbrew/bin/phpbrew:21
PHP   3. CLIFramework\CommandBase->executeWrapper() /tmp/phpbrew/vendor/corneltek/cliframework/src/Application.php:398
PHP   4. call_user_func_array() /tmp/phpbrew/vendor/corneltek/cliframework/src/CommandBase.php:845
PHP   5. PhpBrew\Command\InstallCommand->execute() /tmp/phpbrew/vendor/corneltek/cliframework/src/CommandBase.php:845
PHP   6. PhpBrew\Tasks\ExtractTask->extract() /tmp/phpbrew/src/PhpBrew/Command/InstallCommand.php:336
```
So here really tiny fix :)