### PR TITLE
fix issues about known command

### DIFF
--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -46,7 +46,7 @@ class KnownCommand extends \CLIFramework\Command
         }
 
         foreach ($releases as $majorVersion => $versions) {
-            if (strpos($majorVersion, '5.2') !== false && ! $this->options->old) {
+            if (version_compare($majorVersion, '5.2', 'le') && ! $this->options->old) {
                 continue;
             }
             $versionList = array_keys($versions);

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -39,7 +39,9 @@ class KnownCommand extends \CLIFramework\Command
         $releaseList = new ReleaseList;
 
         $releases = array();
-        if (!$releaseList->foundLocalReleaseList() || $this->options->update) {
+        //always fetch list from remote when --old presents, because the local file may not contain the old versions
+        // and --old is seldom used.
+        if (!$releaseList->foundLocalReleaseList() || $this->options->update || $this->options->old) {
             $fetchTask = new FetchReleaseListTask($this->logger, $this->options);
             $releases = $fetchTask->fetch();
         } else {

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -1,5 +1,6 @@
 <?php
 namespace PhpBrew\Command;
+use PhpBrew\Config;
 use PhpBrew\ReleaseList;
 use PhpBrew\Tasks\FetchReleaseListTask;
 
@@ -42,7 +43,9 @@ class KnownCommand extends \CLIFramework\Command
             $fetchTask = new FetchReleaseListTask($this->logger, $this->options);
             $releases = $fetchTask->fetch();
         } else {
+            $this->logger->info(sprintf('Read local release list (last update: %s UTC).', gmdate('Y-m-d H:i:s', filectime(Config::getPHPReleaseListPath()))));
             $releases = $releaseList->loadLocalReleaseList();
+            $this->logger->info("You can run `phpbrew update` or `phpbrew known --update` to get a newer release list.");
         }
 
         foreach ($releases as $majorVersion => $versions) {
@@ -56,6 +59,9 @@ class KnownCommand extends \CLIFramework\Command
             $this->logger->writeln($this->formatter->format("{$majorVersion}: ", 'yellow') . wordwrap(join(', ', $versionList), 80, "\n" . str_repeat(' ',5))
                 . (!$this->options->more ? ' ...' : ''));
         }
-        $this->logger->info("You can run `phpbrew update` to get a newer release list.");
+
+        if($this->options->old) {
+            $this->logger->warn('phpbrew need php 5.3 or above to run. build/switch to versions below 5.3 at your own risk.');
+        }
     }
 }


### PR DESCRIPTION
this pr includes following changes:
1. if local release file contains old versions (versions below 5.3), `phpbrew known` will list version 5.1 and 5.0. the pr fix this bug
2. when local release file exists and doesn't contain old versions, `phpbrew known --old` doesn't work. the pr fix this bug ( #526 ) as well
3. add warning when --old present as phpbrew need at least 5.3 to run
4. add message about the change time of local release file.