### PR TITLE
Feature/pecl downloader

### DIFF
--- a/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
@@ -137,7 +137,7 @@ For example, to install memcached extension for php7, use:
             $extensions[$extName] = $this->getExtConfig($args);
         }
 
-        $extensionList = new ExtensionList;
+        $extensionList = new ExtensionList($this->logger, $this->options);
 
         $manager = new ExtensionManager($this->logger);
         foreach ($extensions as $extensionName => $extConfig) {

--- a/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
@@ -42,7 +42,7 @@ class KnownCommand extends \CLIFramework\Command
 
     public function execute($extensionName)
     {
-        $extensionList = new ExtensionList;
+        $extensionList = new ExtensionList($this->logger, $this->options);
 
         $provider = $extensionList->exists($extensionName);
 

--- a/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
@@ -2,6 +2,7 @@
 namespace PhpBrew\Command\ExtensionCommand;
 
 use PhpBrew\Config;
+use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Extension\ExtensionDownloader;
 use PhpBrew\ExtensionList;
 use PhpBrew\Tasks\FetchExtensionListTask;
@@ -24,6 +25,7 @@ class KnownCommand extends \CLIFramework\Command
      */
     public function options($opts)
     {
+        DownloadFactory::addOptionsForCommand($opts);
     }
 
     public function arguments($args)

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -23,7 +23,6 @@ use PhpBrew\BuildSettings\DefaultBuildSettings;
 use PhpBrew\Distribution\DistributionUrlPolicy;
 use CLIFramework\ValueCollection;
 use CLIFramework\Command;
-
 use PhpBrew\Exception\SystemCommandException;
 use Exception;
 

--- a/src/PhpBrew/Downloader/BaseDownloader.php
+++ b/src/PhpBrew/Downloader/BaseDownloader.php
@@ -62,7 +62,8 @@ abstract class BaseDownloader
      * @return bool|string return content if download successfully, otherwise false is returned
      * @throws RuntimeException
      */
-    public function request($url) {
+    public function request($url)
+    {
         $path = $this->download($url);
         return $path === false ? false : file_get_contents($path);
     }

--- a/src/PhpBrew/Downloader/BaseDownloader.php
+++ b/src/PhpBrew/Downloader/BaseDownloader.php
@@ -55,6 +55,18 @@ abstract class BaseDownloader
         }
     }
 
+    /**
+     * fetch the remote content
+     *
+     * @param $url the url to be downloaded
+     * @return bool|string return content if download successfully, otherwise false is returned
+     * @throws RuntimeException
+     */
+    public function request($url) {
+        $path = $this->download($url);
+        return $path === false ? false : file_get_contents($path);
+    }
+
     abstract protected function process($url, $targetFilePath);
 
     /**

--- a/src/PhpBrew/Extension/Provider/PeclProvider.php
+++ b/src/PhpBrew/Extension/Provider/PeclProvider.php
@@ -2,12 +2,15 @@
 
 namespace PhpBrew\Extension\Provider;
 
+use CLIFramework\Logger;
+use GetOptionKit\OptionResult;
 use PhpBrew\Config;
 use PEARX\Channel as PeclChannel;
 use CurlKit\CurlDownloader;
 use CurlKit\Progress\ProgressBar;
 use DOMDocument;
 use Exception;
+use PhpBrew\Downloader\DownloadFactory;
 
 class PeclProvider implements Provider
 {
@@ -17,6 +20,15 @@ class PeclProvider implements Provider
     public $repository = null;
     public $packageName = null;
     public $defaultVersion = 'stable';
+
+    private $logger;
+    private $options;
+
+    public function __construct(Logger $logger, OptionResult $options)
+    {
+        $this->logger = $logger;
+        $this->options = $options;
+    }
 
     public static function getName()
     {
@@ -31,6 +43,7 @@ class PeclProvider implements Provider
         $url = "$baseUrl/r/" . strtolower($packageName);
 
         $downloader = new CurlDownloader;
+        $downloader = DownloadFactory::getInstance($this->logger, $this->options);
 
         // translate version name into numbers
         if (in_array($version, array('stable', 'latest', 'beta'))) {

--- a/src/PhpBrew/ExtensionList.php
+++ b/src/PhpBrew/ExtensionList.php
@@ -14,12 +14,16 @@ use RuntimeException;
 class ExtensionList
 {
 
+    private $logger;
+    private $options;
 
-    public function __construct()
+    public function __construct(Logger $logger, OptionResult $options)
     {
+        $this->logger = $logger;
+        $this->options = $options;
     }
 
-    public static function getProviders()
+    public function getProviders()
     {
         static $providers;
         if ($providers) {
@@ -28,14 +32,14 @@ class ExtensionList
         $providers = array(
             new Extension\Provider\GithubProvider,
             new Extension\Provider\BitbucketProvider,
-            new Extension\Provider\PeclProvider
+            new Extension\Provider\PeclProvider($this->logger, $this->options)
         );
         return $providers;
     }
 
-    public static function getProviderByName($providerName)
+    public function getProviderByName($providerName)
     {
-        $providers = self::getProviders();
+        $providers = $this->getProviders();
 
         foreach ($providers as $provider) {
             if ($provider::getName() == $providerName) {
@@ -44,13 +48,13 @@ class ExtensionList
         }
     }
 
-    public static function getReadyInstance($branch = 'master', Logger $logger = null)
+    public static function getReadyInstance($branch = 'master', Logger $logger = null, OptionResult $options)
     {
         static $instance;
         if ($instance) {
             return $instance;
         }
-        $instance = new self;
+        $instance = new self($logger, $options);
 
         return $instance;
     }
@@ -60,7 +64,7 @@ class ExtensionList
 
 
         // determine which provider support this extension
-        $providers = self::getProviders();
+        $providers = $this->getProviders();
         foreach ($providers as $provider) {
             if ($provider->exists($extensionName)) {
                 return $provider;

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -6,8 +6,9 @@ use RuntimeException;
 use PhpBrew\Exception\OopsException;
 use PhpBrew\Build;
 
-function first_existing_executable($possiblePaths) {
-    $existingPaths = 
+function first_existing_executable($possiblePaths)
+{
+    $existingPaths =
         array_filter(
             array_filter(
                 array_filter($possiblePaths, "file_exists"),
@@ -19,7 +20,8 @@ function first_existing_executable($possiblePaths) {
     return false;
 }
 
-function first_existing_path($possiblePaths) {
+function first_existing_path($possiblePaths)
+{
     $existingPaths = array_filter($possiblePaths, "file_exists");
     if (!empty($existingPaths)) {
         return realpath($existingPaths[0]);
@@ -27,7 +29,8 @@ function first_existing_path($possiblePaths) {
     return false;
 }
 
-function exec_line($command) {
+function exec_line($command)
+{
     $output = array();
     exec($command, $output, $retval);
     if ($retval === 0) {
@@ -323,7 +326,7 @@ class VariantBuilder
         $this->variants['editline'] = function (Build $build, $prefix = null) {
             if ($prefix) {
                 return "--with-libedit=$prefix";
-            } else if ($prefix = Utils::findIncludePrefix('editline' . DIRECTORY_SEPARATOR . 'readline.h')) {
+            } elseif ($prefix = Utils::findIncludePrefix('editline' . DIRECTORY_SEPARATOR . 'readline.h')) {
                 return "--with-libedit=$prefix";
             }
         };
@@ -352,9 +355,9 @@ class VariantBuilder
             $opts = array();
             if ($prefix) {
                 $opts[] = "--with-gd=$prefix";
-            } else if ($prefix = Utils::findIncludePrefix('gd.h')) {
+            } elseif ($prefix = Utils::findIncludePrefix('gd.h')) {
                 $opts[] = "--with-gd=shared,$prefix";
-            } else if ($bin = Utils::findBin('brew')) {
+            } elseif ($bin = Utils::findBin('brew')) {
                 if ($output = exec_line("$bin --prefix gd")) {
                     $opts[] = "--with-gd=shared,$output";
                 }
@@ -365,7 +368,7 @@ class VariantBuilder
 
             if ($prefix = Utils::findIncludePrefix('jpeglib.h')) {
                 $opts[] = "--with-jpeg-dir=$prefix";
-            } else if ($bin = Utils::findBin('brew')) {
+            } elseif ($bin = Utils::findBin('brew')) {
                 if ($output = exec_line("$bin --prefix libjpeg")) {
                     $opts[] = "--with-jpeg-dir=$output";
                 }
@@ -601,7 +604,7 @@ class VariantBuilder
             if ($build->hasVariant('pdo')) {
                 if ($bin = Utils::findBin('pg_config')) {
                     $opts[] = "--with-pdo-pgsql=$bin";
-                } else if ($path = first_existing_executable(array(
+                } elseif ($path = first_existing_executable(array(
                         "/opt/local/lib/postgresql95/bin/pg_config",
                         "/opt/local/lib/postgresql94/bin/pg_config",
                         "/opt/local/lib/postgresql93/bin/pg_config",
@@ -613,7 +616,7 @@ class VariantBuilder
                         "/Library/PostgreSQL/9.1/bin/pg_config",
                     ))) {
                     $opts[] = "--with-pdo-pgsql=$path";
-                } else if ($prefix) {
+                } elseif ($prefix) {
                     $opts[] = "--with-pdo-pgsql=$prefix";
                 } else {
                     $opts[] = "--with-pdo-pgsql";

--- a/tests/PhpBrew/Extension/ExtensionInstallerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionInstallerTest.php
@@ -33,7 +33,7 @@ class ExtensionInstallerTest extends CommandTestCase
     {
         $logger = new Logger;
         $logger->setQuiet();
-        $peclProvider = new PeclProvider;
+        $peclProvider = new PeclProvider($logger, new OptionResult);
         $downloader = new ExtensionDownloader($logger, new OptionResult);
         $peclProvider->setPackageName('APCu');
         $extractPath = $downloader->download($peclProvider, 'latest');

--- a/tests/PhpBrew/Extension/KnownCommandTest.php
+++ b/tests/PhpBrew/Extension/KnownCommandTest.php
@@ -16,7 +16,7 @@ class KnownCommandTest extends CommandTestCase {
         $logger = new Logger;
         $logger->setQuiet();
 
-        $provider = new PeclProvider();
+        $provider = new PeclProvider($logger, new OptionResult());
         $provider->setPackageName('xdebug');
 
         $extensionDownloader = new ExtensionDownloader($logger, new OptionResult);


### PR DESCRIPTION
As mentioned in #726 , `--download` option doesn't apply to `phpbrew ext install` and `phpbrew ext known` when reading info from pecl site.