### PR TITLE
Use correct path for MySQL socket on Ubuntu. $paths[0] doesn't work, since array_filter() preserves indices. No need to check existence of all files.

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -647,12 +647,15 @@ class VariantBuilder
                     '/opt/local/var/run/mysql54/mysqld.sock',
 
                     '/tmp/mysql.sock', /* homebrew mysql sock */
-                    '/var/run/mysqld/mysql.sock',
+                    '/var/run/mysqld/mysqld.sock', /* ubuntu */
                     '/var/mysql/mysql.sock',
                 );
-                $paths = array_filter($possiblePaths, 'file_exists');
-                if (count($paths) > 0 && file_exists($paths[0])) {
-                    $opts[] = "--with-mysql-sock={$paths[0]}";
+
+                foreach ($possiblePaths as $path) {
+                    if (file_exists($path)) {
+                        $opts[] = '--with-mysql-sock=' . $path;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
PhpBrew fails to detect MySQL socket on Ubuntu. Even if it existed, it wouldn't be used because it corresponds to `$paths[5]`, not to `$paths[0]`.