### PR TITLE
Adds psysh.org's php REPL tool

### DIFF
--- a/src/PhpBrew/AppStore.php
+++ b/src/PhpBrew/AppStore.php
@@ -16,6 +16,7 @@ class AppStore
             'pdepend'   => array('url' => 'http://static.pdepend.org/php/latest/pdepend.phar',      'as' => 'pdepend'),
             'onion'     => array('url' => 'https://raw.githubusercontent.com/phpbrew/Onion/master/onion', 'as' => 'onion'),
             'box-2.5'   => array('url' => 'https://github.com/box-project/box2/releases/download/2.5.2/box-2.5.2.phar', 'as' => 'box'),
+            'psysh'     => array('url' => 'https://git.io/psysh', 'as' => 'psysh'),
         );
         $phpunitapps = explode(' ', 'phpunit phpcov phpcpd phpdcd phptok phploc');
         foreach ($phpunitapps as $phpunitapp) {


### PR DESCRIPTION
The `psysh` command is much like `ipython`, works perfectly for interactively running code and debugging.

source: http://psysh.org/