### PR TITLE
Do not break too early and let the needed break procedure to be executed on the next iteration.

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -489,9 +489,6 @@ function _phpbrewrc_load ()
             break
         fi
         curr_dir=$(dirname $curr_dir)
-        if [[ "$curr_dir" == "/" ]] ; then
-            break
-        fi
     done
     PHPBREW_LAST_DIR="$PWD"
 }


### PR DESCRIPTION
Fixes #782 introduced by #680.
