### PR TITLE
Fixed automatic detection of --with-libdir

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -1084,9 +1084,9 @@ class VariantBuilder
             }
         }
 
-        if ($prefix = Utils::findLibPrefix('x86_64-linux-gnu')) {
+        if ($prefix = Utils::findLibPrefix('lib/x86_64-linux-gnu')) {
             $this->addOptions('--with-libdir=lib/x86_64-linux-gnu');
-        } elseif ($prefix = Utils::findLibPrefix('i386-linux-gnu')) {
+        } elseif ($prefix = Utils::findLibPrefix('lib/i386-linux-gnu')) {
             $this->addOptions('--with-libdir=lib/i386-linux-gnu');
         }
 


### PR DESCRIPTION
When installing PHP on Ubuntu, it's expected that phpbrew automatically appends `--with-libdir=lib/x86_64-linux-gnu` to the configure command. This feature is broken since e93f221:
```
↪  file /usr/lib/x86_64-linux-gnu/
/usr/lib/x86_64-linux-gnu/: directory

↪  phpbrew --debug install --dryrun 5.6.26
./configure '--cache-file='\''/home/morozov/.phpbrew/cache/config.cache'\''' '--prefix=/home/morozov/.phpbrew/php/php-5.6.26' '--with-config-file-path=/home/morozov/.phpbrew/php/php-5.6.26/etc' '--with-config-file-scan-dir=/home/morozov/.phpbrew/php/php-5.6.26/var/db' '--disable-all' '--enable-phar' '--enable-session' '--enable-short-tags' '--enable-tokenizer' '--with-pcre-regex' '--with-zlib=/usr' '--enable-bcmath' '--with-bz2=/usr' '--enable-calendar' '--enable-cli' '--enable-ctype' '--enable-dom' '--enable-fileinfo' '--enable-filter' '--enable-shmop' '--enable-sysvsem' '--enable-sysvshm' '--enable-sysvmsg' '--enable-json' '--enable-mbregex' '--enable-mbstring' '--with-mhash' '--enable-pcntl' '--with-pcre-regex' '--enable-pdo' '--enable-phar' '--enable-posix' '--with-readline=/usr' '--enable-sockets' '--enable-tokenizer' '--enable-dom' '--enable-libxml' '--enable-simplexml' '--enable-xml' '--enable-xmlreader' '--enable-xmlwriter' '--with-xsl' '--with-libxml-dir=/usr' '--with-curl=/usr' '--enable-zip' '--with-openssl=/usr' '--enable-opcache' '--with-pear=/home/morozov/.phpbrew/php/php-5.6.26/lib/php' >> /home/morozov/.phpbrew/build/php-5.6.26/build.log 2>&1
```

Given that `findLibPrefix()` calls `getLookupPrefixes()` internally, which is unaware of the `lib` suffix anymore, it makes sense to specify `lib/` explicitly when calling the former.