### PR TITLE
`phpbrew use` doesn't work for non-release versions

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -47,7 +47,7 @@ fi
 
 [[ -z "$PHPBREW_ROOT" ]] && export PHPBREW_ROOT="$HOME/.phpbrew"
 [[ -z "$PHPBREW_BIN" ]] && export PHPBREW_BIN="$PHPBREW_HOME/bin"
-[[ -z "$PHPBREW_VERSION_REGEX" ]] && export PHPBREW_VERSION_REGEX="^([[:digit:]]+\.){2}[[:digit:]]+$"
+[[ -z "$PHPBREW_VERSION_REGEX" ]] && export PHPBREW_VERSION_REGEX="^([[:digit:]]+\.){2}[[:digit:]]+((alpha|beta|RC)[[:digit:]]+)?$"
 
 [[ -e "$PHPBREW_ROOT" ]] || mkdir $PHPBREW_ROOT
 [[ -e "$PHPBREW_HOME" ]] || mkdir $PHPBREW_HOME

--- a/src/PhpBrew/BuildFinder.php
+++ b/src/PhpBrew/BuildFinder.php
@@ -24,7 +24,7 @@ class BuildFinder
 
         if ($stripPrefix) {
             $names = array_map(function ($name) {
-                return preg_replace('/^php-(?=(\d+\.\d+\.\d+)$)/', '', $name);
+                return preg_replace('/^php-(?=(\d+\.\d+\.\d+((alpha|beta|RC)\d+)?)$)/', '', $name);
             }, $names);
         }
         uasort($names, 'version_compare'); // ordering version name ascending... 5.5.17, 5.5.12


### PR DESCRIPTION
When switching to a release version, say 5.6.26, one can omit or preserve the php- prefix, and both `phpbrew use 5.6.26` and `phpbrew use php-5.6.26` will work as expected. While in case of a non-release version, say 7.1.0RC3, only the approach with the prefix works:

```
↪  phpbrew list
  php-7.1.0RC3   
* php-7.0.11     
  php-5.6.26     
  php-5.5.38     
  php-5.4.45     
  php-5.3.29     

↪  phpbrew use 5.6.26

↪  php --version
PHP 5.6.26 (cli) (built: Sep 28 2016 14:10:31) 

↪  phpbrew use 7.1.0RC3
php version: 7.1.0RC3 not exists.

↪  phpbrew use php-7.1.0RC3

↪  php --version
PHP 7.1.0RC3 (cli) (built: Oct  3 2016 16:32:50) ( NTS )
```
