### PR TITLE
Double php- when installing from github tag

### DIFF
--- a/src/PhpBrew/VersionDslParser.php
+++ b/src/PhpBrew/VersionDslParser.php
@@ -24,8 +24,14 @@ class VersionDslParser
         if (preg_match("#https?://(www\.)?github\.com/([0-9a-zA-Z-._]+)/php-src(@([0-9a-zA-Z-._]+))?#", $url, $matches)) {
             $owner = $matches[2];
             $branch = isset($matches[4]) ? $matches[4] : 'master';
+            $version = preg_replace('/^php-/', '', $branch);
+
+            if ($owner !== 'php') {
+                $version = $owner . '-' . $version;
+            }
+
             $result = array(
-                'version' => ($owner === 'php' ? "php-{$branch}" : "php-{$owner}-{$branch}"),
+                'version' => 'php-' . $version,
                 'url' => "https://github.com/{$owner}/php-src/archive/{$branch}.tar.gz",
             );
         }

--- a/tests/PhpBrew/VersionDslParserTest.php
+++ b/tests/PhpBrew/VersionDslParserTest.php
@@ -26,6 +26,7 @@ class ExtensionDslParserTest extends \PHPUnit_Framework_TestCase
             array('github.com:php/php-src@branch', 'https://github.com/php/php-src/archive/branch.tar.gz', 'php-branch'), // explicit branch
             array('git@github.com:php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'), // implicit branch
             array('git@github.com:php/php-src@branch', 'https://github.com/php/php-src/archive/branch.tar.gz', 'php-branch'), // explicit branch
+            array('git@github.com:php/php-src@php-7.1.0RC3', 'https://github.com/php/php-src/archive/php-7.1.0RC3.tar.gz', 'php-7.1.0RC3'), // tag
 
             // github urls
             array('https://www.github.com/php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'),
@@ -37,6 +38,7 @@ class ExtensionDslParserTest extends \PHPUnit_Framework_TestCase
             array('github.com:marc/php-src', 'https://github.com/marc/php-src/archive/master.tar.gz', 'php-marc-master'), // implicit branch
             array('git@github.com:marc/php-src', 'https://github.com/marc/php-src/archive/master.tar.gz', 'php-marc-master'),
             array('https://www.github.com/marc/php-src', 'https://github.com/marc/php-src/archive/master.tar.gz', 'php-marc-master'),
+            array('git@github.com:marc/php-src@php-7.1.0RC3', 'https://github.com/marc/php-src/archive/php-7.1.0RC3.tar.gz', 'php-marc-7.1.0RC3'), // tag in fork
 
             // Other URLs
             array('https://www.php.net/~ab/php-7.0.0alpha1.tar.gz', 'https://www.php.net/~ab/php-7.0.0alpha1.tar.gz', 'php-7.0.0alpha1'),


### PR DESCRIPTION
When installing PHP from a github tag, the resulting version has double php- prefix:
```
↪  phpbrew --debug install --dryrun github:php/php-src@php-7.1.0RC3

To use the newly built PHP, try the line(s) below:

    $ phpbrew use php-php-7.1.0RC3

Or you can use switch command to switch your default php to php-php-7.1.0RC3:

    $ phpbrew switch php-php-7.1.0RC3

Enjoy!
```

Despite it can be worked around by means of using version alias like `as php-7.1.0RC3`, it would be more intuitive to have a single prefix out of the box.