### PR TITLE
Prefix completion only works with php- prefix

### DIFF
--- a/src/PhpBrew/Command/UseCommand.php
+++ b/src/PhpBrew/Command/UseCommand.php
@@ -16,7 +16,7 @@ class UseCommand extends Command
     {
         $args->add('php version')
             ->validValues(function () {
-                return \PhpBrew\BuildFinder::findMatchedBuilds(false, false);
+                return \PhpBrew\BuildFinder::findInstalledBuilds();
             })
             ;
     }

--- a/tests/PhpBrew/Command/PathCommandTest.php
+++ b/tests/PhpBrew/Command/PathCommandTest.php
@@ -21,14 +21,6 @@ class PathCommandTest extends CommandTestCase
         );
     }
 
-    public function testUseLatestPHP()
-    {
-        $versionName = $this->getPrimaryVersion();
-        $this->assertCommandSuccess("phpbrew use php-{$versionName}");
-        // $this->assertRegExp("#php/$versionName/bin\$#", getenv('PHPBREW_PATH'));
-        $this->assertEquals("php-$versionName", getenv('PHPBREW_PHP'));
-    }
-
     /**
      * @outputBuffering enabled
      * @dataProvider argumentsProvider


### PR DESCRIPTION
When I start typing a PHP version without the php- prefix, the version doesn't get completed:
```
↪  phpbrew use 5[tab][tab]
# nothing here
```

However, there's a few 5.x versions installed:
```
↪  phpbrew list
  php-7.1.0RC5   
* php-7.0.11     
  php-5.6.27     
  php-5.6.26-libmysqlclient
  php-5.5.38     
  php-5.4.45     
  php-5.3.29     
```

It's especially annoying, given that the `use` command allows [omitting the "php-" prefix](https://github.com/morozov/phpbrew/blob/c9cff47797f560aef126b8d2b1a65daa7cd5590b/shell/bashrc#L137-L137) for standard versions.

In order to get the completion work, one has to not type any prefix and let the completion script add "php-":
```
↪  phpbrew use [tab][tab]php-[5][tab].[tab][tab]
php-5.3.29                 php-5.5.38                 php-5.6.27
php-5.4.45                 php-5.6.26-libmysqlclient  
```

With the suggested patch, the completion UX looks like:
```
↪  phpbrew use [tab][tab]
5.3.29                     5.6.27                     php-7.1.0RC5
5.4.45                     7.0.11                     
5.5.38                     php-5.6.26-libmysqlclient  
```