### PR TITLE
Update Japanese and English READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@ PHPをビルドするための開発用パッケージをインストールす�
 ```bash
 curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
 chmod +x phpbrew
-sudo mv phpbrew /usr/bin/phpbrew
+sudo mv phpbrew /usr/local/bin/phpbrew
 ```
 
 ## 基本的な使い方

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
 chmod +x phpbrew
 
 # Move phpbrew to somewhere can be found by your $PATH
-sudo mv phpbrew /usr/bin/phpbrew
+sudo mv phpbrew /usr/local/bin/phpbrew
 ```
 
 ## QUICK START


### PR DESCRIPTION
This PR updates the Japanese and English README files.

Though minor, installation following current instructions will fail on systems running OS X 10.11 (El Capitan) or macOS 10.12 (Sierra).

This is due to a newer feature of the OS, called [System Integrity Protection], a security measure which prevents even root-level access to a number of directories, including `/usr/bin`.

The Portuguese README has already been updated accounting for this.

[System Integrity Protection]: https://support.apple.com/en-us/HT204899