### PR TITLE
fix travis-ci test 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ php:
 - 5.5
 - 5.6
 - 7.0
+- 7.1
 # - nightly
 sudo: required
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,13 @@ addons:
     - openssl
     # packages for apxs2 
     - apache2
+before_install:
+- |
+  if [[ ${TRAVIS_PHP_VERSION:0:3} < "5.6" ]]; then  # use phpunit 4.8.35 for 5.3/5.4/5.5
+    composer require phpunit/phpunit ~4; 
+  else # and use 5.7 for 5.6/7.0/7.1
+    composer require phpunit/phpunit ~5; 
+  fi
 install:
 - travis_retry composer install --no-interaction
 before_script:
@@ -68,7 +75,9 @@ before_script:
 - cp -v shell/bashrc .phpbrew/
 script:
 - source shell/bashrc
-- phpunit --exclude-group mayignore
+- phpunit --version
+- which phpunit
+- vendor/bin/phpunit --exclude-group mayignore
 after_success:
 - ccache -s
 - travis_retry php vendor/bin/coveralls -v

--- a/tests/PhpBrew/BuildRegisterTest.php
+++ b/tests/PhpBrew/BuildRegisterTest.php
@@ -5,7 +5,7 @@ use PhpBrew\BuildRegister;
 /**
  * @small
  */
-class BuildRegisterTest extends PHPUnit_Framework_TestCase
+class BuildRegisterTest extends \PHPUnit\Framework\TestCase
 {
     public function testBuildRegister()
     {

--- a/tests/PhpBrew/BuildSettings/BuildSettingsTest.php
+++ b/tests/PhpBrew/BuildSettings/BuildSettingsTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\BuildSettings;
 use PhpBrew\Config;
 use PhpBrew\Testing\TemporaryFileFixture;
 
-class BuildSettingsTest extends \PHPUnit_Framework_TestCase
+class BuildSettingsTest extends \\PHPUnit\Framework\TestCase
 {
     public function testConstructorWithEnabledVariants()
     {

--- a/tests/PhpBrew/BuildSettings/BuildSettingsTest.php
+++ b/tests/PhpBrew/BuildSettings/BuildSettingsTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\BuildSettings;
 use PhpBrew\Config;
 use PhpBrew\Testing\TemporaryFileFixture;
 
-class BuildSettingsTest extends \\PHPUnit\Framework\TestCase
+class BuildSettingsTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructorWithEnabledVariants()
     {

--- a/tests/PhpBrew/BuildSettings/DefaultBuildSettingsTest.php
+++ b/tests/PhpBrew/BuildSettings/DefaultBuildSettingsTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace PhpBrew\BuildSettings;
 
-class DefaultBuildSettingsTest extends \\PHPUnit\Framework\TestCase
+class DefaultBuildSettingsTest extends \PHPUnit\Framework\TestCase
 {
     public function testDefaultEnabledVariants()
     {

--- a/tests/PhpBrew/BuildSettings/DefaultBuildSettingsTest.php
+++ b/tests/PhpBrew/BuildSettings/DefaultBuildSettingsTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace PhpBrew\BuildSettings;
 
-class DefaultBuildSettingsTest extends \PHPUnit_Framework_TestCase
+class DefaultBuildSettingsTest extends \\PHPUnit\Framework\TestCase
 {
     public function testDefaultEnabledVariants()
     {

--- a/tests/PhpBrew/BuildTest.php
+++ b/tests/PhpBrew/BuildTest.php
@@ -3,7 +3,7 @@
 /**
  * @small
  */
-class BuildTest extends PHPUnit_Framework_TestCase
+class BuildTest extends \PHPUnit\Framework\TestCase
 {
     public function testBuildAPI()
     {

--- a/tests/PhpBrew/CommandBuilderTest.php
+++ b/tests/PhpBrew/CommandBuilderTest.php
@@ -3,7 +3,7 @@
 /**
  * @small
  */
-class CommandBuilderTest extends PHPUnit_Framework_TestCase
+class CommandBuilderTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {

--- a/tests/PhpBrew/ConfigTest.php
+++ b/tests/PhpBrew/ConfigTest.php
@@ -8,7 +8,7 @@
  * the value to the corresponding environment variable.
  * @small
  */
-class ConfigTest extends PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {

--- a/tests/PhpBrew/Distribution/DistributionUrlPolicyTest.php
+++ b/tests/PhpBrew/Distribution/DistributionUrlPolicyTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Distribution;
 /**
  * @small
  */
-class DistributionUrlPolicyTest extends \\PHPUnit\Framework\TestCase
+class DistributionUrlPolicyTest extends \PHPUnit\Framework\TestCase
 {
     public $policy;
 

--- a/tests/PhpBrew/Distribution/DistributionUrlPolicyTest.php
+++ b/tests/PhpBrew/Distribution/DistributionUrlPolicyTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Distribution;
 /**
  * @small
  */
-class DistributionUrlPolicyTest extends \PHPUnit_Framework_TestCase
+class DistributionUrlPolicyTest extends \\PHPUnit\Framework\TestCase
 {
     public $policy;
 

--- a/tests/PhpBrew/Downloader/DownloaderTest.php
+++ b/tests/PhpBrew/Downloader/DownloaderTest.php
@@ -12,12 +12,12 @@ namespace PhpBrew\Downloader;
 use CLIFramework\Logger;
 use GetOptionKit\OptionResult;
 use PhpBrew\Config;
-use PHPUnit_Framework_TestCase;
+use \PHPUnit\Framework\TestCase;
 
 /**
  * @large
  */
-class DownloaderTest extends PHPUnit_Framework_TestCase
+class DownloaderTest extends \PHPUnit\Framework\TestCase
 {
     public $logger;
 

--- a/tests/PhpBrew/Extension/ExtensionInstallerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionInstallerTest.php
@@ -8,7 +8,7 @@ use PhpBrew\Extension\PeclExtensionInstaller;
 use PhpBrew\Extension\ExtensionDownloader;
 use PhpBrew\Testing\CommandTestCase;
 use PhpBrew\Utils;
-use PHPUnit_Framework_TestCase;
+use \PHPUnit\Framework\TestCase;
 use CLIFramework\Logger;;
 use GetOptionKit\OptionResult;
 use PhpBrew\Extension\Provider\PeclProvider;

--- a/tests/PhpBrew/Extension/ExtensionManagerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionManagerTest.php
@@ -9,7 +9,7 @@ use CLIFramework\Logger;
  * @large
  * @group extension
  */
-class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
+class ExtensionManagerTest extends \\PHPUnit\Framework\TestCase
 {
     private $manager;
 

--- a/tests/PhpBrew/Extension/ExtensionManagerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionManagerTest.php
@@ -9,7 +9,7 @@ use CLIFramework\Logger;
  * @large
  * @group extension
  */
-class ExtensionManagerTest extends \\PHPUnit\Framework\TestCase
+class ExtensionManagerTest extends \PHPUnit\Framework\TestCase
 {
     private $manager;
 

--- a/tests/PhpBrew/Extension/ExtensionTest.php
+++ b/tests/PhpBrew/Extension/ExtensionTest.php
@@ -4,7 +4,7 @@ use PhpBrew\Extension\ExtensionFactory;
 use PhpBrew\Extension\M4Extension;
 use PhpBrew\Extension\PeclExtension;
 use PhpBrew\Extension\Extension;
-use PHPUnit_Framework_TestCase;
+use \PHPUnit\Framework\TestCase;
 
 /**
  * ExtensionTest
@@ -12,7 +12,7 @@ use PHPUnit_Framework_TestCase;
  * @large
  * @group extension
  */
-class ExtensionTest extends PHPUnit_Framework_TestCase
+class ExtensionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * We use getenv to get the path of extension directory because in data provider method

--- a/tests/PhpBrew/Extension/Provider/RepositoryDslParserTest.php
+++ b/tests/PhpBrew/Extension/Provider/RepositoryDslParserTest.php
@@ -8,7 +8,7 @@ namespace PhpBrew\Extension\Provider;
  * @small
  * @group extension
  */
-class ExtensionDslParserTest extends \PHPUnit_Framework_TestCase
+class ExtensionDslParserTest extends \\PHPUnit\Framework\TestCase
 {
     protected $parser;
 

--- a/tests/PhpBrew/Extension/Provider/RepositoryDslParserTest.php
+++ b/tests/PhpBrew/Extension/Provider/RepositoryDslParserTest.php
@@ -8,7 +8,7 @@ namespace PhpBrew\Extension\Provider;
  * @small
  * @group extension
  */
-class ExtensionDslParserTest extends \\PHPUnit\Framework\TestCase
+class ExtensionDslParserTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser;
 

--- a/tests/PhpBrew/MachineTest.php
+++ b/tests/PhpBrew/MachineTest.php
@@ -2,7 +2,7 @@
 
 use PhpBrew\Machine;
 
-class MachineTest extends \PHPUnit_Framework_TestCase
+class MachineTest extends \\PHPUnit\Framework\TestCase
 {
     public function testDetectProcessorNumber()
     {

--- a/tests/PhpBrew/MachineTest.php
+++ b/tests/PhpBrew/MachineTest.php
@@ -2,7 +2,7 @@
 
 use PhpBrew\Machine;
 
-class MachineTest extends \\PHPUnit\Framework\TestCase
+class MachineTest extends \PHPUnit\Framework\TestCase
 {
     public function testDetectProcessorNumber()
     {

--- a/tests/PhpBrew/PatchUtilsTest.php
+++ b/tests/PhpBrew/PatchUtilsTest.php
@@ -4,7 +4,7 @@ use PhpBrew\PatchUtils;
 /**
  * @small
  */
-class PatchUtilsTest extends PHPUnit_Framework_TestCase
+class PatchUtilsTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {

--- a/tests/PhpBrew/Platform/Linux/CentOSTest.php
+++ b/tests/PhpBrew/Platform/Linux/CentOSTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform\Linux;
 /**
  * @small
  */
-class CentOSTest extends \PHPUnit_Framework_TestCase
+class CentOSTest extends \\PHPUnit\Framework\TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/Linux/CentOSTest.php
+++ b/tests/PhpBrew/Platform/Linux/CentOSTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform\Linux;
 /**
  * @small
  */
-class CentOSTest extends \\PHPUnit\Framework\TestCase
+class CentOSTest extends \PHPUnit\Framework\TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/Linux/DebianTest.php
+++ b/tests/PhpBrew/Platform/Linux/DebianTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform\Linux;
 /**
  * @small
  */
-class DebianTest extends \\PHPUnit\Framework\TestCase
+class DebianTest extends \PHPUnit\Framework\TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/Linux/DebianTest.php
+++ b/tests/PhpBrew/Platform/Linux/DebianTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform\Linux;
 /**
  * @small
  */
-class DebianTest extends \PHPUnit_Framework_TestCase
+class DebianTest extends \\PHPUnit\Framework\TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/Linux/UnknownDistributionTest.php
+++ b/tests/PhpBrew/Platform/Linux/UnknownDistributionTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform\Linux;
 /**
  * @small
  */
-class UnknownDistributionTest extends \PHPUnit_Framework_TestCase
+class UnknownDistributionTest extends \\PHPUnit\Framework\TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/Linux/UnknownDistributionTest.php
+++ b/tests/PhpBrew/Platform/Linux/UnknownDistributionTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform\Linux;
 /**
  * @small
  */
-class UnknownDistributionTest extends \\PHPUnit\Framework\TestCase
+class UnknownDistributionTest extends \PHPUnit\Framework\TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/LinuxTest.php
+++ b/tests/PhpBrew/Platform/LinuxTest.php
@@ -6,7 +6,7 @@ use PhpBrew\Platform\Linux\Distribution;
 /**
  * @small
  */
-class LinuxTest extends \PHPUnit_Framework_TestCase
+class LinuxTest extends \\PHPUnit\Framework\TestCase
 {
     private $hardware;
     private $distribution;

--- a/tests/PhpBrew/Platform/LinuxTest.php
+++ b/tests/PhpBrew/Platform/LinuxTest.php
@@ -6,7 +6,7 @@ use PhpBrew\Platform\Linux\Distribution;
 /**
  * @small
  */
-class LinuxTest extends \\PHPUnit\Framework\TestCase
+class LinuxTest extends \PHPUnit\Framework\TestCase
 {
     private $hardware;
     private $distribution;

--- a/tests/PhpBrew/Platform/MacTest.php
+++ b/tests/PhpBrew/Platform/MacTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class MacTest extends \PHPUnit_Framework_TestCase
+class MacTest extends \\PHPUnit\Framework\TestCase
 {
     private $hardware;
     private $platform;

--- a/tests/PhpBrew/Platform/MacTest.php
+++ b/tests/PhpBrew/Platform/MacTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class MacTest extends \\PHPUnit\Framework\TestCase
+class MacTest extends \PHPUnit\Framework\TestCase
 {
     private $hardware;
     private $platform;

--- a/tests/PhpBrew/Platform/PlatformInfoTest.php
+++ b/tests/PhpBrew/Platform/PlatformInfoTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class PlatformInfoTest extends \\PHPUnit\Framework\TestCase
+class PlatformInfoTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateMacPlatform()
     {

--- a/tests/PhpBrew/Platform/PlatformInfoTest.php
+++ b/tests/PhpBrew/Platform/PlatformInfoTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class PlatformInfoTest extends \PHPUnit_Framework_TestCase
+class PlatformInfoTest extends \\PHPUnit\Framework\TestCase
 {
     public function testCreateMacPlatform()
     {

--- a/tests/PhpBrew/Platform/UnixLikeHardwareTest.php
+++ b/tests/PhpBrew/Platform/UnixLikeHardwareTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class UnixLikeHardwareTest extends \PHPUnit_Framework_TestCase
+class UnixLikeHardwareTest extends \\PHPUnit\Framework\TestCase
 {
     public function testBitnessWhenHardwareIs64Bit()
     {

--- a/tests/PhpBrew/Platform/UnixLikeHardwareTest.php
+++ b/tests/PhpBrew/Platform/UnixLikeHardwareTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class UnixLikeHardwareTest extends \\PHPUnit\Framework\TestCase
+class UnixLikeHardwareTest extends \PHPUnit\Framework\TestCase
 {
     public function testBitnessWhenHardwareIs64Bit()
     {

--- a/tests/PhpBrew/Platform/UnknownPlatformTest.php
+++ b/tests/PhpBrew/Platform/UnknownPlatformTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class UnknownPlatformTest extends \PHPUnit_Framework_TestCase
+class UnknownPlatformTest extends \\PHPUnit\Framework\TestCase
 {
     private $platform;
 

--- a/tests/PhpBrew/Platform/UnknownPlatformTest.php
+++ b/tests/PhpBrew/Platform/UnknownPlatformTest.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Platform;
 /**
  * @small
  */
-class UnknownPlatformTest extends \\PHPUnit\Framework\TestCase
+class UnknownPlatformTest extends \PHPUnit\Framework\TestCase
 {
     private $platform;
 

--- a/tests/PhpBrew/ReleaseListTest.php
+++ b/tests/PhpBrew/ReleaseListTest.php
@@ -4,7 +4,7 @@ use PhpBrew\ReleaseList;
 /**
  * @small
  */
-class ReleaseListTest extends PHPUnit_Framework_TestCase
+class ReleaseListTest extends \PHPUnit\Framework\TestCase
 {
     public $releaseList;
 

--- a/tests/PhpBrew/Tasks/MakeTaskTest.php
+++ b/tests/PhpBrew/Tasks/MakeTaskTest.php
@@ -8,7 +8,7 @@ use PhpBrew\Buildable;
 /**
  * @small
  */
-class MakeTaskTest extends \PHPUnit_Framework_TestCase
+class MakeTaskTest extends \\PHPUnit\Framework\TestCase
 {
     private $make;
 

--- a/tests/PhpBrew/Tasks/MakeTaskTest.php
+++ b/tests/PhpBrew/Tasks/MakeTaskTest.php
@@ -8,7 +8,7 @@ use PhpBrew\Buildable;
 /**
  * @small
  */
-class MakeTaskTest extends \\PHPUnit\Framework\TestCase
+class MakeTaskTest extends \PHPUnit\Framework\TestCase
 {
     private $make;
 

--- a/tests/PhpBrew/UtilsTest.php
+++ b/tests/PhpBrew/UtilsTest.php
@@ -5,7 +5,7 @@ use PhpBrew\Config;
 /**
  * @small
  */
-class UtilsTest extends PHPUnit_Framework_TestCase
+class UtilsTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {

--- a/tests/PhpBrew/VariantBuilderTest.php
+++ b/tests/PhpBrew/VariantBuilderTest.php
@@ -5,7 +5,7 @@ use PhpBrew\Build;
 /**
  * @small
  */
-class VariantBuilderTest extends PHPUnit_Framework_TestCase
+class VariantBuilderTest extends \PHPUnit\Framework\TestCase
 {
     public function variantOptionProvider()
     {

--- a/tests/PhpBrew/VariantParserTest.php
+++ b/tests/PhpBrew/VariantParserTest.php
@@ -4,7 +4,7 @@ use PhpBrew\VariantParser;
 /**
  * @small
  */
-class VariantParserTest extends PHPUnit_Framework_TestCase
+class VariantParserTest extends \PHPUnit\Framework\TestCase
 {
     public function makeArgs($arg)
     {

--- a/tests/PhpBrew/VersionDslParserTest.php
+++ b/tests/PhpBrew/VersionDslParserTest.php
@@ -7,7 +7,7 @@ namespace PhpBrew;
  *
  * @small
  */
-class ExtensionDslParserTest extends \\PHPUnit\Framework\TestCase
+class ExtensionDslParserTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser;
 

--- a/tests/PhpBrew/VersionDslParserTest.php
+++ b/tests/PhpBrew/VersionDslParserTest.php
@@ -7,7 +7,7 @@ namespace PhpBrew;
  *
  * @small
  */
-class ExtensionDslParserTest extends \PHPUnit_Framework_TestCase
+class ExtensionDslParserTest extends \\PHPUnit\Framework\TestCase
 {
     protected $parser;
 

--- a/tests/PhpBrew/VersionTest.php
+++ b/tests/PhpBrew/VersionTest.php
@@ -4,7 +4,7 @@ use PhpBrew\Version;
 /**
  * @small
  */
-class VersionTest extends PHPUnit_Framework_TestCase
+class VersionTest extends \PHPUnit\Framework\TestCase
 {
     public function testVersionConstructor()
     {


### PR DESCRIPTION
fix #855 

the test for cliframework still needs to be updated otherwise php 7.2 will broke the ci test since phpunit 5.7 won't support php 7.2.

