### PR TITLE
fix error in fishshell running `phpbrew use xxx`

### DIFF
--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -126,13 +126,14 @@ function phpbrew
                 set NEW_PHPBREW_PHP_PATH "$PHPBREW_ROOT/php/$_PHP_VERSION"
                 if [ -d $NEW_PHPBREW_PHP_PATH ]
                     if [ $BIN = "phpbrew" ]
-                        set code (command phpbrew env $_PHP_VERSION)
+                        set code (command phpbrew env $_PHP_VERSION | tr '\n' ';')
                     else
-                        set code (eval $BIN env $_PHP_VERSION)
+                        set code (eval $BIN env $_PHP_VERSION | tr '\n' ';')
                     end
                     if [ -z "$code" ]
                         set exit_status 1
                     else
+                        set exit_status 0
                         eval $code
                         __phpbrew_set_path
                     end

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -126,9 +126,9 @@ function phpbrew
                 set NEW_PHPBREW_PHP_PATH "$PHPBREW_ROOT/php/$_PHP_VERSION"
                 if [ -d $NEW_PHPBREW_PHP_PATH ]
                     if [ $BIN = "phpbrew" ]
-                        set code (command phpbrew env $_PHP_VERSION | tr '\n' ';')
+                        set code (command phpbrew env $_PHP_VERSION | grep -v '^#' | tr '\n' ';')
                     else
-                        set code (eval $BIN env $_PHP_VERSION | tr '\n' ';')
+                        set code (eval $BIN env $_PHP_VERSION | grep -v '^#' | tr '\n' ';')
                     end
                     if [ -z "$code" ]
                         set exit_status 1


### PR DESCRIPTION
error message

    [: Expected a combining operator like '-a' at index 1”

in fish `set code (phpbrew env xxx)` set $code as an array instead of
multiline text (see fish-shell/fish-shell#159)

thus `eval $code` become
```
eval "export A=B export C=D"
```

instead of
```
eval "export A=B\
  export C=D"
```

(another problem is the export polyfill function is not robust)

this commit fix that replacing newline with semicol, makes $code a
valid one-liner
```
eval "export A=B;export C=D"
```

also set the exit status (`__phpbrew_set_path ` somehow return nonzero
status)