### PR TITLE
phpbrew fpm {start|stop} fails on PHP 7.2.0-dev

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -217,7 +217,7 @@ function phpbrew ()
             function fpm_start()
             {
               echo "Starting php-fpm..."
-              local regex="^php-[57]\.2.*"
+              local regex="^php-5\.2.*"
 
               if [[ ${_PHP_VERSION} =~ ${regex} ]]; then
                 ${PHPFPM_BIN} start
@@ -234,7 +234,7 @@ function phpbrew ()
             }
             function fpm_stop()
             {
-              local regex="^php-[57]\.2.*"
+              local regex="^php-5\.2.*"
 
               if [[ ${PHPBREW_PHP} =~ ${regex} ]]; then
                 ${PHPFPM_BIN} stop


### PR DESCRIPTION
Steps to reproduce:
1. Install PHP 7.2.0-dev with FPM support: 
   ```
   phpbrew install github:php/php-src@master as php-7.2.0 +default +fpm
   ```
2. Start the FPM service:
   ```
   phpbrew fpm start
   ```

Expected behavior: the service starts.

Actual behavior:
```
Starting php-fpm...
Usage: php-fpm [-n] [-e] [-h] [-i] [-m] [-v] [-t] [-p <prefix>] [-g <pid>] [-c <file>] [-d foo[=bar]] [-y <file>] [-D] [-F [-O]]
  -c <path>|<file> Look for php.ini file in this directory
  -n               No php.ini file will be used
  -d foo[=bar]     Define INI entry foo with value 'bar'
  -e               Generate extended information for debugger/profiler
  -h               This help
  -i               PHP information
  -m               Show compiled in modules
  -v               Version number
  -p, --prefix <dir>
                   Specify alternative prefix path to FastCGI process manager (default: /home/morozov/.phpbrew/php/php-7.2).
  -g, --pid <file>
                   Specify the PID file location.
  -y, --fpm-config <file>
                   Specify alternative path to FastCGI process manager config file.
  -t, --test       Test FPM configuration and exit
  -D, --daemonize  force to run in background, and ignore daemonize option from config file
  -F, --nodaemonize
                   force to stay in foreground, and ignore daemonize option from config file
  -O, --force-stderr
                   force output to stderr in nodaemonize even if stderr is not a TTY
  -R, --allow-to-run-as-root
                   Allow pool to run as root (disabled by default)
php-fpm start failed.
```