### PR TITLE
Removed the warning when installing extensions for PHP 7

### DIFF
--- a/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
@@ -90,19 +90,6 @@ class InstallCommand extends BaseCommand
 
     public function execute($extName, $version = 'stable')
     {
-        if (version_compare(PHP_VERSION, '7.0.0') > 0) {
-            $this->logger->warn(
-"Warning: Some extension won't be able to be built with php7. If the extension
-supports php7 in another branch or new major version, you will need to specify
-the branch name or version name explicitly.
-
-For example, to install memcached extension for php7, use:
-
-    phpbrew ext install github:php-memcached-dev/php-memcached php7 -- --disable-memcached-sasl
-"
-            );
-        }
-
         if (strtolower($extName) === 'apc' && version_compare(PHP_VERSION, '5.6.0') > 0) {
             $this->logger->warn('apc is not compatible with php 5.6+ versions, install apcu instead.');
         }


### PR DESCRIPTION
While [PHP 5.6 only receives security updates](http://php.net/supported-versions.php) and [PHP 7 overall now represents over 50%](https://seld.be/notes/php-versions-stats-2017-1-edition) of installations, the warning in the question seems no more relevant.