### PR TITLE
Fix installing extension from GitHub

### DIFF
--- a/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
@@ -51,7 +51,7 @@ class InstallCommand extends BaseCommand
 
     protected function getExtConfig($args)
     {
-        $version = 'stable';
+        $version = null;
         $options = array();
 
         if (count($args) > 0) {


### PR DESCRIPTION
Currently, it's impossible to install an extension from GitHub without explicitly specifying the version:
```
$ phpbrew ext install github:nikic/php-ast.git

Downloading https://github.com/nikic/php-ast/archive/stable.tar.gz via curl extension
Redirecting to https://codeload.github.com/nikic/php-ast/tar.gz/stable
PHP Fatal error:  Uncaught CurlKit\CurlException: The requested URL returned error: 404 Not Found at [https://codeload.github.com/nikic/php-ast/tar.gz/stable:The requested URL returned error: 404 Not Found] in vendor/corneltek/curlkit/src/CurlKit/CurlDownloader.php:153
```
The generated URL (https://codeload.github.com/nikic/php-ast/tar.gz/stable) is incorrect, it should be https://codeload.github.com/nikic/php-ast/tar.gz/master.

The default extension configuration should not contain provider-specific details.