### PR TITLE
Reimplemented the each command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 CHANGES
 =======
 
+### Version 1.23.0
+- Changed the semantics of the `each` command (#888). Prior to this release, the arguments were interpreted as internal PHPBrew command (e.g. `phpbrew each install xdebug` would install the Xdebug extensions on all available builds). As of this release, the command is interpreted as a shell command, i.e. the previously mentioned command will now look like `phpbrew each phpbrew ext install xdebug`. This change opens the possibility to run shell commands like `phpbrew each phpunit` and internal PHPBrew commands implemented in shell like `phpbrew each phpbrew fpm restart`.
+
 ### Version 1.22.7
 - Updated App store (#850)
 - Improved warning messages about environment check
@@ -11,7 +14,6 @@ CHANGES
 - Fixed --cache-file option escape
 - Improved user experience (#798, #792)
 
-
 ### Version 1.22.6
 - Fixed .phpbrew lookup in parent directories (#775)
 - Improved MySQL socket path detection on Ubuntu
@@ -20,7 +22,7 @@ CHANGES
 - Improved user experience (#799, #807)
 
 ### Version 1.22.5
-- Fixed downloading historic version from museum (#769) 
+- Fixed downloading historic version from museum (#769)
 - Fixed wget downloader failure when some special chars presents
 
 ### Version 1.22.4
@@ -40,7 +42,7 @@ CHANGES
 
 ### Version 1.22.1
 
-- The install command now patches the default listen path defined in php-fpm/www.conf 
+- The install command now patches the default listen path defined in php-fpm/www.conf
   for each different build.
 
 - Fixed pgsql base dir finder
@@ -52,7 +54,7 @@ CHANGES
 
     To setup systemctl service config for the current php:
 
-        phpbrew fpm setup --systemctl 
+        phpbrew fpm setup --systemctl
 
     To setup launchctl service config for the current php:
 
@@ -130,7 +132,7 @@ Bash
 
 ### Version 1.21.0 - Wed Apr 27 23:19:33 2016
 
-- Refactored patch classes 
+- Refactored patch classes
 - Supported new diff-based patches and regexp-based patches
 - Added some default options for 5.3, 5.4, 5.5 and 5.6 separately
 - Added BeforeConfigureTask and AfterConfigureTask to separate build phases.
@@ -347,7 +349,7 @@ Development updates:
         +gd=shared should work for Mac OS platform
 
 
-- platform libdir is supported, now supports for include/lib paths under 
+- platform libdir is supported, now supports for include/lib paths under
 
         $prefix/i386-linux-gnu/
         $prefix/x86_64-linux-gnu/

--- a/shell/bashrc
+++ b/shell/bashrc
@@ -203,6 +203,11 @@ function phpbrew ()
             builtin cd $chdir
             return 0
             ;;
+        each)
+            shift
+            __phpbrew_each "$@"
+            exit_status=$?
+            ;;
         fpm)
             if ! [[ -z $3 ]]; then
               _PHP_VERSION=$3
@@ -319,7 +324,6 @@ function phpbrew ()
             unset PHPBREW_PATH
             eval `$BIN env`
             __phpbrew_set_path
-            echo "phpbrew is turned off."
             ;;
         switch-off)
             unset PHPBREW_PHP
@@ -379,6 +383,28 @@ function __phpbrew_reinit ()
     fi
     __phpbrew_update_config $_PHP_VERSION
     __phpbrew_set_path
+}
+
+function __phpbrew_each()
+{
+    local result=0
+
+    current="$PHPBREW_PHP"
+    for build in ${PHPBREW_ROOT}/php/* ; do
+        if [ -x "$build/bin/php" ]; then
+            phpbrew use $(basename "$build")
+            eval "$@" || result=$?
+        fi
+    done;
+
+    if ! [[ -z "$current" ]]
+        then
+            phpbrew use $current
+        else
+            phpbrew off
+    fi
+
+    return $result
 }
 
 function __phpbrew_purge()

--- a/src/PhpBrew/Command/EachCommand.php
+++ b/src/PhpBrew/Command/EachCommand.php
@@ -2,72 +2,10 @@
 
 namespace PhpBrew\Command;
 
-use PhpBrew\Config;
-use PhpBrew\PhpBrew;
-use Exception;
-
-class EachCommand extends \CLIFramework\Command
+class EachCommand extends VirtualCommand
 {
     public function brief()
     {
-        return 'Iterate and run a given command over all php versions managed by PHPBrew.';
-    }
-
-    public function options($options)
-    {
-        $options->add('d|debug', 'Show debug information');
-        $options->add('y|assumeyes', 'now confirmation');
-    }
-
-    public function execute($command)
-    {
-        $command = trim($command);
-
-        if (empty($command)) {
-            throw new \Exception('Empty command supplied.');
-        }
-        $this->prompt($command);
-        $this->runCommandRecursive($command);
-    }
-
-    protected function prompt($command)
-    {
-        if ($this->options->assumeyes) {
-            return;
-        }
-        $versions = $this->getVersions();
-        $versionlist = implode(', ', $versions);
-        echo $this->formatter->format('Run ', 'transparent');
-        echo $this->formatter->format($command, 'yellow');
-        echo $this->formatter->format(' for php-', 'transparent');
-        echo $this->formatter->format("[{$versionlist}]", 'green');
-        echo $this->formatter->format('. Proceed? [', 'transparent');
-        echo $this->formatter->format('Yes/no', 'green');
-        echo $this->formatter->format(']> ', 'transparent');
-        $response = fgetc(fopen('php://stdin', 'r'));
-        if (preg_match('/n|o/i', $response)) {
-            throw new \Exception('Aborted.');
-        }
-    }
-
-    protected function runCommandRecursive($command)
-    {
-        $phpbrew = new PhpBrew();
-        foreach ($this->getVersions() as $version) {
-            $this->logger->info($this->formatter->format("Running `{$command}` for php-{$version}:", 'bold'));
-            $output = trim($phpbrew->run(preg_split('#\s+#', $command), $version, true));
-            if (!empty($output)) {
-                $this->logger->info($output);
-            }
-        }
-    }
-
-    protected function getVersions()
-    {
-        $versions = Config::getInstalledPhpVersions();
-
-        return array_map(function ($version) {
-            return str_replace('php-', '', $version);
-        }, $versions);
+        return 'Iterate and run a given shell command over all php versions managed by PHPBrew.';
     }
 }


### PR DESCRIPTION
Currently, the `each` command only allows running only a subset PhpBrew commands (see #559, #800). It's reimplemented on the shell level to support running shell commands instead. 