### PR TITLE
fix: Inverted condition for option http-proxy-auth

### DIFF
--- a/src/PhpBrew/Downloader/WgetCommandDownloader.php
+++ b/src/PhpBrew/Downloader/WgetCommandDownloader.php
@@ -33,9 +33,9 @@ class WgetCommandDownloader extends BaseDownloader
         $proxy = '';
         if (!empty($this->options->{'http-proxy'})) {
             if (!empty($this->options->{'http-proxy-auth'})) {
-                $proxy = sprintf('-e use_proxy=on -e http_proxy=%s', $this->options->{'http-proxy'});
-            } else {
                 $proxy = sprintf('-e use_proxy=on -e http_proxy=%s@%s', $this->options->{'http-proxy-auth'}, $this->options->{'http-proxy'});
+            } else {
+                $proxy = sprintf('-e use_proxy=on -e http_proxy=%s', $this->options->{'http-proxy'});
             }
         }
 


### PR DESCRIPTION
The condition was inverted.
When no http-proxy-auth was given, the wget was using authentication which resulted in broken http_proxy option such as:
-e http_proxy=@http://my.proxy:8080