### PR TITLE
Use bundled GD if no prefix provided

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -421,6 +421,8 @@ class VariantBuilder
                         echo "homebrew prefix '$output' doesn't exist. you forgot to install?\n";
                     }
                 }
+            } else {
+                $opts[] = '--with-gd=shared';
             }
 
             $opts[] = '--enable-gd-native-ttf';


### PR DESCRIPTION
When building PHP `+gd` without the prefix specified, the `gd` extension is not built:
```
$ phpbrew --debug install --dryrun 7.1.9 as test-gd1 +neutral +gd

--------8<--------

./configure \
    '--cache-file=/home/morozov/.phpbrew/cache/config.cache' \
    '--prefix=/home/morozov/.phpbrew/php/test' \
    '--with-config-file-path=/home/morozov/.phpbrew/php/test/etc' \
    '--with-config-file-scan-dir=/home/morozov/.phpbrew/php/test/var/db' \
    '--with-libdir=lib/x86_64-linux-gnu' \
    '--enable-gd-native-ttf' \
    '--with-jpeg-dir=/usr' \
    '--with-png-dir=/usr' \
    '--with-freetype-dir=/usr' \
    '--enable-dom' \
    '--enable-libxml' \
    '--enable-simplexml' \
    '--enable-xml' \
    '--enable-xmlreader' \
    '--enable-xmlwriter' \
    '--with-xsl' \
    '--with-libxml-dir=/usr' \
    '--enable-opcache' \
    '--with-pear=/home/morozov/.phpbrew/php/test/lib/php' \
    >> \
    /home/morozov/.phpbrew/build/test/build.log \
    2>&1
```
As you can see, there's no `--with-gd` switch in the `./configure` command.

Given that PHPBrew automatically prepends `shared` to the automatically discovered prefixes, it should fall back to `--with-gd=shared` by default.