### PR TITLE
Moved --with-pear to the pear variant

### DIFF
--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -47,7 +47,7 @@ class Build implements Serializable, Buildable
     public $phpEnvironment = self::ENV_DEVELOPMENT;
 
     /**
-     * @var PhpBrew\BuildSettings
+     * @var BuildSettings
      */
     public $settings;
 

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -60,9 +60,6 @@ class ConfigureTask extends BaseTask
         $this->debug('Enabled variants: ['.implode(', ', array_keys($build->getVariants())).']');
         $this->debug('Disabled variants: ['.implode(', ', array_keys($build->getDisabledVariants())).']');
 
-        // todo: move to pear variant
-        $args[] = "--with-pear={$prefix}/lib/php";
-
         // Options for specific versions
         // todo: extract to BuildPlan class: PHP53 BuildPlan, PHP54 BuildPlan, PHP55 BuildPlan ?
         if ($build->compareVersion('5.4') == -1) {

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -140,6 +140,7 @@ class VariantBuilder
             'pcntl',
             'pcre',
             'pdo',
+            'pear',
             'phar',
             'posix',
             'readline',
@@ -866,6 +867,14 @@ class VariantBuilder
             }
 
             return '--with-gmp'; // let autotool to find it.
+        };
+
+        $this->variants['pear'] = function (Build $build, $prefix = null) {
+            if ($prefix === null) {
+                $prefix = $build->getInstallPrefix() . '/lib/php/pear';
+            }
+
+            return '--with-pear=' . $prefix;
         };
 
         // merge virtual variants with config file


### PR DESCRIPTION
Additionally, modified the default PEAR path from `$BUILD_DIR/lib/php` to `$BUILD_DIR/lib/php/pear` for cleaner directory layout.

The current layout looks a bit messy:
```
├── Archive
├── build
├── Console
├── data
├── doc
├── extensions
├── OS
├── PEAR
├── pearcmd.php
├── PEAR.php
├── peclcmd.php
├── Structures
├── System.php
├── test
└── XML
```
The _extensions_ and _build_ directory do not belong to PEAR but are mixed with its top-level packages. Moving PEAR into its own directory makes the layout cleaner:
```
├── build
├── extensions
└── pear
```
It also helps avoid potential conflicts between top-level PEAR packages and internal PHP resources.