### PR TITLE
Fixed cURL extension being silently dropped if dependencies not found

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -329,7 +329,7 @@ class VariantBuilder
                 }
             }
 
-            return;
+            return '--with-curl';
         };
 
         /*


### PR DESCRIPTION
Currently, if the variant builder cannot detect prefix for cURL, it silently drops the variant (note the absence of `--with-curl` in the resulting `./configure` command):
```
↪  phpbrew --debug install --dryrun 7.1.9 +neutral +curl

./configure \
  '--cache-file=/home/morozov/.phpbrew/cache/config.cache' \
  '--prefix=/home/morozov/.phpbrew/php/php-7.1.9' \
  '--with-config-file-path=/home/morozov/.phpbrew/php/php-7.1.9/etc' \
  '--with-config-file-scan-dir=/home/morozov/.phpbrew/php/php-7.1.9/var/db' \
  '--with-libdir=lib/x86_64-linux-gnu' \
  '--enable-dom' \
  '--enable-libxml' \
  '--enable-simplexml' \
  '--enable-xml' \
  '--enable-xmlreader' \
  '--enable-xmlwriter' \
  '--with-xsl' \
  '--with-libxml-dir=/usr' \
  '--enable-opcache' \
  >> /home/morozov/.phpbrew/build/php-7.1.9/build.log 2>&1
```
If dependencies are not found, the variant should be kept in place without the prefix to let `./configure` either found them itself or fail the build. Otherwise, the build passes but its configuration is different from expected which causes issues down the line.