### PR TITLE
PHP Notice: Undefined variable: output in .../VariantBuilder.php on line 243

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -240,7 +240,8 @@ class VariantBuilder
                     if (file_exists($prefix)) {
                         return array('--with-pcre-regex', "--with-pcre-dir=$prefix");
                     }
-                    echo "homebrew prefix '$output' doesn't exist. you forgot to install?\n";
+
+                    printf('Homebrew prefix "%s" doesn\'t exist' . PHP_EOL, $prefix);
                 }
             }
 


### PR DESCRIPTION
Fixes #919. Replaced `$output` with `$prefix`, use `printf()` for cleaner error message.