### PR TITLE
Removed the warning about rootless mode in macOS

### DIFF
--- a/src/PhpBrew/Console.php
+++ b/src/PhpBrew/Console.php
@@ -82,11 +82,6 @@ class Console extends Application
         if (!extension_loaded('ctype')) {
             $this->logger->warn('# WARNING: ctype extension might be required for parsing yaml file.');
         }
-
-        if (Utils::isRootlessEnabled()) {
-            $this->logger->warn('#WARNING: it seems you are running PHPBrew under MacOS 10.11 or above with rootless enabled. ' .
-                'it\'s recommended turn off rootless before your continue, or you may experience some issues.');
-        }
     }
 
     public function configure()

--- a/src/PhpBrew/Testing/CommandTestCase.php
+++ b/src/PhpBrew/Testing/CommandTestCase.php
@@ -76,16 +76,13 @@ abstract class CommandTestCase extends BaseCommandTestCase
             if ($this->debug) {
                 fwrite(STDERR, $args.PHP_EOL);
             }
+
             ob_start();
-            $this->assertTrue($ret = parent::runCommand($args));
+            $ret = parent::runCommand($args);
             $output = ob_get_contents();
             ob_end_clean();
-            if ($ret === false) {
-                echo '[' , implode(' ', $args), ']', PHP_EOL;
-                echo '===================================', PHP_EOL;
-                echo $output, PHP_EOL;
-                echo '===================================', PHP_EOL;
-            }
+
+            $this->assertTrue($ret, $output);
         } catch (\CurlKit\CurlException $e) {
             $this->markTestIncomplete($e->getMessage());
         }

--- a/src/PhpBrew/Utils.php
+++ b/src/PhpBrew/Utils.php
@@ -376,12 +376,4 @@ class Utils
         $editor = escapeshellarg(getenv('EDITOR') ?: 'nano');
         exec("{$editor} {$file} > {$tty}");
     }
-
-    public static function isRootlessEnabled()
-    {
-        return PlatformInfo::getInstance()->isMac() &&
-            !is_writeable('/bin');
-        // following directories are restricted if rootless enabled (osX 10.11+):
-        // /System, /bin, /sbin, /usr (except /usr/bin)
-    }
 }


### PR DESCRIPTION
According to #824, the issue happens outside of PHPBrew and is by design. PHPBrew itself doesn't try to change anything in protected directories.

According to comments in #879, the warning may be confusing since it's displayed for every command and therefore can be misinterpreted as the cause of any issue.

Fixes #879.