### PR TITLE
Fail on invalid argument

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "76b751b677d00bd18ab19d85dfeb3430",
+    "content-hash": "c93584446e4c365f4a42a5924ffd3b1d",
     "packages": [
         {
             "name": "corneltek/cachekit",
@@ -93,16 +93,16 @@
         },
         {
             "name": "corneltek/cliframework",
-            "version": "dev-master",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/CLIFramework.git",
-                "reference": "df9139a84c8aee2cd6952632c31bdfab4855f22f"
+                "reference": "5a902ba54cb19e944bbf14eb1c8522c921e3217e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/CLIFramework/zipball/df9139a84c8aee2cd6952632c31bdfab4855f22f",
-                "reference": "df9139a84c8aee2cd6952632c31bdfab4855f22f",
+                "url": "https://api.github.com/repos/c9s/CLIFramework/zipball/5a902ba54cb19e944bbf14eb1c8522c921e3217e",
+                "reference": "5a902ba54cb19e944bbf14eb1c8522c921e3217e",
                 "shasum": ""
             },
             "require": {
@@ -117,6 +117,7 @@
             },
             "require-dev": {
                 "corneltek/phpunit-testmore": "dev-master",
+                "phpunit/phpunit": "^5.7",
                 "satooshi/php-coveralls": "^1"
             },
             "type": "library",
@@ -151,7 +152,7 @@
                 "getopt",
                 "zsh"
             ],
-            "time": "2016-03-18T13:55:38+00:00"
+            "time": "2017-11-08T01:09:58+00:00"
         },
         {
             "name": "corneltek/codegen",

--- a/src/PhpBrew/Command/UseCommand.php
+++ b/src/PhpBrew/Command/UseCommand.php
@@ -2,21 +2,18 @@
 
 namespace PhpBrew\Command;
 
-use CLIFramework\Command;
-use PhpBrew\Config;
 use PhpBrew\BuildFinder;
-use Exception;
 
 /**
  * @codeCoverageIgnore
  */
-class UseCommand extends Command
+class UseCommand extends VirtualCommand
 {
     public function arguments($args)
     {
         $args->add('php version')
             ->validValues(function () {
-                return \PhpBrew\BuildFinder::findInstalledBuilds();
+                return BuildFinder::findInstalledBuilds();
             })
             ;
     }
@@ -24,28 +21,5 @@ class UseCommand extends Command
     public function brief()
     {
         return 'Use php, switch version temporarily';
-    }
-
-    public function execute($buildName)
-    {
-        if (!$buildName) {
-            // This exception is used for tracing tests
-            throw new \Exception('build name is required.');
-        }
-        { // this block is important for tests only
-            $root = Config::getRoot();
-            $home = Config::getHome();
-            if (!file_exists("$root/php/$buildName")) {
-                throw new \Exception("build $buildName doesn't exist.");
-            }
-            putenv("PHPBREW_ROOT=$root");
-            putenv("PHPBREW_HOME=$home");
-            putenv("PHPBREW_PHP=$buildName") or die('putenv failed');
-            putenv("PHPBREW_PATH=$root/php/$buildName/bin");
-            putenv("PHPBREW_BIN=$home/bin");
-        }
-        if (!getenv('TRAVIS')) {
-            $this->logger->warning("You should not see this, if you see this, it means you didn't load the ~/.phpbrew/bashrc script, please check if bashrc is sourced in your shell.");
-        }
     }
 }

--- a/src/PhpBrew/Config.php
+++ b/src/PhpBrew/Config.php
@@ -139,9 +139,9 @@ class Config
         return self::getRoot().DIRECTORY_SEPARATOR.'php';
     }
 
-    public static function getVersionInstallPrefix($version)
+    public static function getVersionInstallPrefix($buildName)
     {
-        return self::getInstallPrefix().DIRECTORY_SEPARATOR.$version;
+        return self::getInstallPrefix().DIRECTORY_SEPARATOR.$buildName;
     }
 
     /**

--- a/tests/PhpBrew/Command/InstallCommandTest.php
+++ b/tests/PhpBrew/Command/InstallCommandTest.php
@@ -43,10 +43,10 @@ class InstallCommandTest extends CommandTestCase
     /**
      * @depends testInstallCommand
      */
-    public function testUseCommand()
+    public function testEnvCommand()
     {
         $versionName = $this->getPrimaryVersion();
-        $this->assertCommandSuccess("phpbrew use php-{$versionName}");
+        $this->assertCommandSuccess("phpbrew env php-{$versionName}");
     }
 
     /**


### PR DESCRIPTION
Prior to fixing c9s/CLIFramework#106, even if the command argument was invalid, it didn't cause the command to fail. After having this fixed, `InstallCommandTest::testUseCommand()` started failing. The `UseCommand` declared that it expected a non-prefixed with php- version name while it expected the build name instead. It's fine since it only provides completion info but not the implementation.

The `testUseCommand()` is reworked to `testEnvCommand()` because this is what gets invoked from the shell wrapper when a user types `phpbrew use`.

Fixes #822.