### PR TITLE
Fixing throw of RuntimeException in BaseDownloader

### DIFF
--- a/src/PhpBrew/Downloader/BaseDownloader.php
+++ b/src/PhpBrew/Downloader/BaseDownloader.php
@@ -36,7 +36,7 @@ abstract class BaseDownloader
         if (empty($targetFilePath)) {
             $targetFilePath = tempnam(sys_get_temp_dir(), 'phpbrew_');
             if ($targetFilePath === false) {
-                throw new RuntimeException('Fail to create temp file');
+                throw new \RuntimeException('Fail to create temp file');
             }
         } else {
             if (!file_exists($targetFilePath)) {


### PR DESCRIPTION
One of the thrown exceptions inside the "download" function was being referenced wrongly.