### PR TITLE
Removed the mcrypt extension from the default variant

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -136,7 +136,6 @@ class VariantBuilder
             'mbregex',
             'mbstring',
             'mhash',
-            'mcrypt',
             'pcntl',
             'pcre',
             'pdo',


### PR DESCRIPTION
An attempt to `phpbrew install 7.2.2 +default` produces:
```
configure: WARNING: unrecognized options: --with-mcrypt
```

The `mcrypt` extension has been deprecated in PHP 7.1 and removed in PHP 7.2. We could add some conditional logic to detect if `mcrypt` is available in the PHP version being built and still enable it by default if it's available, but I believe it's better to just remove it from the default variant.