### PR TITLE
Made --enable-gd-native-ttf conditional depending on the PHP version

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -427,7 +427,9 @@ class VariantBuilder
                 $opts[] = '--with-gd=shared';
             }
 
-            $opts[] = '--enable-gd-native-ttf';
+            if ($build->compareVersion('5.5') < 0) {
+                $opts[] = '--enable-gd-native-ttf';
+            }
 
             if ($prefix = Utils::findIncludePrefix('jpeglib.h')) {
                 $opts[] = "--with-jpeg-dir=$prefix";


### PR DESCRIPTION
An attempt to `phpbrew install 7.2.2 +gd` produces:
```
configure: WARNING: unrecognized options: --enable-gd-native-ttf
```

According to the [manual](http://php.net/manual/en/image.installation.php), the `--enable-gd-native-ttf` switch is effectless as of PHP 5.5.0 and removed as of PHP 7.2.0.