### PR TITLE
Use zsh chpwd hooks to look for .phpbrewrc instead of trap call

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -515,6 +515,20 @@ function _phpbrewrc_load ()
     PHPBREW_LAST_DIR="$PWD"
 }
 
-if [[ (-n "$BASH_VERSION" || -n "$ZSH_VERSION") && -n "$PHPBREW_RC_ENABLE" ]]; then
-    trap "_phpbrewrc_load" DEBUG
+if [[ -n "$PHPBREW_RC_ENABLE" ]]; then
+    if [[ -n "$BASH_VERSION" ]]; then
+        trap "_phpbrewrc_load" DEBUG
+    fi
+
+    # zsh has easy-to-extend cd hooks, so we migth as well use them instead
+    # of running _phpbrewrc_load after EVERY command.
+    if [[ -n "$ZSH_VERSION" ]]; then
+        if [[ -n "$chpwd_functions" ]]; then
+            if [[ ${chpwd_functions[(ie)_phpbrewrc_load]} -gt ${#chpwd_functions} ]]; then
+                chpwd_functions+=_phpbrewrc_load
+            fi
+        else
+            chpwd_functions=( _phpbrewrc_load )
+        fi
+    fi
 fi


### PR DESCRIPTION
If `PHPBREW_RC_ENABLE` is set, we look for `.phpbrewrc` after **EVERY** command, even though we only need to look for it _when the current directory changes_. That `trap` call may be needed in bash, but zsh provides a hook mechanism for various shell events, including changing directory.

This PR makes use of that hook mechanism to look for .`phpbrewrc` **ONLY** when the current directory changes. This affects only zsh users.

#### Pros of this approach:

- Looks for `.phpbrewrc` **ONLY** when changing directories, instead of after **EVERY** command.
- Plays nice with other tools who might have included their own functions in the same `cd` hook.
- Integrates more seamlessly into a zsh ecosystem.

#### Cons of this approach:

- Benefits only zsh users (at least for now).

You can check http://zsh.sourceforge.net/Doc/Release/Functions.html#Hook-Functions for more info on zsh hooks.