### PR TITLE
Add 'php-cs-fixer' to the AppStore

### DIFF
--- a/completion/bash/_phpbrew
+++ b/completion/bash/_phpbrew
@@ -1205,7 +1205,8 @@ phpcov
 phpcpd
 phpdcd
 phptok
-phploc" -- $cur) )
+phploc
+php-cs-fixer" -- $cur) )
       return
       ;;
   esac

--- a/completion/zsh/_phpbrew
+++ b/completion/zsh/_phpbrew
@@ -194,7 +194,7 @@ local ret=1
                           '--http-proxy=[HTTP proxy address]' \
                           '--http-proxy-auth=[HTTP proxy authentication]' \
                           '--connect-timeout=[Connection timeout]' \
-                          ':app-name:("composer" "phpunit" "phpmd" "behat-2.5" "behat-3.3" "sami" "phpcs" "phpcbf" "pdepend" "onion" "box-2.7" "psysh" "phpdoc" "phpcov" "phpcpd" "phpdcd" "phptok" "phploc")' \
+                          ':app-name:("composer" "phpunit" "phpmd" "behat-2.5" "behat-3.3" "sami" "phpcs" "phpcbf" "pdepend" "onion" "box-2.7" "psysh" "phpdoc" "phpcov" "phpcpd" "phpdcd" "phptok" "phploc" "php-cs-fixer")' \
                            && ret=0
                   
                   ;;

--- a/src/PhpBrew/AppStore.php
+++ b/src/PhpBrew/AppStore.php
@@ -31,7 +31,11 @@ class AppStore
                 'as' => 'box',
             ),
             'psysh'     => array('url' => 'https://psysh.org/psysh', 'as' => 'psysh'),
-            'phpdoc'    => array('url' => 'http://www.phpdoc.org/phpDocumentor.phar', 'as' => 'phpdoc')
+            'php-cs-fixer' => array(
+                'url' => 'https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar',
+                'as' => 'php-cs-fixer',
+            ),
+            'phpdoc'    => array('url' => 'http://www.phpdoc.org/phpDocumentor.phar', 'as' => 'phpdoc'),
         );
         $phpunitapps = explode(' ', 'phpunit phpcov phpcpd phpdcd phptok phploc');
         foreach ($phpunitapps as $phpunitapp) {


### PR DESCRIPTION
[The PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) (PHP CS Fixer) tool fixes your code to follow standards; whether you want to follow PHP coding standards as defined in the PSR-1, PSR-2, etc., or other community driven ones like the Symfony one. You can also define your (teams) style through configuration.