### PR TITLE
Do not pass --with-pcre-dir to PHP 7.4

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -228,6 +228,10 @@ class VariantBuilder
         };
 
         $this->variants['pcre'] = function (Build $build, $prefix = null) {
+            if ($build->compareVersion('7.4') >= 0) {
+                return array();
+            }
+
             if ($prefix) {
                 return array('--with-pcre-regex', "--with-pcre-dir=$prefix");
             }
@@ -1087,8 +1091,11 @@ class VariantBuilder
                 '--enable-session',
                 '--enable-short-tags',
                 '--enable-tokenizer',
-                '--with-pcre-regex',
             );
+
+            if ($build->compareVersion('7.4') < 0) {
+                $this->addOptions('--with-pcre-regex');
+            }
 
             if ($prefix = Utils::findIncludePrefix('zlib.h')) {
                 $this->addOptions('--with-zlib='.$prefix);


### PR DESCRIPTION
Unlike `--with-pcre-dir`, `--with-external-pcre` does not accept a prefix and if enabled, will rely on `pkg-config` internally. If a user wants to build the extension with an external library, they will have to specify `--with-external-pcre`. There's nothing PHPBrew can do in this case.

Fixes #1022.