### PR TITLE
Use --enable-gd instead of --with-gd for PHP 7.4

### DIFF
--- a/src/PhpBrew/PrefixFinder.php
+++ b/src/PhpBrew/PrefixFinder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpBrew;
+
+/**
+ * A strategy of finding prefix
+ */
+interface PrefixFinder
+{
+    /**
+     * Returns the found prefix or NULL of it's not found.
+     *
+     * @return string|null
+     */
+    public function findPrefix();
+}

--- a/src/PhpBrew/PrefixFinder/BrewPrefixFinder.php
+++ b/src/PhpBrew/PrefixFinder/BrewPrefixFinder.php
@@ -2,40 +2,68 @@
 
 namespace PhpBrew\PrefixFinder;
 
+use PhpBrew\PrefixFinder;
 use PhpBrew\Utils;
 
-class BrewPrefixFinder
+/**
+ * The strategy of finding prefix using Homebrew.
+ */
+final class BrewPrefixFinder implements PrefixFinder
 {
-    public function __construct()
+    /**
+     * @var string
+     */
+    private $formula;
+
+    /**
+     * @param string $formula Homebrew formula
+     */
+    public function __construct($formula)
     {
-        $this->bin = Utils::findBin('brew');
+        $this->formula = $formula;
     }
 
-    public function find($formula, &$reason = null)
+    /**
+     * {@inheritDoc}
+     */
+    public function findPrefix()
     {
-        if ($prefix = $this->execLine("{$this->bin} --prefix {$formula}")) {
-            if (file_exists($prefix)) {
-                return $prefix;
-            }
-            $reason = "$prefix doesn't exist.";
+        $brew = Utils::findBin('brew');
 
-            return false;
+        if ($brew === null) {
+            return null;
         }
-        $reason = "hombrew formula {$formula} not found.";
 
-        return false;
+        $output = $this->execLine(
+            sprintf('%s --prefix %s', escapeshellcmd($brew), escapeshellarg($this->formula))
+        );
+
+        if ($output === null) {
+            printf('Homebrew formula "%s" not found.' . PHP_EOL, $this->formula);
+
+            return null;
+        }
+
+        if (!file_exists($output)) {
+            printf('Homebrew prefix "%s" does not exist.' . PHP_EOL, $output);
+
+            return null;
+        }
+
+        return $output;
     }
 
-    protected function execLine($command)
+    private function execLine($command)
     {
         $output = array();
         exec($command, $output, $retval);
+
         if ($retval === 0) {
             $output = array_filter($output);
 
             return end($output);
         }
 
-        return false;
+        return null;
     }
 }

--- a/src/PhpBrew/PrefixFinder/IncludePrefixFinder.php
+++ b/src/PhpBrew/PrefixFinder/IncludePrefixFinder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PhpBrew\PrefixFinder;
+
+use PhpBrew\PrefixFinder;
+use PhpBrew\Utils;
+
+/**
+ * The strategy of finding prefix using include paths.
+ */
+final class IncludePrefixFinder implements PrefixFinder
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @param string $path
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findPrefix()
+    {
+        return Utils::findIncludePrefix($this->path);
+    }
+}

--- a/src/PhpBrew/Utils.php
+++ b/src/PhpBrew/Utils.php
@@ -263,7 +263,7 @@ class Utils
      *
      * @param string $bin binary name
      *
-     * @return string the path
+     * @return string|null The path or NULL if the path does not exist
      */
     public static function findBin($bin)
     {
@@ -279,7 +279,26 @@ class Utils
             }
         }
 
-        return;
+        return null;
+    }
+
+    /**
+     * Finds prefix using the given finders.
+     *
+     * @param  PrefixFinder[] $prefixFinders
+     * @return string|null
+     */
+    public static function findPrefix(array $prefixFinders)
+    {
+        foreach ($prefixFinders as $prefixFinder) {
+            $prefix = $prefixFinder->findPrefix();
+
+            if ($prefix !== null) {
+                return $prefix;
+            }
+        }
+
+        return null;
     }
 
     public static function pipeExecute($command)


### PR DESCRIPTION
Additionally, introduced the Include and Brew prefix finders to reduce the amount of boilerplate code.

Fixes #1020.