### PR TITLE
Switched to Bitbucket API v2.0 since v1.0 is no longer supported

### DIFF
--- a/src/PhpBrew/Extension/Provider/BitbucketProvider.php
+++ b/src/PhpBrew/Extension/Provider/BitbucketProvider.php
@@ -73,7 +73,11 @@ class BitbucketProvider implements Provider
 
     public function buildKnownReleasesUrl()
     {
-        return sprintf('https://bitbucket.org/api/1.0/repositories/%s/%s/tags/', $this->getOwner(), $this->getRepository());
+        return sprintf(
+            'https://bitbucket.org/api/2.0/repositories/%s/%s/refs/tags',
+            rawurlencode($this->getOwner()),
+            rawurlencode($this->getRepository())
+        );
     }
 
     public function parseKnownReleasesResponse($content)


### PR DESCRIPTION
This is supposed to fix build failures like [#552268742](https://travis-ci.org/phpbrew/phpbrew/jobs/552268742#L478).