### PR TITLE
Do not pass --with-icu-dir to PHP 7.4

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -509,6 +509,10 @@ class VariantBuilder
         $this->variants['intl'] = function (Build $build) {
             $opts = array('--enable-intl');
 
+            if ($build->compareVersion('7.4') >= 0) {
+                return $opts;
+            }
+
             // If icu variant is not set, and --with-icu-dir could not been found in the extra options
             $icuOption = $build->settings->grepExtraOptionsByPattern('#--with-icu-dir#');
             if (!$build->settings->isEnabledVariant('icu') || empty($icuOption)) {


### PR DESCRIPTION
PHP 7.4 no longer supports `--with-icu-dir` (https://github.com/php/php-src/pull/3701).