### PR TITLE
Allow empty argument to the `env` command.

### DIFF
--- a/src/PhpBrew/Command/EnvCommand.php
+++ b/src/PhpBrew/Command/EnvCommand.php
@@ -16,7 +16,7 @@ class EnvCommand extends \CLIFramework\Command
         $args->add('installed php')
             ->optional()
             ->validValues(function () {
-                return \PhpBrew\Config::getInstalledPhpVersions();
+                return array_merge(\PhpBrew\BuildFinder::findMatchedBuilds(), array(''));
             })
             ;
     }

--- a/tests/PhpBrew/Command/EnvCommandTest.php
+++ b/tests/PhpBrew/Command/EnvCommandTest.php
@@ -25,5 +25,11 @@ class EnvCommandTest extends CommandTestCase
         $this->assertCommandSuccess("phpbrew env");
     }
 
-
+    /**
+     * @outputBuffering enabled
+     */
+    public function testEnvCommandEmptyArg()
+    {
+        $this->assertCommandSuccess("phpbrew env ");
+    }
 }


### PR DESCRIPTION
It was causing 'Invalid argument' error on `switch-off` on fish shell.

On fish shell (v3.0.2) run `phpbrew switch-off`.
The output:
```
Invalid: command not found
~/.phpbrew/init (line 2): 
Invalid argument 
^
from sourcing file ~/.phpbrew/init
	called on line 699 of file ~/.phpbrew/phpbrew.fish

in function “__phpbrew_update_config”
	called on line 726 of file ~/.phpbrew/phpbrew.fish
	with parameter list “”

in function “__phpbrew_reinit”
	called on line 379 of file ~/.phpbrew/phpbrew.fish

in function “phpbrew”
	called on standard input
	with parameter list “switch-off”

phpbrew is switched off.
```
Contents of init file:
```
~ $ cat ~/.phpbrew/init 
# DO NOT EDIT THIS FILE
Invalid argument 
```
Apparently this is caused by fish command `command phpbrew env $VERSION` with empty $VERSION.
While we can trim it in `~/.phpbrew/phpbrew.fish` it's better to make validation less strict and allow empty string.

https://github.com/phpbrew/phpbrew/issues/926 may be related