### PR TITLE
Apply patch to PHP 5.6 for running with OpenSSL 0.11

### DIFF
--- a/src/PhpBrew/Patches/PHP56WithOpenSSL11Patch.php
+++ b/src/PhpBrew/Patches/PHP56WithOpenSSL11Patch.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PhpBrew\Patches;
+
+use PhpBrew\Buildable;
+use PhpBrew\PatchKit\Patch;
+use PhpBrew\PatchKit\DiffPatchRule;
+use CLIFramework\Logger;
+
+class PHP56WithOpenSSL11Patch extends Patch
+{
+    public function desc()
+    {
+        return 'php5.6 with openssl 1.1.x patch.';
+    }
+
+    public function match(Buildable $build, Logger $logger)
+    {
+        return version_compare($build->getVersion(), '5.6') === 0
+            && version_compare($build->getVersion(), '5.6.31') >= 0 // patch only works for 5.6.31 and up
+            && $build->isEnabledVariant('openssl');
+    }
+
+    public function rules()
+    {
+        $rules = array();
+        $rules[] = DiffPatchRule::from('https://patch-diff.githubusercontent.com/raw/php/php-src/pull/2667.patch')
+            ->strip(1)
+            ->sha256('507bb74b2612328cdf5e59b964645a49d0f9367add001ecd698e0fd0d4445421');
+
+        return $rules;
+    }
+}

--- a/src/PhpBrew/Tasks/AfterConfigureTask.php
+++ b/src/PhpBrew/Tasks/AfterConfigureTask.php
@@ -6,6 +6,7 @@ use PhpBrew\Build;
 use PhpBrew\Patches\IntlWith64bitPatch;
 use PhpBrew\Patches\OpenSSLDSOPatch;
 use PhpBrew\Patches\PHP53Patch;
+use PhpBrew\Patches\PHP56WithOpenSSL11Patch;
 
 /**
  * Task run before 'configure'.
@@ -25,6 +26,7 @@ class AfterConfigureTask extends BaseTask
             $patches[] = new PHP53Patch();
             $patches[] = new IntlWith64bitPatch();
             $patches[] = new OpenSSLDSOPatch();
+            $patches[] = new PHP56WithOpenSSL11Patch();
             foreach ($patches as $patch) {
                 $this->logger->info('Checking patch for ' . $patch->desc());
                 if ($patch->match($build, $this->logger)) {


### PR DESCRIPTION
The API of OpenSSL has changed from 0.10 to 0.11. This makes it difficult to run PHP 5 on an updated system. The patch is from https://github.com/php/php-src/pull/2667.

Note that the patch only works for PHP 5.6.31 or higher. While not ideal, being able to install the last (released) PHP5 version will be sufficient for most.