### PR TITLE
Fixed the switch subcommand exit status on Fish

### DIFF
--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -334,10 +334,9 @@ function __phpbrew_set_path
     if [ -z "$PHPBREW_PATH" ]
         set -gx PATH $PHPBREW_BIN $PATH_WITHOUT_PHPBREW
     else
-      #set -gx PATH $PHPBREW_PATH $PHPBREW_BIN $PATH_WITHOUT_PHPBREW
         set -gx PATH $PHPBREW_PATH $PHPBREW_BIN $PATH_WITHOUT_PHPBREW
+        return 0
     end
-    # echo "PATH => $PATH"
 end
 
 function __phpbrew_update_config


### PR DESCRIPTION
When switching PHP versions using Fish, `phpbrew switch` exits with a non-zero code even on success:
```
$ phpbrew list
  php-7.4.0RC2
* php-7.3.10

$ phpbrew switch 7.4.0RC2

$ echo $status
1

$ phpbrew list
* php-7.4.0RC2   
  php-7.3.10     

$ php -v
PHP 7.4.0RC2 (cli) (built: Sep 21 2019 15:26:11) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0-dev, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.0RC2, Copyright (c), by Zend Technologies
    with Xdebug v3.0.0-dev, Copyright (c) 2002-2019, by Derick Rethans
```