### PR TITLE
Patch ext/gd in PHP < 7.4 for compatibility with newer Debian distros

### DIFF
--- a/src/PhpBrew/Patches/FreeTypePatch.php
+++ b/src/PhpBrew/Patches/FreeTypePatch.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PhpBrew\Patches;
+
+use PhpBrew\Buildable;
+use PhpBrew\PatchKit\DiffPatchRule;
+use PhpBrew\PatchKit\Patch;
+use CLIFramework\Logger;
+
+/**
+ * As of recently, freetype-config has been removed in favor of pkg-config. It has been fixed in PHP 7.4beta1
+ * but the older PHP sources need to be patched in order to be able to compile them on newer Ubuntu/Debian
+ * distributions.
+ */
+class FreeTypePatch extends Patch
+{
+    public function desc()
+    {
+        return 'replace freetype-config with pkg-config on php older than 7.4';
+    }
+
+    public function match(Buildable $build, Logger $logger)
+    {
+        return $build->isEnabledVariant('gd') && version_compare($build->getVersion(), '7.4', '<=');
+    }
+
+    public function rules()
+    {
+        return array(
+            DiffPatchRule::from(
+                'https://git.archlinux.org/svntogit/packages.git/plain/trunk/freetype.patch?h=packages/php'
+            )
+                ->strip(1)
+                ->sha256('07c4648669dc05afc3c1ad5a4739768079c423b817eabf5296ca3d1ea5ffd163')
+        );
+    }
+}

--- a/src/PhpBrew/Tasks/BuildConfTask.php
+++ b/src/PhpBrew/Tasks/BuildConfTask.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PhpBrew\Tasks;
+
+use PhpBrew\Build;
+use PhpBrew\Exception\SystemCommandException;
+
+/**
+ * Task to run `./buildconf`.
+ */
+class BuildConfTask extends BaseTask
+{
+    public function run(Build $build)
+    {
+        $lastLine = system('./buildconf --force', $status);
+
+        if ($status !== 0) {
+            throw new SystemCommandException(
+                sprintf('buildconf error: %s', $lastLine),
+                $build
+            );
+        }
+    }
+}


### PR DESCRIPTION
1. Patch `ext/gd` with the [patch](https://git.archlinux.org/svntogit/packages.git/tree/trunk/freetype.patch?h=packages/php) from Arch Linux.
2. Extract `./buildconf --force` into a reusable component.

Fixes #1033.