### PR TITLE
Added PHP_CodeSniffer configuration with PSR-12 as the target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /build
 .onion
 .phpbrew
+.phpcs.cache
 tags
 /build/logs
 *.phar

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg value="ps"/>
+    <arg name="cache" value=".phpcs.cache"/>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <rule ref="PSR12">
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
+    </rule>
+
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>src/PhpBrew/Topic/*</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>src/PhpBrew/Utils.php</exclude-pattern>
+    </rule>
+</ruleset>

--- a/src/PhpBrew/AppStore.php
+++ b/src/PhpBrew/AppStore.php
@@ -10,14 +10,26 @@ class AppStore
             'composer' => array('url' => 'https://getcomposer.org/composer.phar', 'as' => 'composer'),
             'phpunit' => array('url' => 'https://phar.phpunit.de/phpunit.phar', 'as' => 'phpunit'),
             'phpmd' => array('url' => 'http://static.phpmd.org/php/latest/phpmd.phar', 'as' => 'phpmd'),
-            'behat-2.5' => array('url' => 'https://github.com/Behat/Behat/releases/download/v2.5.5/behat.phar', 'as' => 'behat'),
-            'behat-3.3' => array('url' => 'https://github.com/Behat/Behat/releases/download/v3.3.0/behat.phar', 'as' => 'behat'),
+            'behat-2.5' => array(
+                'url' => 'https://github.com/Behat/Behat/releases/download/v2.5.5/behat.phar',
+                'as' => 'behat',
+            ),
+            'behat-3.3' => array(
+                'url' => 'https://github.com/Behat/Behat/releases/download/v3.3.0/behat.phar',
+                'as' => 'behat',
+            ),
             'sami'      => array('url' => 'http://get.sensiolabs.org/sami.phar',                    'as' => 'sami'),
             'phpcs'     => array('url' => 'https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar', 'as' => 'phpcs'),
             'phpcbf'    => array('url' => 'https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar', 'as' => 'phpcbf'),
             'pdepend'   => array('url' => 'http://static.pdepend.org/php/latest/pdepend.phar',      'as' => 'pdepend'),
-            'onion'     => array('url' => 'https://raw.githubusercontent.com/phpbrew/Onion/master/onion', 'as' => 'onion'),
-            'box-2.7'   => array('url' => 'https://github.com/box-project/box2/releases/download/2.7.5/box-2.7.5.phar', 'as' => 'box'),
+            'onion'     => array(
+                'url' => 'https://raw.githubusercontent.com/phpbrew/Onion/master/onion',
+                'as' => 'onion',
+            ),
+            'box-2.7'   => array(
+                'url' => 'https://github.com/box-project/box2/releases/download/2.7.5/box-2.7.5.phar',
+                'as' => 'box',
+            ),
             'psysh'     => array('url' => 'https://psysh.org/psysh', 'as' => 'psysh'),
             'phpdoc'    => array('url' => 'http://www.phpdoc.org/phpDocumentor.phar', 'as' => 'phpdoc')
         );

--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew;
 
-use Serializable;
 use PhpBrew\BuildSettings\BuildSettings;
+use Serializable;
 
 /**
  * A build object contains version information,
@@ -152,12 +152,12 @@ class Build implements Serializable, Buildable
 
     public function isBuildable()
     {
-        return file_exists($this->sourceDirectory.DIRECTORY_SEPARATOR.'Makefile');
+        return file_exists($this->sourceDirectory . DIRECTORY_SEPARATOR . 'Makefile');
     }
 
     public function getBuildLogPath()
     {
-        $dir = $this->getSourceDirectory().DIRECTORY_SEPARATOR.'build.log';
+        $dir = $this->getSourceDirectory() . DIRECTORY_SEPARATOR . 'build.log';
         return $dir;
     }
 
@@ -168,12 +168,12 @@ class Build implements Serializable, Buildable
 
     public function getBinDirectory()
     {
-        return $this->installPrefix.DIRECTORY_SEPARATOR.'bin';
+        return $this->installPrefix . DIRECTORY_SEPARATOR . 'bin';
     }
 
     public function getEtcDirectory()
     {
-        $etc = $this->installPrefix.DIRECTORY_SEPARATOR.'etc';
+        $etc = $this->installPrefix . DIRECTORY_SEPARATOR . 'etc';
         if (!file_exists($etc)) {
             mkdir($etc, 0755, true);
         }
@@ -183,12 +183,12 @@ class Build implements Serializable, Buildable
 
     public function getVarDirectory()
     {
-        return $this->installPrefix.DIRECTORY_SEPARATOR.'var';
+        return $this->installPrefix . DIRECTORY_SEPARATOR . 'var';
     }
 
     public function getVarConfigDirectory()
     {
-        return $this->installPrefix.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'db';
+        return $this->installPrefix . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'db';
     }
 
     public function getInstallPrefix()
@@ -201,12 +201,12 @@ class Build implements Serializable, Buildable
      */
     public function getCurrentConfigScanPath()
     {
-        return $this->installPrefix.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'db';
+        return $this->installPrefix . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'db';
     }
 
     public function getPath($subpath)
     {
-        return $this->installPrefix.DIRECTORY_SEPARATOR.$subpath;
+        return $this->installPrefix . DIRECTORY_SEPARATOR . $subpath;
     }
 
     /**
@@ -229,7 +229,7 @@ class Build implements Serializable, Buildable
                     $names[] = $n;
                 } else {
                     $v = preg_replace('#\W+#', '_', $v);
-                    $str = $n.'='.$v;
+                    $str = $n . '=' . $v;
                     $names[] = $str;
                 }
             }
@@ -246,7 +246,7 @@ class Build implements Serializable, Buildable
 
     public function getSourceExtensionDirectory()
     {
-        return $this->sourceDirectory.DIRECTORY_SEPARATOR.'ext';
+        return $this->sourceDirectory . DIRECTORY_SEPARATOR . 'ext';
     }
 
     public function setBuildSettings(BuildSettings $settings)
@@ -259,7 +259,7 @@ class Build implements Serializable, Buildable
         // also contains the variant info,
         // but for backward compatibility, we still need a method to handle
         // the variant info file..
-        $variantFile = $this->getInstallPrefix().DIRECTORY_SEPARATOR.'phpbrew.variants';
+        $variantFile = $this->getInstallPrefix() . DIRECTORY_SEPARATOR . 'phpbrew.variants';
         if (file_exists($variantFile)) {
             $this->settings->loadVariantInfoFile($variantFile);
         }
@@ -329,7 +329,7 @@ class Build implements Serializable, Buildable
     public function getStateFile()
     {
         if ($dir = $this->getInstallPrefix()) {
-            return $dir.DIRECTORY_SEPARATOR.'phpbrew_status';
+            return $dir . DIRECTORY_SEPARATOR . 'phpbrew_status';
         }
     }
 

--- a/src/PhpBrew/BuildFinder.php
+++ b/src/PhpBrew/BuildFinder.php
@@ -2,6 +2,8 @@
 
 namespace PhpBrew;
 
+use Exception;
+
 class BuildFinder
 {
     /**
@@ -9,13 +11,20 @@ class BuildFinder
      */
     public static function findInstalledBuilds($stripPrefix = true)
     {
-        $path = Config::getRoot().DIRECTORY_SEPARATOR.'php';
+        $path = Config::getRoot() . DIRECTORY_SEPARATOR . 'php';
         if (!file_exists($path)) {
-            throw new \Exception($path.' does not exist.');
+            throw new Exception($path . ' does not exist.');
         }
         $names = scandir($path);
         $names = array_filter($names, function ($name) use ($path) {
-            return $name != '.' && $name != '..' && file_exists($path.DIRECTORY_SEPARATOR.$name.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'php');
+            return $name != '.'
+                && $name != '..'
+                && file_exists(
+                $path
+                    . DIRECTORY_SEPARATOR . $name
+                    . DIRECTORY_SEPARATOR . 'bin'
+                    . DIRECTORY_SEPARATOR . 'php'
+            );
         });
 
         if ($names == null || empty($names)) {
@@ -28,7 +37,9 @@ class BuildFinder
             }, $names);
         }
         uasort($names, 'version_compare'); // ordering version name ascending... 5.5.17, 5.5.12
-        return array_reverse($names);  // make it descending... since there is no sort function for user-define in reverse order.
+
+        // make it descending... since there is no sort function for user-define in reverse order.
+        return array_reverse($names);
     }
 
     /**

--- a/src/PhpBrew/BuildRegister.php
+++ b/src/PhpBrew/BuildRegister.php
@@ -11,19 +11,19 @@ class BuildRegister
     public function __construct()
     {
         $this->root = Config::getRoot();
-        $this->baseDir = $this->root.DIRECTORY_SEPARATOR.'registry';
+        $this->baseDir = $this->root . DIRECTORY_SEPARATOR . 'registry';
     }
 
     public function register(Build $build)
     {
-        $file = $this->baseDir.DIRECTORY_SEPARATOR.$build->getName();
+        $file = $this->baseDir . DIRECTORY_SEPARATOR . $build->getName();
 
         return $build->writeFile($file);
     }
 
     public function deregister(Build $build)
     {
-        $file = $this->baseDir.DIRECTORY_SEPARATOR.$build->getName();
+        $file = $this->baseDir . DIRECTORY_SEPARATOR . $build->getName();
         if (file_exists($file)) {
             unlink($file);
 

--- a/src/PhpBrew/BuildSettings/BuildSettings.php
+++ b/src/PhpBrew/BuildSettings/BuildSettings.php
@@ -2,6 +2,8 @@
 
 namespace PhpBrew\BuildSettings;
 
+use Exception;
+
 class BuildSettings
 {
     /**
@@ -185,7 +187,7 @@ class BuildSettings
     public function loadVariantInfoFile($variantFile)
     {
         if (!is_readable($variantFile)) {
-            throw new \Exception(
+            throw new Exception(
                 "Can't load variant info! Variants file {$variantFile} is not readable."
             );
         }

--- a/src/PhpBrew/Command/AppCommand/GetCommand.php
+++ b/src/PhpBrew/Command/AppCommand/GetCommand.php
@@ -2,11 +2,11 @@
 
 namespace PhpBrew\Command\AppCommand;
 
-use PhpBrew\Downloader\DownloadFactory;
-use PhpBrew\Config;
-use PhpBrew\AppStore;
 use CLIFramework\Command;
 use Exception;
+use PhpBrew\AppStore;
+use PhpBrew\Config;
+use PhpBrew\Downloader\DownloadFactory;
 
 class GetCommand extends Command
 {
@@ -35,11 +35,12 @@ class GetCommand extends Command
         $apps = AppStore::all();
 
         if (!isset($apps[$appName])) {
-            throw new \Exception("App $appName not found.");
+            throw new Exception("App $appName not found.");
         }
+
         $app = $apps[$appName];
-        $targetDir = Config::getRoot().DIRECTORY_SEPARATOR.'bin';
-        $target = $targetDir.DIRECTORY_SEPARATOR.$app['as'];
+        $targetDir = Config::getRoot() . DIRECTORY_SEPARATOR . 'bin';
+        $target = $targetDir . DIRECTORY_SEPARATOR . $app['as'];
 
         DownloadFactory::getInstance($this->logger, $this->options)->download($app['url'], $target);
 

--- a/src/PhpBrew/Command/AppCommand/ListCommand.php
+++ b/src/PhpBrew/Command/AppCommand/ListCommand.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\Command\AppCommand;
 
-use PhpBrew\AppStore;
 use CLIFramework\Command;
+use PhpBrew\AppStore;
 
 class ListCommand extends Command
 {

--- a/src/PhpBrew/Command/CleanCommand.php
+++ b/src/PhpBrew/Command/CleanCommand.php
@@ -2,11 +2,11 @@
 
 namespace PhpBrew\Command;
 
-use PhpBrew\Tasks\MakeTask;
+use CLIFramework\Command;
 use PhpBrew\Build;
 use PhpBrew\Config;
+use PhpBrew\Tasks\MakeTask;
 use PhpBrew\Utils;
-use CLIFramework\Command;
 
 class CleanCommand extends Command
 {
@@ -29,19 +29,19 @@ class CleanCommand extends Command
     {
         $args->add('installed php')
             ->validValues(function () {
-                return \PhpBrew\Config::getInstalledPhpVersions();
+                return Config::getInstalledPhpVersions();
             })
             ;
     }
 
     public function execute($version)
     {
-        $buildDir = Config::getBuildDir().DIRECTORY_SEPARATOR.$version;
+        $buildDir = Config::getBuildDir() . DIRECTORY_SEPARATOR . $version;
         if ($this->options->all) {
             if (!file_exists($buildDir)) {
-                $this->logger->info('Source directory '.$buildDir.' does not exist.');
+                $this->logger->info('Source directory ' . $buildDir . ' does not exist.');
             } else {
-                $this->logger->info('Source directory '.$buildDir.' found, deleting...');
+                $this->logger->info('Source directory ' . $buildDir . ' found, deleting...');
                 Utils::recursive_unlink($buildDir, $this->logger);
             }
         } else {

--- a/src/PhpBrew/Command/ConfigCommand.php
+++ b/src/PhpBrew/Command/ConfigCommand.php
@@ -3,8 +3,8 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command;
-use PhpBrew\Utils;
 use PhpBrew\Config;
+use PhpBrew\Utils;
 
 class ConfigCommand extends Command
 {

--- a/src/PhpBrew/Command/CtagsCommand.php
+++ b/src/PhpBrew/Command/CtagsCommand.php
@@ -2,10 +2,11 @@
 
 namespace PhpBrew\Command;
 
-use PhpBrew\Config;
+use CLIFramework\Command;
 use PhpBrew\CommandBuilder;
+use PhpBrew\Config;
 
-class CtagsCommand extends \CLIFramework\Command
+class CtagsCommand extends Command
 {
     public function brief()
     {
@@ -16,7 +17,7 @@ class CtagsCommand extends \CLIFramework\Command
     {
         $args->add('installed versions')
             ->validValues(function () {
-                return \PhpBrew\Config::getInstalledPhpVersions();
+                return Config::getInstalledPhpVersions();
             })
             ;
     }
@@ -31,22 +32,27 @@ class CtagsCommand extends \CLIFramework\Command
         $home = Config::getHome();
 
         if ($versionName) {
-            $sourceDir = Config::getBuildDir().DIRECTORY_SEPARATOR.$versionName;
+            $sourceDir = Config::getBuildDir() . DIRECTORY_SEPARATOR . $versionName;
         } else {
             if (!getenv('PHPBREW_PHP')) {
-                $this->logger->error('Error: PHPBREW_PHP environment variable is not defined.');
-                $this->logger->error('  This command requires you specify a PHP version from your build list.');
-                $this->logger->error("  And it looks like you haven't switched to a version from the builds that were built with PHPBrew.");
-                $this->logger->error('Suggestion: Please install at least one PHP with your prefered version and switch to it.');
+                $this->logger->error(<<<EOF
+Error: PHPBREW_PHP environment variable is not defined.
+  This command requires you specify a PHP version from your build list.
+  And it looks like you haven't switched to a version from the builds that were built with PHPBrew.
+Suggestion: Please install at least one PHP with your preferred version and switch to it.
+EOF
+                );
 
-                return false;
+                return;
             }
             $sourceDir = Config::getCurrentBuildDir();
         }
         if (!file_exists($sourceDir)) {
-            return $this->logger->error("$sourceDir does not exist.");
+            $this->logger->error("$sourceDir does not exist.");
+
+            return;
         }
-        $this->logger->info('Scanning '.$sourceDir);
+        $this->logger->info('Scanning ' . $sourceDir);
 
         $cmd = new CommandBuilder('ctags');
         $cmd->arg('-R');
@@ -54,9 +60,9 @@ class CtagsCommand extends \CLIFramework\Command
         $cmd->arg('-h');
         $cmd->arg('.c.h.cpp');
 
-        $cmd->arg($sourceDir.DIRECTORY_SEPARATOR.'main');
-        $cmd->arg($sourceDir.DIRECTORY_SEPARATOR.'ext');
-        $cmd->arg($sourceDir.DIRECTORY_SEPARATOR.'Zend');
+        $cmd->arg($sourceDir . DIRECTORY_SEPARATOR . 'main');
+        $cmd->arg($sourceDir . DIRECTORY_SEPARATOR . 'ext');
+        $cmd->arg($sourceDir . DIRECTORY_SEPARATOR . 'Zend');
 
         foreach ($args as $a) {
             $cmd->arg($a);

--- a/src/PhpBrew/Command/DownloadCommand.php
+++ b/src/PhpBrew/Command/DownloadCommand.php
@@ -2,15 +2,16 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command;
+use CLIFramework\ValueCollection;
 use Exception;
+use GetOptionKit\OptionSpecCollection;
 use PhpBrew\Config;
 use PhpBrew\Distribution\DistributionUrlPolicy;
 use PhpBrew\Downloader\DownloadFactory;
+use PhpBrew\ReleaseList;
 use PhpBrew\Tasks\DownloadTask;
 use PhpBrew\Tasks\PrepareDirectoryTask;
-use PhpBrew\ReleaseList;
-use CLIFramework\Command;
-use CLIFramework\ValueCollection;
 
 class DownloadCommand extends Command
 {
@@ -42,7 +43,7 @@ class DownloadCommand extends Command
     }
 
     /**
-     * @param \GetOptionKit\OptionSpecCollection $opts
+     * @param OptionSpecCollection $opts
      */
     public function options($opts)
     {
@@ -60,12 +61,15 @@ class DownloadCommand extends Command
         $releases = $releaseList->getReleases();
         $versionInfo = $releaseList->getVersion($version);
         if (!$versionInfo) {
-            throw new \Exception("Version $version not found.");
+            throw new Exception("Version $version not found.");
         }
         $version = $versionInfo['version'];
         $distUrlPolicy = new DistributionUrlPolicy();
         if ($this->options->mirror) {
-            $this->logger->warn('php.net has retired the mirror program, hence --mirror option has been deprecated and will be removed in the future.');
+            $this->logger->warn(
+                'php.net has retired the mirror program, '
+                . 'hence --mirror option has been deprecated and will be removed in the future.'
+            );
         }
         $distUrl = $distUrlPolicy->buildUrl($version, $versionInfo['filename'], $versionInfo['museum']);
 
@@ -87,7 +91,7 @@ class DownloadCommand extends Command
         $targetDir = $download->download($distUrl, $distFileDir, $algo, $hash);
 
         if (!file_exists($targetDir)) {
-            throw new \Exception('Download failed.');
+            throw new Exception('Download failed.');
         }
         $this->logger->info("Done, please look at: $targetDir");
     }

--- a/src/PhpBrew/Command/EnvCommand.php
+++ b/src/PhpBrew/Command/EnvCommand.php
@@ -2,9 +2,10 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command as BaseCommand;
 use PhpBrew\Config;
 
-class EnvCommand extends \CLIFramework\Command
+class EnvCommand extends BaseCommand
 {
     public function brief()
     {
@@ -16,7 +17,7 @@ class EnvCommand extends \CLIFramework\Command
         $args->add('installed php')
             ->optional()
             ->validValues(function () {
-                return \PhpBrew\Config::getInstalledPhpVersions();
+                return Config::getInstalledPhpVersions();
             })
             ;
     }
@@ -41,8 +42,8 @@ class EnvCommand extends \CLIFramework\Command
             // checking php version existence
             $targetPhpBinPath = Config::getVersionBinPath($buildName);
             if (is_dir($targetPhpBinPath)) {
-                echo 'export PHPBREW_PHP='.$buildName."\n";
-                echo 'export PHPBREW_PATH='.($buildName ? Config::getVersionBinPath($buildName) : '')."\n";
+                echo 'export PHPBREW_PHP=' . $buildName . "\n";
+                echo 'export PHPBREW_PATH=' . ($buildName ? Config::getVersionBinPath($buildName) : '') . "\n";
             }
         }
         $this->logger->writeln('# Run this command to configure your shell:');

--- a/src/PhpBrew/Command/ExtensionCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand.php
@@ -2,12 +2,12 @@
 
 namespace PhpBrew\Command;
 
-use PhpBrew\Config;
-use PhpBrew\Extension\ExtensionFactory;
-use PhpBrew\Extension\M4Extension;
-use PhpBrew\Extension\Extension;
 use Exception;
 use PhpBrew\Command\ExtensionCommand\BaseCommand;
+use PhpBrew\Config;
+use PhpBrew\Extension\Extension;
+use PhpBrew\Extension\ExtensionFactory;
+use PhpBrew\Extension\M4Extension;
 
 class ExtensionCommand extends BaseCommand
 {
@@ -48,7 +48,8 @@ class ExtensionCommand extends BaseCommand
 
     public function describeExtension(Extension $ext)
     {
-        $this->logger->write(sprintf(' [%s] %-12s %-12s',
+        $this->logger->write(sprintf(
+            ' [%s] %-12s %-12s',
             extension_loaded($ext->getExtensionName()) ? '*' : ' ',
             $ext->getExtensionName(),
             phpversion($ext->getExtensionName())
@@ -66,12 +67,13 @@ class ExtensionCommand extends BaseCommand
             if ($ext instanceof M4Extension) {
                 $options = $ext->getConfigureOptions();
                 if (!empty($options)) {
-                    $this->logger->info($padding.'Configure options:');
+                    $this->logger->info($padding . 'Configure options:');
                     foreach ($options as $option) {
-                        $this->logger->info($padding.'  '
-                            .sprintf('%-32s %s',
-                                $option->option.($option->valueHint ? '[='.$option->valueHint.']' : ''),
-                                $option->desc));
+                        $this->logger->info($padding . '  ' . sprintf(
+                            '%-32s %s',
+                            $option->option . ($option->valueHint ? '[=' . $option->valueHint . ']' : ''),
+                            $option->desc
+                        ));
                     }
                 }
             }
@@ -81,7 +83,7 @@ class ExtensionCommand extends BaseCommand
     public function execute()
     {
         $buildDir = Config::getCurrentBuildDir();
-        $extDir = $buildDir.DIRECTORY_SEPARATOR.'ext';
+        $extDir = $buildDir . DIRECTORY_SEPARATOR . 'ext';
 
         // list for extensions which are not enabled
         $extensions = array();
@@ -96,9 +98,9 @@ class ExtensionCommand extends BaseCommand
                 if ($extName == '.' || $extName == '..') {
                     continue;
                 }
-                $dir = $extDir.DIRECTORY_SEPARATOR.$extName;
+                $dir = $extDir . DIRECTORY_SEPARATOR . $extName;
                 foreach ($lookupDirectories as $lookupDirectory) {
-                    $extensionDir = $dir.(empty($lookupDirectory) ? '' : DIRECTORY_SEPARATOR.$lookupDirectory);
+                    $extensionDir = $dir . (empty($lookupDirectory) ? '' : DIRECTORY_SEPARATOR . $lookupDirectory);
                     if ($m4files = ExtensionFactory::configM4Exists($extensionDir)) {
                         $this->logger->debug("Loading extension information $extName from $extensionDir");
 

--- a/src/PhpBrew/Command/ExtensionCommand/BaseCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/BaseCommand.php
@@ -2,18 +2,21 @@
 
 namespace PhpBrew\Command\ExtensionCommand;
 
-use PhpBrew\Extension;
+use CLIFramework\Command;
 
-abstract class BaseCommand extends \CLIFramework\Command
+abstract class BaseCommand extends Command
 {
     public function prepare()
     {
         parent::prepare();
         if (!getenv('PHPBREW_PHP')) {
-            $this->logger->error('Error: PHPBREW_PHP environment variable is not defined.');
-            $this->logger->error('  This extension command requires you specify a PHP version from your build list.');
-            $this->logger->error("  And it looks like you haven't switched to a version from the builds that were built with PHPBrew.");
-            $this->logger->error('Suggestion: Please install at least one PHP with your prefered version and switch to it.');
+            $this->logger->error(<<<EOF
+Error: PHPBREW_PHP environment variable is not defined.
+  This extension command requires you specify a PHP version from your build list.
+  And it looks like you haven't switched to a version from the builds that were built with PHPBrew.
+Suggestion: Please install at least one PHP with your preferred version and switch to it.
+EOF
+            );
 
             return false;
         }

--- a/src/PhpBrew/Command/ExtensionCommand/CleanCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/CleanCommand.php
@@ -3,7 +3,6 @@
 namespace PhpBrew\Command\ExtensionCommand;
 
 use PhpBrew\Config;
-use PhpBrew\Extension;
 use PhpBrew\Extension\ExtensionFactory;
 use PhpBrew\Extension\ExtensionManager;
 
@@ -23,12 +22,12 @@ class CleanCommand extends BaseCommand
     {
         $args->add('extensions')
             ->suggestions(function () {
-                $extdir = Config::getBuildDir().'/'.Config::getCurrentPhpName().'/ext';
+                $extdir = Config::getBuildDir() . '/' . Config::getCurrentPhpName() . '/ext';
 
                 return array_filter(
                     scandir($extdir),
                     function ($d) use ($extdir) {
-                        return $d != '.' && $d != '..' && is_dir($extdir.DIRECTORY_SEPARATOR.$d);
+                        return $d != '.' && $d != '..' && is_dir($extdir . DIRECTORY_SEPARATOR . $d);
                     }
                 );
             });

--- a/src/PhpBrew/Command/ExtensionCommand/ConfigCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/ConfigCommand.php
@@ -3,8 +3,8 @@
 namespace PhpBrew\Command\ExtensionCommand;
 
 use PhpBrew\Config;
-use PhpBrew\Utils;
 use PhpBrew\Extension\ExtensionFactory;
+use PhpBrew\Utils;
 
 class ConfigCommand extends BaseCommand
 {
@@ -19,7 +19,7 @@ class ConfigCommand extends BaseCommand
             ->suggestions(function () {
                 return array_map(function ($path) {
                     return basename(basename($path, '.disabled'), '.ini');
-                }, glob(Config::getCurrentPhpDir().'/var/db/*.{ini,disabled}', GLOB_BRACE));
+                }, glob(Config::getCurrentPhpDir() . '/var/db/*.{ini,disabled}', GLOB_BRACE));
             });
     }
 
@@ -35,7 +35,9 @@ class ConfigCommand extends BaseCommand
             $file .= '.disabled'; // try with ini.disabled file
             $this->logger->info("Looking for {$file} file...");
             if (!file_exists($file)) {
-                $this->logger->warn("Sorry, I can't find the ini file for the requested extension: \"{$extensionName}\".");
+                $this->logger->warn(
+                    "Sorry, I can't find the ini file for the requested extension: \"{$extensionName}\"."
+                );
 
                 return;
             }

--- a/src/PhpBrew/Command/ExtensionCommand/DisableCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/DisableCommand.php
@@ -25,7 +25,7 @@ class DisableCommand extends BaseCommand
 
                 return array_map(function ($path) use ($extension) {
                     return basename($path, $extension);
-                }, glob(Config::getCurrentPhpDir()."/var/db/*{$extension}"));
+                }, glob(Config::getCurrentPhpDir() . "/var/db/*{$extension}"));
             });
     }
 

--- a/src/PhpBrew/Command/ExtensionCommand/EnableCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/EnableCommand.php
@@ -25,7 +25,7 @@ class EnableCommand extends BaseCommand
 
                 return array_map(function ($path) use ($extension) {
                     return basename($path, $extension);
-                }, glob(Config::getCurrentPhpDir()."/var/db/*{$extension}"));
+                }, glob(Config::getCurrentPhpDir() . "/var/db/*{$extension}"));
             });
     }
 

--- a/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
@@ -2,12 +2,14 @@
 
 namespace PhpBrew\Command\ExtensionCommand;
 
+use CLIFramework\Command;
+use GetOptionKit\OptionSpecCollection;
 use PhpBrew\Config;
 use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Extension\ExtensionDownloader;
 use PhpBrew\ExtensionList;
 
-class KnownCommand extends \CLIFramework\Command
+class KnownCommand extends Command
 {
     public function usage()
     {
@@ -20,7 +22,7 @@ class KnownCommand extends \CLIFramework\Command
     }
 
     /**
-     * @param \GetOptionKit\OptionSpecCollection $opts
+     * @param OptionSpecCollection $opts
      */
     public function options($opts)
     {
@@ -31,12 +33,12 @@ class KnownCommand extends \CLIFramework\Command
     {
         $args->add('extensions')
             ->suggestions(function () {
-                $extdir = Config::getBuildDir().'/'.Config::getCurrentPhpName().'/ext';
+                $extdir = Config::getBuildDir() . '/' . Config::getCurrentPhpName() . '/ext';
 
                 return array_filter(
                     scandir($extdir),
                     function ($d) use ($extdir) {
-                        return $d != '.' && $d != '..' && is_dir($extdir.DIRECTORY_SEPARATOR.$d);
+                        return $d != '.' && $d != '..' && is_dir($extdir . DIRECTORY_SEPARATOR . $d);
                     }
                 );
             });

--- a/src/PhpBrew/Command/ExtensionCommand/ShowCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/ShowCommand.php
@@ -2,11 +2,11 @@
 
 namespace PhpBrew\Command\ExtensionCommand;
 
+use Exception;
 use PhpBrew\Config;
 use PhpBrew\Extension\Extension;
-use PhpBrew\Extension\PeclExtension;
 use PhpBrew\Extension\ExtensionFactory;
-use Exception;
+use PhpBrew\Extension\PeclExtension;
 
 class ShowCommand extends BaseCommand
 {
@@ -29,12 +29,12 @@ class ShowCommand extends BaseCommand
     {
         $args->add('extension')
             ->suggestions(function () {
-                $extdir = Config::getBuildDir().'/'.Config::getCurrentPhpName().'/ext';
+                $extdir = Config::getBuildDir() . '/' . Config::getCurrentPhpName() . '/ext';
 
                 return array_filter(
                     scandir($extdir),
                     function ($d) use ($extdir) {
-                        return $d != '.' && $d != '..' && is_dir($extdir.DIRECTORY_SEPARATOR.$d);
+                        return $d != '.' && $d != '..' && is_dir($extdir . DIRECTORY_SEPARATOR . $d);
                     }
                 );
             });
@@ -64,9 +64,11 @@ class ShowCommand extends BaseCommand
             $this->logger->writeln(sprintf('%20s: ', 'Configure Options'));
             $this->logger->newline();
             foreach ($options as $option) {
-                $this->logger->writeln(sprintf('        %-32s %s',
-                        $option->option.($option->valueHint ? '[='.$option->valueHint.']' : ''),
-                        $option->desc));
+                $this->logger->writeln(sprintf(
+                    '        %-32s %s',
+                    $option->option . ($option->valueHint ? '[=' . $option->valueHint . ']' : ''),
+                    $option->desc
+                ));
                 $this->logger->newline();
             }
         }
@@ -94,7 +96,7 @@ class ShowCommand extends BaseCommand
             $ext = ExtensionFactory::lookupRecursive($extensionName, array($extDir));
         }
         if (!$ext) {
-            throw new \Exception("$extensionName extension not found.");
+            throw new Exception("$extensionName extension not found.");
         }
         $this->describeExtension($ext);
     }

--- a/src/PhpBrew/Command/FpmCommand/SetupCommand.php
+++ b/src/PhpBrew/Command/FpmCommand/SetupCommand.php
@@ -2,21 +2,9 @@
 
 namespace PhpBrew\Command\FpmCommand;
 
-use PhpBrew\Config;
-use PhpBrew\Downloader\DownloadFactory;
-use PhpBrew\VariantParser;
-use PhpBrew\VariantBuilder;
-use PhpBrew\Tasks\DownloadTask;
-use PhpBrew\Build;
-use PhpBrew\ReleaseList;
-use PhpBrew\VersionDslParser;
-use PhpBrew\BuildSettings\DefaultBuildSettings;
-use PhpBrew\Distribution\DistributionUrlPolicy;
-use CLIFramework\ValueCollection;
 use CLIFramework\Command;
-use PhpBrew\Exception\SystemCommandException;
 use Exception;
-
+use PhpBrew\Config;
 
 class SetupCommand extends Command
 {
@@ -32,13 +20,15 @@ class SetupCommand extends Command
 
     public function options($opts)
     {
-        $opts->add('systemctl',
+        $opts->add(
+            'systemctl',
             "Generate systemd service entry. " .
             "This option only works for systemd-based Linux. " .
             "To use this option, be sure to compile PHP with --with-fpm-systemd option. " .
             "Start from 1.22, phpbrew automatically add --with-fpm-systemd when systemd is detected."
         );
-        $opts->add('initd',
+        $opts->add(
+            'initd',
             'Generate init.d script. ' .
             'The generated init.d script depends on lsb-base >= 4.0. ' .
             'If initctl is based on upstart, the init.d script will not be executed. ' .
@@ -59,16 +49,20 @@ class SetupCommand extends Command
             $buildName = Config::getCurrentPhpName();
         }
         if (!$buildName) {
-            throw new \Exception("PHPBREW_PHP is not set. You should provide the build name in the command.");
+            throw new Exception("PHPBREW_PHP is not set. You should provide the build name in the command.");
         }
 
-        fprintf(STDERR, "*WARNING* php-fpm --pid option requires php >= 5.6, you need to update your php-fpm.conf for the pid file location.\n");
+        fprintf(
+            STDERR,
+            "*WARNING* php-fpm --pid option requires php >= 5.6. "
+            . "You need to update your php-fpm.conf for the pid file location.\n"
+        );
 
         $root = Config::getRoot();
         $fpmBin = "$root/php/$buildName/sbin/php-fpm";
 
         if (!file_exists($fpmBin)) {
-            throw new \Exception("$fpmBin doesn't exist.");
+            throw new Exception("$fpmBin doesn't exist.");
         }
 
         // TODO: require sudo permission
@@ -133,7 +127,9 @@ class SetupCommand extends Command
             $this->logger->info("To load the service:");
             $this->logger->info("    sudo launchctl load $file");
         } else {
-            $this->logger->info('Please use one of the options [--systemctl, --initd, --launchctl] to setup system fpm service.');
+            $this->logger->info(
+                'Please use one of the options [--systemctl, --initd, --launchctl] to setup system fpm service.'
+            );
         }
     }
 
@@ -142,7 +138,7 @@ class SetupCommand extends Command
         $root   = Config::getRoot();
         $phpdir = "$root/php/$buildName";
         $pidFile = $phpdir . '/var/run/php-fpm.pid';
-        $config =<<<"EOS"
+        $config = <<<"EOS"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -176,7 +172,7 @@ EOS;
         $root   = Config::getRoot();
         $phpdir = "$root/php/$buildName";
         $pidFile = $phpdir . '/var/run/php-fpm.pid';
-        $config =<<<"EOS"
+        $config = <<<"EOS"
 [Unit]
 Description=The PHPBrew FastCGI Process Manager
 After=network.target
@@ -199,7 +195,7 @@ EOS;
         $root   = Config::getRoot();
         $phpdir = "$root/php/$buildName";
         $pidFile = $phpdir . '/var/run/php-fpm.pid';
-        $config =<<<"EOS"
+        $config = <<<"EOS"
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          phpbrew-fpm

--- a/src/PhpBrew/Command/InfoCommand.php
+++ b/src/PhpBrew/Command/InfoCommand.php
@@ -2,7 +2,9 @@
 
 namespace PhpBrew\Command;
 
-class InfoCommand extends \CLIFramework\Command
+use CLIFramework\Command;
+
+class InfoCommand extends Command
 {
     public function brief()
     {
@@ -17,7 +19,7 @@ class InfoCommand extends \CLIFramework\Command
     public function header($text)
     {
         $f = $this->logger->formatter;
-        echo $f->format($text."\n", 'strong_white');
+        echo $f->format($text . "\n", 'strong_white');
     }
 
     public function execute()
@@ -58,26 +60,28 @@ class InfoCommand extends \CLIFramework\Command
         echo "\n";
 
         $this->header('Database Extensions');
-        foreach (array_filter(
-            $extensions,
-            function ($n) {
-                return in_array(
-                $n,
-                array(
-                    'PDO',
-                    'pdo_mysql',
-                    'pdo_pgsql',
-                    'pdo_sqlite',
-                    'pgsql',
-                    'mysqli',
-                    'mysql',
-                    'oci8',
-                    'sqlite3',
-                    'mysqlnd',
-                )
-            );
-            }
-        ) as $extName) {
+        foreach (
+            array_filter(
+                $extensions,
+                function ($n) {
+                    return in_array(
+                        $n,
+                        array(
+                        'PDO',
+                        'pdo_mysql',
+                        'pdo_pgsql',
+                        'pdo_sqlite',
+                        'pgsql',
+                        'mysqli',
+                        'mysql',
+                        'oci8',
+                        'sqlite3',
+                        'mysqlnd',
+                        )
+                    );
+                }
+            ) as $extName
+        ) {
             $this->logger->info($extName, 1);
         }
     }

--- a/src/PhpBrew/Command/InitCommand.php
+++ b/src/PhpBrew/Command/InitCommand.php
@@ -2,10 +2,11 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command;
 use Phar;
 use PhpBrew\Config;
 
-class InitCommand extends \CLIFramework\Command
+class InitCommand extends Command
 {
     public function brief()
     {
@@ -14,13 +15,15 @@ class InitCommand extends \CLIFramework\Command
 
     public function options($opts)
     {
-        $opts->add('c|config:',
+        $opts->add(
+            'c|config:',
             'The YAML config file which should be copied into phpbrew home.' .
             'The config file is used for creating custom virtual variants. ' .
             'For more details, please see https://github.com/phpbrew/phpbrew/wiki/Setting-up-Configuration'
         )->isa('file');
 
-        $opts->add('root:',
+        $opts->add(
+            'root:',
             'Override the default PHPBREW_ROOT path setting.' .
             'This option is usually used to load system-wide build pool. ' .
             'e.g. phpbrew init --root=/opt/phpbrew '
@@ -45,7 +48,7 @@ class InitCommand extends \CLIFramework\Command
         $paths = array();
         $paths[] = $home;
         $paths[] = $root;
-        $paths[] = $root.DIRECTORY_SEPARATOR.'register';
+        $paths[] = $root . DIRECTORY_SEPARATOR . 'register';
         $paths[] = $buildDir;
         $paths[] = $buildPrefix;
         foreach ($paths as $p) {
@@ -60,8 +63,8 @@ class InitCommand extends \CLIFramework\Command
 
         $this->logger->debug('Creating .metadata_never_index to prevent SpotLight indexing');
         $indexFiles = array(
-            $root.DIRECTORY_SEPARATOR.'.metadata_never_index',
-            $home.DIRECTORY_SEPARATOR.'.metadata_never_index',
+            $root . DIRECTORY_SEPARATOR . '.metadata_never_index',
+            $home . DIRECTORY_SEPARATOR . '.metadata_never_index',
         );
         foreach ($indexFiles as $indexFile) {
             if (!file_exists($indexFile)) {
@@ -71,19 +74,26 @@ class InitCommand extends \CLIFramework\Command
 
         if ($configFile = $this->options->{'config'}) {
             if (!file_exists($configFile)) {
-                return $this->logger->error("config file '$configFile' does not exist.");
+                $this->logger->error("config file '$configFile' does not exist.");
+
+                return;
             }
             $this->logger->debug("Using yaml config from '$configFile'");
-            copy($configFile, $root.DIRECTORY_SEPARATOR.'config.yaml');
+            copy($configFile, $root . DIRECTORY_SEPARATOR . 'config.yaml');
         }
 
         $this->logger->writeln($this->formatter->format('Initialization successfully finished!', 'strong_green'));
-        $this->logger->writeln($this->formatter->format('<=====================================================>', 'strong_white'));
+        $this->logger->writeln(
+            $this->formatter->format(
+                '<=====================================================>',
+                'strong_white'
+            )
+        );
 
         // write bashrc script to phpbrew home
-        file_put_contents($home.'/bashrc', $this->getBashScriptPath());
+        file_put_contents($home . '/bashrc', $this->getBashScriptPath());
         // write phpbrew.fish script to phpbrew home
-        file_put_contents($home.'/phpbrew.fish', $this->getFishScriptPath());
+        file_put_contents($home . '/phpbrew.fish', $this->getFishScriptPath());
 
         if (strpos(getenv('SHELL'), 'fish') !== false) {
             $initConfig = <<<EOS
@@ -124,16 +134,22 @@ Enjoy phpbrew at \$HOME!!
 
 
 EOS;
-        $this->logger->writeln($this->formatter->format('<=====================================================>', 'strong_white'));
+
+        $this->logger->writeln(
+            $this->formatter->format(
+                '<=====================================================>',
+                'strong_white'
+            )
+        );
     }
 
     protected function getCurrentShellDirectory()
     {
         $path = Phar::running();
         if ($path) {
-            $path = $path.DIRECTORY_SEPARATOR.'shell';
+            $path = $path . DIRECTORY_SEPARATOR . 'shell';
         } else {
-            $path = dirname(dirname(dirname(__DIR__))).DIRECTORY_SEPARATOR.'shell';
+            $path = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'shell';
         }
 
         return $path;
@@ -143,13 +159,13 @@ EOS;
     {
         $path = $this->getCurrentShellDirectory();
 
-        return file_get_contents($path.DIRECTORY_SEPARATOR.'bashrc');
+        return file_get_contents($path . DIRECTORY_SEPARATOR . 'bashrc');
     }
 
     protected function getFishScriptPath()
     {
         $path = $this->getCurrentShellDirectory();
 
-        return file_get_contents($path.DIRECTORY_SEPARATOR.'phpbrew.fish');
+        return file_get_contents($path . DIRECTORY_SEPARATOR . 'phpbrew.fish');
     }
 }

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -2,12 +2,14 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command;
+use GetOptionKit\OptionSpecCollection;
 use PhpBrew\Config;
 use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\ReleaseList;
 use PhpBrew\Tasks\FetchReleaseListTask;
 
-class KnownCommand extends \CLIFramework\Command
+class KnownCommand extends Command
 {
     public function brief()
     {
@@ -15,7 +17,7 @@ class KnownCommand extends \CLIFramework\Command
     }
 
     /**
-     * @param \GetOptionKit\OptionSpecCollection $opts
+     * @param OptionSpecCollection $opts
      */
     public function options($opts)
     {
@@ -37,9 +39,19 @@ class KnownCommand extends \CLIFramework\Command
             $fetchTask = new FetchReleaseListTask($this->logger, $this->options);
             $releases = $fetchTask->fetch();
         } else {
-            $this->logger->info(sprintf('Read local release list (last update: %s UTC).', gmdate('Y-m-d H:i:s', filectime(Config::getPHPReleaseListPath()))));
+            $this->logger->info(
+                sprintf(
+                    'Read local release list (last update: %s UTC).',
+                    gmdate(
+                        'Y-m-d H:i:s',
+                        filectime(Config::getPHPReleaseListPath())
+                    )
+                )
+            );
             $releases = $releaseList->loadLocalReleaseList();
-            $this->logger->info('You can run `phpbrew update` or `phpbrew known --update` to get a newer release list.');
+            $this->logger->info(
+                'You can run `phpbrew update` or `phpbrew known --update` to get a newer release list.'
+            );
         }
 
         foreach ($releases as $majorVersion => $versions) {
@@ -50,12 +62,17 @@ class KnownCommand extends \CLIFramework\Command
             if (!$this->options->more) {
                 array_splice($versionList, 8);
             }
-            $this->logger->writeln($this->formatter->format("{$majorVersion}: ", 'yellow').wordwrap(implode(', ', $versionList), 80, "\n".str_repeat(' ', 5))
-                .(!$this->options->more ? ' ...' : ''));
+            $this->logger->writeln(
+                $this->formatter->format("{$majorVersion}: ", 'yellow')
+                . wordwrap(implode(', ', $versionList), 80, "\n" . str_repeat(' ', 5))
+                . (!$this->options->more ? ' ...' : '')
+            );
         }
 
         if ($this->options->old) {
-            $this->logger->warn('phpbrew need php 5.3 or above to run. build/switch to versions below 5.3 at your own risk.');
+            $this->logger->warn(
+                'PHPBrew needs PHP 5.3 or above to run. build/switch to versions below 5.3 at your own risk.'
+            );
         }
     }
 }

--- a/src/PhpBrew/Command/ListCommand.php
+++ b/src/PhpBrew/Command/ListCommand.php
@@ -2,10 +2,11 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command;
 use PhpBrew\Config;
 use PhpBrew\VariantParser;
 
-class ListCommand extends \CLIFramework\Command
+class ListCommand extends Command
 {
     public function brief()
     {
@@ -49,8 +50,8 @@ class ListCommand extends \CLIFramework\Command
             }
 
             // TODO: use Build class to get the variants
-            if ($this->options->variants && file_exists($versionPrefix.DIRECTORY_SEPARATOR.'phpbrew.variants')) {
-                $info = unserialize(file_get_contents($versionPrefix.DIRECTORY_SEPARATOR.'phpbrew.variants'));
+            if ($this->options->variants && file_exists($versionPrefix . DIRECTORY_SEPARATOR . 'phpbrew.variants')) {
+                $info = unserialize(file_get_contents($versionPrefix . DIRECTORY_SEPARATOR . 'phpbrew.variants'));
                 echo '    Variants: ';
                 echo wordwrap(VariantParser::revealCommandArguments($info), 75, " \\\n              ");
                 echo "\n";

--- a/src/PhpBrew/Command/ListIniCommand.php
+++ b/src/PhpBrew/Command/ListIniCommand.php
@@ -18,7 +18,7 @@ class ListIniCommand extends Command
             if (strlen($filelist) > 0) {
                 $files = explode(',', $filelist);
                 foreach ($files as $file) {
-                    echo ' - '.trim($file)."\n";
+                    echo ' - ' . trim($file) . "\n";
                 }
             }
         }

--- a/src/PhpBrew/Command/PathCommand.php
+++ b/src/PhpBrew/Command/PathCommand.php
@@ -15,15 +15,38 @@ class PathCommand extends Command
     public function usage()
     {
         return 'phpbrew path ['
-            .implode(', ', array('root', 'home', 'build', 'bin', 'include', 'etc', 'ext', 'ext-src', 'extension-src', 'extension-dir', 'config-scan', 'dist'))
-            .']';
+            . implode(', ', array(
+                'root',
+                'home',
+                'build',
+                'bin',
+                'include',
+                'etc',
+                'ext',
+                'ext-src',
+                'extension-src',
+                'extension-dir',
+                'config-scan',
+                'dist'
+            )) . ']';
     }
 
     public function arguments($args)
     {
         $args->add('type')
             ->validValues(array(
-                'root', 'home', 'build', 'bin', 'include', 'etc', 'ext', 'ext-src', 'extension-src', 'extension-dir', 'config-scan', 'dist',
+                'root',
+                'home',
+                'build',
+                'bin',
+                'include',
+                'etc',
+                'ext',
+                'ext-src',
+                'extension-src',
+                'extension-dir',
+                'config-scan',
+                'dist',
             ));
     }
 
@@ -49,12 +72,12 @@ class PathCommand extends Command
                 echo Config::getCurrentPhpBin();
                 break;
             case 'include':
-                echo Config::getVersionInstallPrefix(Config::getCurrentPhpName()).
-                    DIRECTORY_SEPARATOR.'include';
+                echo Config::getVersionInstallPrefix(Config::getCurrentPhpName()) .
+                    DIRECTORY_SEPARATOR . 'include';
                 break;
             case 'extension-src':
             case 'ext-src':
-                echo Config::getCurrentBuildDir().DIRECTORY_SEPARATOR.'ext';
+                echo Config::getCurrentBuildDir() . DIRECTORY_SEPARATOR . 'ext';
                 break;
             case 'extension-dir':
             case 'ext-dir':
@@ -62,8 +85,8 @@ class PathCommand extends Command
                 echo ini_get('extension_dir');
                 break;
             case 'etc':
-                echo Config::getVersionInstallPrefix(Config::getCurrentPhpName()).
-                    DIRECTORY_SEPARATOR.'etc';
+                echo Config::getVersionInstallPrefix(Config::getCurrentPhpName()) .
+                    DIRECTORY_SEPARATOR . 'etc';
                 break;
         }
     }

--- a/src/PhpBrew/Command/PurgeCommand.php
+++ b/src/PhpBrew/Command/PurgeCommand.php
@@ -3,8 +3,8 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command;
-use PhpBrew\Config;
 use Exception;
+use PhpBrew\Config;
 
 /**
  * @codeCoverageIgnore
@@ -28,6 +28,6 @@ class PurgeCommand extends Command
 
     public function execute($version = null)
     {
-        throw new \Exception('You should not see this, please check if phpbrew bashrc is sourced in your shell.');
+        throw new Exception('You should not see this, please check if phpbrew bashrc is sourced in your shell.');
     }
 }

--- a/src/PhpBrew/Command/RemoveCommand.php
+++ b/src/PhpBrew/Command/RemoveCommand.php
@@ -5,8 +5,9 @@ namespace PhpBrew\Command;
 /*
  * @codeCoverageIgnore
  */
-use Exception;
 use CLIFramework\Command;
+use CLIFramework\Prompter;
+use Exception;
 use PhpBrew\Config;
 use PhpBrew\Utils;
 
@@ -28,9 +29,9 @@ class RemoveCommand extends Command
     {
         $prefix = Config::getVersionInstallPrefix($buildName);
         if (!file_exists($prefix)) {
-            throw new \Exception("$prefix does not exist.");
+            throw new Exception("$prefix does not exist.");
         }
-        $prompter = new \CLIFramework\Prompter();
+        $prompter = new Prompter();
         $answer = $prompter->ask("Are you sure to delete $buildName?", array('Y', 'n'), 'Y');
         if (strtolower($answer) == 'y') {
             Utils::recursive_unlink($prefix, $this->logger);

--- a/src/PhpBrew/Command/SelfUpdateCommand.php
+++ b/src/PhpBrew/Command/SelfUpdateCommand.php
@@ -2,10 +2,11 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command;
 use Exception;
+use GetOptionKit\OptionSpecCollection;
 use PhpBrew\Downloader\DownloadFactory;
 use RuntimeException;
-use CLIFramework\Command;
 
 class SelfUpdateCommand extends Command
 {
@@ -20,7 +21,7 @@ class SelfUpdateCommand extends Command
     }
 
     /**
-     * @param \GetOptionKit\OptionSpecCollection $opts
+     * @param OptionSpecCollection $opts
      */
     public function options($opts)
     {
@@ -41,7 +42,7 @@ class SelfUpdateCommand extends Command
         $script = realpath($argv[0]);
 
         if (!is_writable($script)) {
-            throw new \Exception("$script is not writable.");
+            throw new Exception("$script is not writable.");
         }
 
         // fetch new version phpbrew
@@ -49,8 +50,12 @@ class SelfUpdateCommand extends Command
         $url = "https://raw.githubusercontent.com/phpbrew/phpbrew/$branch/phpbrew";
 
         //download to a tmp file first
-        $downloader = DownloadFactory::getInstance($this->logger, $this->options,
-            array(DownloadFactory::METHOD_CURL, DownloadFactory::METHOD_WGET)); //the phar file is large so we prefer the commands rather than extensions.
+        //the phar file is large so we prefer the commands rather than extensions.
+        $downloader = DownloadFactory::getInstance(
+            $this->logger,
+            $this->options,
+            array(DownloadFactory::METHOD_CURL, DownloadFactory::METHOD_WGET)
+        );
         $tempFile = $downloader->download($url);
 
         if ($tempFile === false) {
@@ -69,7 +74,7 @@ class SelfUpdateCommand extends Command
         }
 
         $this->logger->info('Version updated.');
-        system($script.' init');
-        system($script.' --version');
+        system($script . ' init');
+        system($script . ' --version');
     }
 }

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -2,10 +2,11 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command;
 use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Tasks\FetchReleaseListTask;
 
-class UpdateCommand extends \CLIFramework\Command
+class UpdateCommand extends Command
 {
     public function brief()
     {
@@ -32,7 +33,7 @@ class UpdateCommand extends \CLIFramework\Command
             }
             $versionList = array_keys($versions);
             $this->logger->writeln($this->formatter->format("{$majorVersion}: ", 'yellow')
-                .count($versionList).' releases');
+                . count($versionList) . ' releases');
         }
         $this->logger->info('===> Done');
     }

--- a/src/PhpBrew/Command/VariantsCommand.php
+++ b/src/PhpBrew/Command/VariantsCommand.php
@@ -2,9 +2,10 @@
 
 namespace PhpBrew\Command;
 
+use CLIFramework\Command;
 use PhpBrew\VariantBuilder;
 
-class VariantsCommand extends \CLIFramework\Command
+class VariantsCommand extends Command
 {
     public function brief()
     {
@@ -26,7 +27,7 @@ class VariantsCommand extends \CLIFramework\Command
             $newLine .= $c;
 
             if ($lineX > 68 && $c === ' ') {
-                $newLine .= "\n".$indent;
+                $newLine .= "\n" . $indent;
                 $lineX = 0;
             }
         }
@@ -47,7 +48,7 @@ class VariantsCommand extends \CLIFramework\Command
         echo "Virtual variants: \n";
 
         foreach ($variants->virtualVariants as $name => $subvars) {
-            echo $this->wrapLine("$name: ".implode(', ', $subvars)) , "\n";
+            echo $this->wrapLine("$name: " . implode(', ', $subvars)) , "\n";
         }
 
         echo "\n\n";

--- a/src/PhpBrew/Command/VirtualCommand.php
+++ b/src/PhpBrew/Command/VirtualCommand.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\Command;
 
-use Exception;
 use CLIFramework\Command;
+use Exception;
 
 /**
  * @codeCoverageIgnore
@@ -15,6 +15,10 @@ class VirtualCommand extends Command
      */
     final public function execute()
     {
-        throw new Exception("You should not see this, if you see this, it means you didn't load the ~/.phpbrew/bashrc script, please check if bashrc is sourced in your shell.");
+        throw new Exception(
+            "You should not see this. "
+            . "If you see this, it means you didn't load the ~/.phpbrew/bashrc script. "
+            . "Please check if bashrc is sourced in your shell."
+        );
     }
 }

--- a/src/PhpBrew/Config.php
+++ b/src/PhpBrew/Config.php
@@ -30,24 +30,24 @@ class Config
             return $custom;
         }
         if ($home = getenv('HOME')) {
-            $path = $home.DIRECTORY_SEPARATOR.'.phpbrew';
+            $path = $home . DIRECTORY_SEPARATOR . '.phpbrew';
             if (!file_exists($path)) {
                 mkdir($path, 0755, true);
             }
 
             return $path;
         }
-        throw new \Exception('Environment variable PHPBREW_HOME or HOME is required');
+        throw new Exception('Environment variable PHPBREW_HOME or HOME is required');
     }
 
     public static function setPhpbrewHome($home)
     {
-        putenv('PHPBREW_HOME='.$home);
+        putenv('PHPBREW_HOME=' . $home);
     }
 
     public static function setPhpbrewRoot($root)
     {
-        putenv('PHPBREW_ROOT='.$root);
+        putenv('PHPBREW_ROOT=' . $root);
     }
 
     public static function getRoot()
@@ -60,9 +60,9 @@ class Config
             return $root;
         }
         if ($home = getenv('HOME')) {
-            return $home.DIRECTORY_SEPARATOR.'.phpbrew';
+            return $home . DIRECTORY_SEPARATOR . '.phpbrew';
         }
-        throw new \Exception('Environment variable PHPBREW_ROOT is required');
+        throw new Exception('Environment variable PHPBREW_ROOT is required');
     }
 
     /**
@@ -70,7 +70,7 @@ class Config
      */
     public static function getVariantsDir()
     {
-        return self::getHome().DIRECTORY_SEPARATOR.'variants';
+        return self::getHome() . DIRECTORY_SEPARATOR . 'variants';
     }
 
     /**
@@ -78,7 +78,7 @@ class Config
      */
     public static function getCacheDir()
     {
-        return self::getRoot().DIRECTORY_SEPARATOR.'cache';
+        return self::getRoot() . DIRECTORY_SEPARATOR . 'cache';
     }
 
     /**
@@ -86,22 +86,22 @@ class Config
      */
     public static function getBuildDir()
     {
-        return self::getRoot().DIRECTORY_SEPARATOR.'build';
+        return self::getRoot() . DIRECTORY_SEPARATOR . 'build';
     }
 
     public static function getRegistryDir()
     {
-        return self::getRoot().DIRECTORY_SEPARATOR.'registry';
+        return self::getRoot() . DIRECTORY_SEPARATOR . 'registry';
     }
 
     public static function getCurrentBuildDir()
     {
-        return self::getRoot().DIRECTORY_SEPARATOR.'build'.DIRECTORY_SEPARATOR.self::getCurrentPhpName();
+        return self::getRoot() . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . self::getCurrentPhpName();
     }
 
     public static function getDistFileDir()
     {
-        $dir = self::getRoot().DIRECTORY_SEPARATOR.'distfiles';
+        $dir = self::getRoot() . DIRECTORY_SEPARATOR . 'distfiles';
         if (!file_exists($dir)) {
             mkdir($dir, 0755, true);
         }
@@ -111,7 +111,7 @@ class Config
 
     public static function getTempFileDir()
     {
-        $dir = self::getRoot().DIRECTORY_SEPARATOR.'tmp';
+        $dir = self::getRoot() . DIRECTORY_SEPARATOR . 'tmp';
         if (!file_exists($dir)) {
             mkdir($dir, 0755, true);
         }
@@ -122,7 +122,7 @@ class Config
     public static function getPHPReleaseListPath()
     {
         // Release list from php.net
-        return self::getRoot().DIRECTORY_SEPARATOR.'php-releases.json';
+        return self::getRoot() . DIRECTORY_SEPARATOR . 'php-releases.json';
     }
 
     /**
@@ -136,12 +136,12 @@ class Config
      */
     public static function getInstallPrefix()
     {
-        return self::getRoot().DIRECTORY_SEPARATOR.'php';
+        return self::getRoot() . DIRECTORY_SEPARATOR . 'php';
     }
 
     public static function getVersionInstallPrefix($buildName)
     {
-        return self::getInstallPrefix().DIRECTORY_SEPARATOR.$buildName;
+        return self::getInstallPrefix() . DIRECTORY_SEPARATOR . $buildName;
     }
 
     /**
@@ -153,26 +153,26 @@ class Config
      */
     public static function getVersionEtcPath($buildName)
     {
-        return self::getVersionInstallPrefix($buildName).DIRECTORY_SEPARATOR.'etc';
+        return self::getVersionInstallPrefix($buildName) . DIRECTORY_SEPARATOR . 'etc';
     }
 
     public static function getVersionBinPath($buildName)
     {
-        return self::getVersionInstallPrefix($buildName).DIRECTORY_SEPARATOR.'bin';
+        return self::getVersionInstallPrefix($buildName) . DIRECTORY_SEPARATOR . 'bin';
     }
 
     public static function putPathEnvFor($buildName)
     {
         $root = self::getRoot();
-        $buildDir = $root.DIRECTORY_SEPARATOR.'php'.DIRECTORY_SEPARATOR.$buildName;
+        $buildDir = $root . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR . $buildName;
 
         // re-build path
         $paths = explode(PATH_SEPARATOR, getenv('PATH'));
         $paths = array_filter($paths, function ($p) use ($root) {
             return strpos($p, $root) === false;
         });
-        array_unshift($paths, $buildDir.DIRECTORY_SEPARATOR.'bin');
-        putenv('PATH='.implode(PATH_SEPARATOR, $paths));
+        array_unshift($paths, $buildDir . DIRECTORY_SEPARATOR . 'bin');
+        putenv('PATH=' . implode(PATH_SEPARATOR, $paths));
     }
 
     /**
@@ -183,23 +183,31 @@ class Config
     public static function getInstalledPhpVersions()
     {
         $versions = array();
-        $path = self::getRoot().DIRECTORY_SEPARATOR.'php';
+        $path = self::getRoot() . DIRECTORY_SEPARATOR . 'php';
 
         if (!file_exists($path)) {
-            throw new \Exception("$path doesn't exist.");
+            throw new Exception("$path doesn't exist.");
         }
         if ($fp = opendir($path)) {
             while (($item = readdir($fp)) !== false) {
                 if ($item == '.' || $item == '..') {
                     continue;
                 }
-                if (file_exists($path.DIRECTORY_SEPARATOR.$item.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'php')) {
+
+                if (
+                    file_exists(
+                        $path
+                        . DIRECTORY_SEPARATOR . $item
+                        . DIRECTORY_SEPARATOR . 'bin'
+                        . DIRECTORY_SEPARATOR . 'php'
+                    )
+                ) {
                     $versions[] = $item;
                 }
             }
             closedir($fp);
         } else {
-            throw new \Exception('opendir failed');
+            throw new Exception('opendir failed');
         }
         rsort($versions);
 
@@ -208,12 +216,12 @@ class Config
 
     public static function getCurrentPhpConfigBin()
     {
-        return self::getCurrentPhpDir().DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'php-config';
+        return self::getCurrentPhpDir() . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'php-config';
     }
 
     public static function getCurrentPhpizeBin()
     {
-        return self::getCurrentPhpDir().DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'phpize';
+        return self::getCurrentPhpDir() . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'phpize';
     }
 
     /**
@@ -221,16 +229,16 @@ class Config
      */
     public static function getCurrentPhpConfigScanPath($home = false)
     {
-        return self::getCurrentPhpDir($home).DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'db';
+        return self::getCurrentPhpDir($home) . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'db';
     }
 
     public static function getCurrentPhpDir($home = false)
     {
         if ($home) {
-            return self::getHome().DIRECTORY_SEPARATOR.'php'.DIRECTORY_SEPARATOR.self::getCurrentPhpName();
+            return self::getHome() . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR . self::getCurrentPhpName();
         }
 
-        return self::getRoot().DIRECTORY_SEPARATOR.'php'.DIRECTORY_SEPARATOR.self::getCurrentPhpName();
+        return self::getRoot() . DIRECTORY_SEPARATOR . 'php' . DIRECTORY_SEPARATOR . self::getCurrentPhpName();
     }
 
     // XXX: needs to be removed.
@@ -242,7 +250,7 @@ class Config
     // XXX: needs to be removed.
     public static function setPhpVersion($phpVersion)
     {
-        self::$currentPhpVersion = 'php-'.$phpVersion;
+        self::$currentPhpVersion = 'php-' . $phpVersion;
     }
 
     /**
@@ -272,7 +280,7 @@ class Config
 
     public static function getConfig()
     {
-        $configFile = self::getRoot().DIRECTORY_SEPARATOR.'config.yaml';
+        $configFile = self::getRoot() . DIRECTORY_SEPARATOR . 'config.yaml';
         if (!file_exists($configFile)) {
             return array();
         }
@@ -282,7 +290,7 @@ class Config
 
     public static function getProxyConfig()
     {
-        $configFile = self::getRoot().DIRECTORY_SEPARATOR.'proxy.yaml';
+        $configFile = self::getRoot() . DIRECTORY_SEPARATOR . 'proxy.yaml';
         if (!file_exists($configFile)) {
             return false;
         }
@@ -312,8 +320,8 @@ class Config
         $dirs[] = self::getRegistryDir();
         if ($buildName) {
             $dirs[] = self::getCurrentBuildDir($buildName);
-            $dirs[] = self::getCurrentBuildDir($buildName).DIRECTORY_SEPARATOR.'ext';
-            $dirs[] = self::getInstallPrefix($buildName).DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'db';
+            $dirs[] = self::getCurrentBuildDir($buildName) . DIRECTORY_SEPARATOR . 'ext';
+            $dirs[] = self::getInstallPrefix($buildName) . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'db';
         }
         foreach ($dirs as $dir) {
             if (!file_exists($dir)) {
@@ -330,7 +338,7 @@ class Config
         $write[] = self::getRegistryDir();
         foreach ($write as $dir) {
             if (!is_writable($dir)) {
-                throw new \Exception("$dir is not writable, please fix the folder permissions.");
+                throw new Exception("$dir is not writable, please fix the folder permissions.");
             }
         }
     }

--- a/src/PhpBrew/Console.php
+++ b/src/PhpBrew/Console.php
@@ -2,13 +2,13 @@
 
 namespace PhpBrew;
 
-use CLIFramework\Application;
-use CLIFramework\Exception\CommandNotFoundException;
-use CLIFramework\Exception\CommandArgumentNotEnoughException;
-use CLIFramework\ExceptionPrinter\ProductionExceptionPrinter;
-use CLIFramework\ExceptionPrinter\DevelopmentExceptionPrinter;
-use Exception;
 use BadMethodCallException;
+use CLIFramework\Application;
+use CLIFramework\Exception\CommandArgumentNotEnoughException;
+use CLIFramework\Exception\CommandNotFoundException;
+use CLIFramework\ExceptionPrinter\DevelopmentExceptionPrinter;
+use CLIFramework\ExceptionPrinter\ProductionExceptionPrinter;
+use Exception;
 use PhpBrew\Exception\SystemCommandException;
 
 class Console extends Application
@@ -116,23 +116,26 @@ class Console extends Application
             $this->logger->error($e->getMessage());
             $this->logger->writeln('Expected argument prototypes:');
             foreach ($e->getCommand()->getAllCommandPrototype() as $p) {
-                $this->logger->writeln("\t".$p);
+                $this->logger->writeln("\t" . $p);
             }
             $this->logger->newline();
         } catch (CommandNotFoundException $e) {
-            $this->logger->error($e->getMessage().' available commands are: '.implode(', ', $e->getCommand()->getVisibleCommandList()));
+            $this->logger->error(
+                $e->getMessage()
+                . ' available commands are: '
+                . implode(', ', $e->getCommand()->getVisibleCommandList())
+            );
             $this->logger->newline();
 
             $this->logger->writeln('Please try the command below to see the details:');
             $this->logger->newline();
-            $this->logger->writeln("\t".$this->getProgramName().' help ');
+            $this->logger->writeln("\t" . $this->getProgramName() . ' help ');
             $this->logger->newline();
         } catch (SystemCommandException $e) {
-
             // Todo: detect $lastline for library missing here...
 
             $buildLog = $e->getLogFile();
-            $this->logger->error('Error: '.trim($e->getMessage()));
+            $this->logger->error('Error: ' . trim($e->getMessage()));
 
             if (file_exists($buildLog)) {
                 $this->logger->error('The last 5 lines in the log file:');

--- a/src/PhpBrew/Distribution/DistributionUrlPolicy.php
+++ b/src/PhpBrew/Distribution/DistributionUrlPolicy.php
@@ -14,10 +14,10 @@ class DistributionUrlPolicy
     {
         //the historic releases only available at museum
         if ($museum || $this->isDistributedAtMuseum($version)) {
-            return 'https://museum.php.net/php5/'.$filename;
+            return 'https://museum.php.net/php5/' . $filename;
         }
 
-        return 'https://www.php.net/distributions/'.$filename;
+        return 'https://www.php.net/distributions/' . $filename;
     }
 
     private function isDistributedAtMuseum($version)

--- a/src/PhpBrew/Downloader/BaseDownloader.php
+++ b/src/PhpBrew/Downloader/BaseDownloader.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: xiami
- * Date: 2015/12/30
- * Time: 11:55.
- */
 
 namespace PhpBrew\Downloader;
 
 use CLIFramework\Logger;
 use GetOptionKit\OptionResult;
+use RuntimeException;
 
 abstract class BaseDownloader
 {
@@ -29,14 +24,14 @@ abstract class BaseDownloader
      *
      * @return bool|string if download successfully, return target file path, otherwise return false.
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public function download($url, $targetFilePath = null)
     {
         if (empty($targetFilePath)) {
             $targetFilePath = tempnam(sys_get_temp_dir(), 'phpbrew_');
             if ($targetFilePath === false) {
-                throw new \RuntimeException('Fail to create temp file');
+                throw new RuntimeException('Fail to create temp file');
             }
         } else {
             if (!file_exists($targetFilePath)) {
@@ -44,7 +39,7 @@ abstract class BaseDownloader
             }
         }
         if (!is_writable($targetFilePath)) {
-            throw new \RuntimeException("Target path ($targetFilePath) is not writable!");
+            throw new RuntimeException("Target path ($targetFilePath) is not writable!");
         }
         if ($this->process($url, $targetFilePath)) {
             $this->logger->debug("$url => $targetFilePath");
@@ -58,7 +53,7 @@ abstract class BaseDownloader
     /**
      * fetch the remote content.
      *
-     * @param $url the url to be downloaded
+     * @param string $url The url to be downloaded
      *
      * @return bool|string return content if download successfully, otherwise false is returned
      *

--- a/src/PhpBrew/Downloader/CurlCommandDownloader.php
+++ b/src/PhpBrew/Downloader/CurlCommandDownloader.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: xiami
- * Date: 2015/12/30
- * Time: 11:57.
- */
 
 namespace PhpBrew\Downloader;
 

--- a/src/PhpBrew/Downloader/DownloadFactory.php
+++ b/src/PhpBrew/Downloader/DownloadFactory.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Downloader Factory.
- *
- * @date 2015/12/30
- * @author: xiami, yoanlin
- */
 
 namespace PhpBrew\Downloader;
 
@@ -74,7 +68,8 @@ class DownloadFactory
             $downloader = array_keys(self::$availableDownloaders);
         }
 
-        //if --downloader presents, we will use it as the first choice, even if the caller specific downloader by alias/array
+        //if --downloader presents, we will use it as the first choice,
+        //even if the caller specific downloader by alias/array
         if ($options->has('downloader')) {
             $logger->info("Found --downloader option, try to use {$options->downloader} as default downloader.");
             $downloader = array_merge(array($options->downloader), $downloader);
@@ -98,7 +93,10 @@ class DownloadFactory
             ->valueName('Proxy host[:port]');
         $opts->add('http-proxy-auth:', 'HTTP proxy authentication')
             ->valueName('Proxy username:password');
-        $opts->add('connect-timeout:', 'Connection timeout')
+        $opts->add(
+            'connect-timeout:',
+            'Connection timeout'
+        )
             ->valueName('Timeout in seconds');
 
         return $opts;

--- a/src/PhpBrew/Downloader/PhpCurlDownloader.php
+++ b/src/PhpBrew/Downloader/PhpCurlDownloader.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: xiami
- * Date: 2015/12/30
- * Time: 11:59.
- */
 
 namespace PhpBrew\Downloader;
 

--- a/src/PhpBrew/Downloader/PhpStreamDownloader.php
+++ b/src/PhpBrew/Downloader/PhpStreamDownloader.php
@@ -1,14 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: xiami
- * Date: 2015/12/30
- * Time: 12:05.
- */
 
 namespace PhpBrew\Downloader;
-
-use RuntimeException;
 
 class PhpStreamDownloader extends BaseDownloader
 {

--- a/src/PhpBrew/Downloader/WgetCommandDownloader.php
+++ b/src/PhpBrew/Downloader/WgetCommandDownloader.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: xiami
- * Date: 2015/12/30
- * Time: 12:02.
- */
 
 namespace PhpBrew\Downloader;
 
 use PhpBrew\Utils;
+use RuntimeException;
 
 class WgetCommandDownloader extends BaseDownloader
 {
@@ -24,7 +19,7 @@ class WgetCommandDownloader extends BaseDownloader
      *
      * @return bool|string
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     protected function process($url, $targetFilePath)
     {
@@ -33,7 +28,11 @@ class WgetCommandDownloader extends BaseDownloader
         $proxy = '';
         if (!empty($this->options->{'http-proxy'})) {
             if (!empty($this->options->{'http-proxy-auth'})) {
-                $proxy = sprintf('-e use_proxy=on -e http_proxy=%s@%s', $this->options->{'http-proxy-auth'}, $this->options->{'http-proxy'});
+                $proxy = sprintf(
+                    '-e use_proxy=on -e http_proxy=%s@%s',
+                    $this->options->{'http-proxy-auth'},
+                    $this->options->{'http-proxy'}
+                );
             } else {
                 $proxy = sprintf('-e use_proxy=on -e http_proxy=%s', $this->options->{'http-proxy'});
             }
@@ -41,8 +40,14 @@ class WgetCommandDownloader extends BaseDownloader
 
         $quiet = $this->logger->isQuiet() ? '--quiet' : '';
         $continue = $this->enableContinueAt || $this->options->{'continue'} ? '-c' : '';
-        Utils::system(sprintf('wget --no-check-certificate %s %s %s -N -O %s %s',
-            $continue, $quiet, $proxy, escapeshellarg($targetFilePath), escapeshellarg($url)));
+        Utils::system(sprintf(
+            'wget --no-check-certificate %s %s %s -N -O %s %s',
+            $continue,
+            $quiet,
+            $proxy,
+            escapeshellarg($targetFilePath),
+            escapeshellarg($url)
+        ));
 
         return true;
     }

--- a/src/PhpBrew/Exception/SystemCommandException.php
+++ b/src/PhpBrew/Exception/SystemCommandException.php
@@ -2,9 +2,8 @@
 
 namespace PhpBrew\Exception;
 
-use RuntimeException;
-use PhpBrew\Build;
 use PhpBrew\Buildable;
+use RuntimeException;
 
 class SystemCommandException extends RuntimeException
 {

--- a/src/PhpBrew/Extension/Extension.php
+++ b/src/PhpBrew/Extension/Extension.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\Extension;
 
-use PhpBrew\Config;
 use PhpBrew\Buildable;
+use PhpBrew\Config;
 
 class Extension implements Buildable
 {
@@ -87,7 +87,7 @@ class Extension implements Buildable
             return $this->sharedLibraryName;
         }
 
-        return strtolower($this->extensionName).'.so'; // for windows it might be a DLL.
+        return strtolower($this->extensionName) . '.so'; // for windows it might be a DLL.
     }
 
     public function setExtensionName($name)
@@ -116,19 +116,19 @@ class Extension implements Buildable
 
     public function getConfigM4Path()
     {
-        return $this->sourceDirectory.DIRECTORY_SEPARATOR.$this->configM4File;
+        return $this->sourceDirectory . DIRECTORY_SEPARATOR . $this->configM4File;
     }
 
     public function findConfigM4File($dir)
     {
-        $configM4Path = $dir.DIRECTORY_SEPARATOR.'config.m4';
+        $configM4Path = $dir . DIRECTORY_SEPARATOR . 'config.m4';
         if (file_exists($configM4Path)) {
             return 'config.m4';
         }
 
         for ($i = 0; $i < 10; ++$i) {
             $filename = "config{$i}.m4";
-            $configM4Path = $dir.DIRECTORY_SEPARATOR.$filename;
+            $configM4Path = $dir . DIRECTORY_SEPARATOR . $filename;
             if (file_exists($configM4Path)) {
                 return $filename;
             }
@@ -137,7 +137,7 @@ class Extension implements Buildable
 
     public function isBuildable()
     {
-        return file_exists($this->sourceDirectory.DIRECTORY_SEPARATOR.'Makefile');
+        return file_exists($this->sourceDirectory . DIRECTORY_SEPARATOR . 'Makefile');
     }
 
     public function getSourceDirectory()
@@ -147,17 +147,17 @@ class Extension implements Buildable
 
     public function getBuildLogPath()
     {
-        return $this->sourceDirectory.DIRECTORY_SEPARATOR.'build.log';
+        return $this->sourceDirectory . DIRECTORY_SEPARATOR . 'build.log';
     }
 
     public function getSharedLibraryPath()
     {
-        return ini_get('extension_dir').DIRECTORY_SEPARATOR.$this->getSharedLibraryName();
+        return ini_get('extension_dir') . DIRECTORY_SEPARATOR . $this->getSharedLibraryName();
     }
 
     public function getConfigFilePath()
     {
-        return Config::getCurrentPhpConfigScanPath().'/'.$this->getName().'.ini';
+        return Config::getCurrentPhpConfigScanPath() . '/' . $this->getName() . '.ini';
     }
 
     /**

--- a/src/PhpBrew/Extension/ExtensionDownloader.php
+++ b/src/PhpBrew/Extension/ExtensionDownloader.php
@@ -2,12 +2,13 @@
 
 namespace PhpBrew\Extension;
 
+use CLIFramework\Logger;
+use Exception;
+use GetOptionKit\OptionResult;
 use PhpBrew\Config;
 use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Extension\Provider\Provider;
 use PhpBrew\Utils;
-use CLIFramework\Logger;
-use GetOptionKit\OptionResult;
 
 class ExtensionDownloader
 {
@@ -24,7 +25,7 @@ class ExtensionDownloader
     public function buildGithubTarballUrl($owner, $repos, $version = 'stable')
     {
         if (empty($owner) || empty($repos)) {
-            throw new \Exception('Username or Repository invalid.');
+            throw new Exception('Username or Repository invalid.');
         }
 
         return sprintf('https://%s/%s/%s/archive/%s.tar.gz', $this->githubSite, $owner, $repos, $version);
@@ -35,22 +36,24 @@ class ExtensionDownloader
         $url = $provider->buildPackageDownloadUrl($version);
         $basename = $provider->resolveDownloadFileName($version);
         $distDir = Config::getDistFileDir();
-        $targetFilePath = $distDir.DIRECTORY_SEPARATOR.$basename;
+        $targetFilePath = $distDir . DIRECTORY_SEPARATOR . $basename;
         DownloadFactory::getInstance($this->logger, $this->options)->download($url, $targetFilePath);
         $info = pathinfo($basename);
 
-        $currentPhpExtensionDirectory = Config::getBuildDir().'/'.Config::getCurrentPhpName().'/ext';
+        $currentPhpExtensionDirectory = Config::getBuildDir() . '/' . Config::getCurrentPhpName() . '/ext';
 
         // tar -C ~/.phpbrew/build/php-5.5.8/ext -xvf ~/.phpbrew/distfiles/memcache-2.2.7.tgz
-        $extensionDir = $currentPhpExtensionDirectory.DIRECTORY_SEPARATOR.$provider->getPackageName();
+        $extensionDir = $currentPhpExtensionDirectory . DIRECTORY_SEPARATOR . $provider->getPackageName();
         if (!file_exists($extensionDir)) {
             mkdir($extensionDir, 0755, true);
         }
 
         $this->logger->info("===> Extracting to $currentPhpExtensionDirectory...");
 
-        $cmds = array_merge($provider->extractPackageCommands($currentPhpExtensionDirectory, $targetFilePath),
-            $provider->postExtractPackageCommands($currentPhpExtensionDirectory, $targetFilePath));
+        $cmds = array_merge(
+            $provider->extractPackageCommands($currentPhpExtensionDirectory, $targetFilePath),
+            $provider->postExtractPackageCommands($currentPhpExtensionDirectory, $targetFilePath)
+        );
 
         foreach ($cmds as $cmd) {
             $this->logger->debug($cmd);
@@ -71,11 +74,11 @@ class ExtensionDownloader
 
     public function renameSourceDirectory(Extension $ext)
     {
-        $currentPhpExtensionDirectory = Config::getBuildDir().'/'.Config::getCurrentPhpName().'/ext';
+        $currentPhpExtensionDirectory = Config::getBuildDir() . '/' . Config::getCurrentPhpName() . '/ext';
         $extName = $ext->getExtensionName();
         $name = $ext->getName();
-        $extensionDir = $currentPhpExtensionDirectory.DIRECTORY_SEPARATOR.$extName;
-        $extensionExtractDir = $currentPhpExtensionDirectory.DIRECTORY_SEPARATOR.$name;
+        $extensionDir = $currentPhpExtensionDirectory . DIRECTORY_SEPARATOR . $extName;
+        $extensionExtractDir = $currentPhpExtensionDirectory . DIRECTORY_SEPARATOR . $name;
 
         if ($name != $extName) {
             $this->logger->info("===> Rename source directory to $extensionDir...");

--- a/src/PhpBrew/Extension/ExtensionFactory.php
+++ b/src/PhpBrew/Extension/ExtensionFactory.php
@@ -2,11 +2,11 @@
 
 namespace PhpBrew\Extension;
 
-use PhpBrew\Config;
-use PEARX\PackageXml\Parser as PackageXmlParser;
 use Exception;
-use RecursiveIteratorIterator;
+use PEARX\PackageXml\Parser as PackageXmlParser;
+use PhpBrew\Config;
 use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * This factory class handles the extension information.
@@ -20,12 +20,12 @@ class ExtensionFactory
     public static function configM4Exists($extensionDir)
     {
         $files = array();
-        $configM4Path = $extensionDir.DIRECTORY_SEPARATOR.'config.m4';
+        $configM4Path = $extensionDir . DIRECTORY_SEPARATOR . 'config.m4';
         if (file_exists($configM4Path)) {
             $files[] = $configM4Path;
         }
         for ($i = 0; $i < 10; ++$i) {
-            $configM4Path = $extensionDir.DIRECTORY_SEPARATOR."config{$i}.m4";
+            $configM4Path = $extensionDir . DIRECTORY_SEPARATOR . "config{$i}.m4";
             if (file_exists($configM4Path)) {
                 $files[] = $configM4Path;
             }
@@ -36,7 +36,7 @@ class ExtensionFactory
 
     public static function createFromDirectory($packageName, $extensionDir)
     {
-        $packageXmlPath = $extensionDir.DIRECTORY_SEPARATOR.'package.xml';
+        $packageXmlPath = $extensionDir . DIRECTORY_SEPARATOR . 'package.xml';
 
         // If the package.xml exists, we may get the configureoptions for configuring the Makefile
         // and use the provided extension name to enable the extension.
@@ -84,7 +84,10 @@ class ExtensionFactory
     {
         if ($fallback) {
             // Always push the PHP source directory to the end of the list for the fallback.
-            $lookupDirs[] = Config::getBuildDir().DIRECTORY_SEPARATOR.Config::getCurrentPhpName().DIRECTORY_SEPARATOR.'ext'.DIRECTORY_SEPARATOR.$packageName;
+            $lookupDirs[] = Config::getBuildDir()
+                . DIRECTORY_SEPARATOR . Config::getCurrentPhpName()
+                . DIRECTORY_SEPARATOR . 'ext'
+                . DIRECTORY_SEPARATOR . $packageName;
         }
 
         foreach ($lookupDirs as $lookupDir) {
@@ -122,7 +125,7 @@ class ExtensionFactory
     {
         if ($fallback) {
             // Always push the PHP source directory to the end of the list for the fallback.
-            $lookupDirectories[] = Config::getBuildDir().'/'.Config::getCurrentPhpName().'/ext';
+            $lookupDirectories[] = Config::getBuildDir() . '/' . Config::getCurrentPhpName() . '/ext';
         }
 
         foreach ($lookupDirectories as $lookupDir) {
@@ -130,7 +133,7 @@ class ExtensionFactory
                 continue;
             }
 
-            $extensionDir = $lookupDir.DIRECTORY_SEPARATOR.$packageName;
+            $extensionDir = $lookupDir . DIRECTORY_SEPARATOR . $packageName;
             if ($ext = self::createFromDirectory($packageName, $extensionDir)) {
                 return $ext;
             }
@@ -148,7 +151,8 @@ class ExtensionFactory
         $m4 = file_get_contents($m4Path);
 
         // PHP_NEW_EXTENSION(extname, sources [, shared [, sapi_class [, extra-cflags [, cxx [, zend_ext]]]]])
-        if (preg_match('/PHP_NEW_EXTENSION \( \s* 
+        if (
+            preg_match('/PHP_NEW_EXTENSION \( \s* 
                 \[?
                     (\w+)   # The extension name
                 \]?
@@ -175,11 +179,12 @@ class ExtensionFactory
                         )?
                     )?
                 )?
-                /x', $m4, $matches)) {
+                /x', $m4, $matches)
+        ) {
             $fullmatched = array_shift($matches);
             $ext = new M4Extension($packageName);
             $ext->setExtensionName($matches[0]);
-            $ext->setSharedLibraryName($matches[0].'.so');
+            $ext->setSharedLibraryName($matches[0] . '.so');
             if (isset($matches[6]) && strpos($matches[6], 'yes') !== false) {
                 $ext->setZend(true);
             }
@@ -189,7 +194,8 @@ class ExtensionFactory
             PHP_ARG_ENABLE(calendar,whether to enable calendar conversion support,
             [  --enable-calendar       Enable support for calendar conversion])
             */
-            if (preg_match_all('/
+            if (
+                preg_match_all('/
                 PHP_ARG_ENABLE\(
                     \s*([^,]*)
                     (?:
@@ -207,13 +213,14 @@ class ExtensionFactory
                                 \s* 
                             \]
                         )?
-                    )?/x', $m4, $allMatches)) {
+                    )?/x', $m4, $allMatches)
+            ) {
                 for ($i = 0; $i < count($allMatches[0]); ++$i) {
                     $name = $allMatches[1][$i];
                     $desc = $allMatches[2][$i];
                     $option = $allMatches[3][$i];
                     $optionDesc = $allMatches[4][$i];
-                    $ext->addConfigureOption(new ConfigureOption($option ?: '--enable-'.$name, $desc ?: $optionDesc));
+                    $ext->addConfigureOption(new ConfigureOption($option ?: '--enable-' . $name, $desc ?: $optionDesc));
                 }
             }
 
@@ -230,7 +237,8 @@ class ExtensionFactory
                 --with-yaml[[=DIR]]
                 --with-mysql-sock[=SOCKPATH]
             */
-            if (preg_match_all('/
+            if (
+                preg_match_all('/
                 PHP_ARG_WITH\(
                     \s*
 
@@ -275,7 +283,8 @@ class ExtensionFactory
                                 )?
                             )?
                         )?
-                    )?/x', $m4, $allMatches)) {
+                    )?/x', $m4, $allMatches)
+            ) {
                 // Parsing the M4 statement:
                 //
                 //   dnl PHP_ARG_WITH(arg-name, check message, help text[, default-val[, extension-or-not]])
@@ -290,7 +299,12 @@ class ExtensionFactory
 
                     $defaultValue = $allMatches[6][$i];
 
-                    $opt = new ConfigureOption(($option ?: '--with-'.$name), ($desc ?: $optionDesc), $optionValueHint);
+                    $opt = new ConfigureOption(
+                        ($option ?: '--with-' . $name),
+                        ($desc ?: $optionDesc),
+                        $optionValueHint
+                    );
+
                     if ($defaultValue) {
                         $opt->setDefaultValue($opt);
                     }
@@ -300,7 +314,7 @@ class ExtensionFactory
 
             return $ext;
         } else {
-            throw new \Exception("Can not parse config.m4: $m4Path");
+            throw new Exception("Can not parse config.m4: $m4Path");
         }
     }
 
@@ -320,7 +334,7 @@ class ExtensionFactory
             $sourceDirectory = dirname($packageXmlPath);
             $m4dir = dirname($m4path);
             if ($m4dir != '.') {
-                $sourceDirectory .= DIRECTORY_SEPARATOR.$m4dir;
+                $sourceDirectory .= DIRECTORY_SEPARATOR . $m4dir;
             }
             $ext->setSourceDirectory($sourceDirectory);
         } else {

--- a/src/PhpBrew/Extension/ExtensionInstaller.php
+++ b/src/PhpBrew/Extension/ExtensionInstaller.php
@@ -3,10 +3,10 @@
 namespace PhpBrew\Extension;
 
 use CLIFramework\Logger;
-use PhpBrew\Config;
-use PhpBrew\Utils;
-use PhpBrew\Tasks\MakeTask;
 use GetOptionKit\OptionResult;
+use PhpBrew\Config;
+use PhpBrew\Tasks\MakeTask;
+use PhpBrew\Utils;
 
 class ExtensionInstaller
 {
@@ -17,14 +17,14 @@ class ExtensionInstaller
     public function __construct(Logger $logger, OptionResult $options = null)
     {
         $this->logger = $logger;
-        $this->options = $options ?: new \GetOptionKit\OptionResult();
+        $this->options = $options ?: new OptionResult();
     }
 
     public function install(Extension $ext, array $configureOptions = array())
     {
         $sourceDir = $ext->getSourceDirectory();
         $pwd = getcwd();
-        $buildLogPath = $sourceDir.DIRECTORY_SEPARATOR.'build.log';
+        $buildLogPath = $sourceDir . DIRECTORY_SEPARATOR . 'build.log';
         $make = new MakeTask($this->logger, $this->options);
 
         $make->setBuildLogPath($buildLogPath);
@@ -40,8 +40,8 @@ class ExtensionInstaller
             $clean->clean($ext);
         }
 
-        if ($ext->getConfigM4File() !== 'config.m4' && !file_exists($sourceDir.DIRECTORY_SEPARATOR.'config.m4')) {
-            symlink($ext->getConfigM4File(), $sourceDir.DIRECTORY_SEPARATOR.'config.m4');
+        if ($ext->getConfigM4File() !== 'config.m4' && !file_exists($sourceDir . DIRECTORY_SEPARATOR . 'config.m4')) {
+            symlink($ext->getConfigM4File(), $sourceDir . DIRECTORY_SEPARATOR . 'config.m4');
         }
 
         // If the php version is specified, we should get phpize with the correct version.
@@ -58,11 +58,11 @@ class ExtensionInstaller
         $phpConfig = Config::getCurrentPhpConfigBin();
         if (file_exists($phpConfig)) {
             $this->logger->debug("Appending argument: --with-php-config=$phpConfig");
-            $escapeOptions[] = '--with-php-config='.$phpConfig;
+            $escapeOptions[] = '--with-php-config=' . $phpConfig;
         }
 
         // Utils::system('./configure ' . join(' ', $escapeOptions) . ' >> build.log 2>&1');
-        $cmd = './configure '.implode(' ', $escapeOptions);
+        $cmd = './configure ' . implode(' ', $escapeOptions);
         if (!$this->logger->isDebug()) {
             $cmd .= " >> $buildLogPath 2>&1";
         }
@@ -86,7 +86,7 @@ class ExtensionInstaller
         }
 
         // TODO: use getSharedLibraryPath()
-        $this->logger->debug('Installed extension library: '.$ext->getSharedLibraryPath());
+        $this->logger->debug('Installed extension library: ' . $ext->getSharedLibraryPath());
 
         // Try to find the installed path by pattern
         // Installing shared extensions: /Users/c9s/.phpbrew/php/php-5.4.10/lib/php/extensions/debug-non-zts-20100525/

--- a/src/PhpBrew/Extension/ExtensionManager.php
+++ b/src/PhpBrew/Extension/ExtensionManager.php
@@ -2,11 +2,11 @@
 
 namespace PhpBrew\Extension;
 
-use Exception;
 use CLIFramework\Logger;
-use PhpBrew\Utils;
+use Exception;
 use PhpBrew\Config;
 use PhpBrew\Tasks\MakeTask;
+use PhpBrew\Utils;
 
 class ExtensionManager
 {
@@ -32,9 +32,9 @@ class ExtensionManager
     public function purgeExtension(Extension $ext)
     {
         if ($sourceDir = $ext->getSourceDirectory()) {
-            $currentPhpExtensionDirectory = Config::getBuildDir().'/'.Config::getCurrentPhpName().'/ext';
+            $currentPhpExtensionDirectory = Config::getBuildDir() . '/' . Config::getCurrentPhpName() . '/ext';
             $extName = $ext->getExtensionName();
-            $extensionDir = $currentPhpExtensionDirectory.DIRECTORY_SEPARATOR.$extName;
+            $extensionDir = $currentPhpExtensionDirectory . DIRECTORY_SEPARATOR . $extName;
             if (file_exists($extensionDir)) {
                 Utils::system("rm -rvf $extensionDir");
             }
@@ -68,7 +68,7 @@ class ExtensionManager
         $name = $ext->getName();
 
         if (!file_exists($sourceDir)) {
-            throw new \Exception("Source directory $sourceDir does not exist.");
+            throw new Exception("Source directory $sourceDir does not exist.");
         }
 
         // Install local extension
@@ -88,7 +88,7 @@ class ExtensionManager
     public function createExtensionConfig(Extension $ext)
     {
         $sourceDir = $ext->getSourceDirectory();
-        $ini = $ext->getConfigFilePath().'.disabled';
+        $ini = $ext->getConfigFilePath() . '.disabled';
         $this->logger->info("===> Creating config file {$ini}");
 
         if (!file_exists(dirname($ini))) {
@@ -154,16 +154,17 @@ class ExtensionManager
         $name = $ext->getExtensionName();
         $this->logger->info("===> Enabling extension $name");
         $enabled_file = $ext->getConfigFilePath();
-        $disabled_file = $enabled_file.'.disabled';
+        $disabled_file = $enabled_file . '.disabled';
         if (file_exists($enabled_file) && ($ext->isLoaded() && !$this->hasConflicts($ext))) {
             $this->logger->info("[*] {$name} extension is already enabled.");
 
             return true;
         }
 
-        if (!file_exists($disabled_file)
+        if (
+            !file_exists($disabled_file)
             && !(file_exists($ext->getSharedLibraryPath())
-                && $this->createExtensionConfig($ext))
+            && $this->createExtensionConfig($ext))
         ) {
             $this->logger->info("{$name} extension is not installed. Suggestions:");
             $this->logger->info("\t\$ phpbrew ext install {$name}");
@@ -193,7 +194,7 @@ class ExtensionManager
     {
         $name = $ext->getExtensionName();
         $enabled_file = $ext->getConfigFilePath();
-        $disabled_file = $enabled_file.'.disabled';
+        $disabled_file = $enabled_file . '.disabled';
 
         if (file_exists($disabled_file)) {
             $this->logger->info("[ ] {$name} extension is already disabled.");
@@ -221,7 +222,7 @@ class ExtensionManager
         $name = $ext->getName();
         if (isset($this->conflicts[$name])) {
             $conflicts = $this->conflicts[$name];
-            $this->logger->info('===> Applying conflicts resolution ('.implode(', ', $conflicts).'):');
+            $this->logger->info('===> Applying conflicts resolution (' . implode(', ', $conflicts) . '):');
             foreach ($conflicts as $extensionName) {
                 $ext = ExtensionFactory::lookup($extensionName);
                 $this->disableExtension($ext);

--- a/src/PhpBrew/Extension/PeclExtension.php
+++ b/src/PhpBrew/Extension/PeclExtension.php
@@ -19,13 +19,13 @@ class PeclExtension extends Extension
 
         if ($n = strtolower($pkg->getProvidesExtension())) {
             $this->setExtensionName($n);
-            $this->setSharedLibraryName($n.'.so');
+            $this->setSharedLibraryName($n . '.so');
         }
 
         if ($options = $pkg->getConfigureOptions()) {
             $this->configureOptions = array();
             foreach ($options as $option) {
-                $this->addConfigureOption(new ConfigureOption('--'.$option->name, $option->prompt, $option->default));
+                $this->addConfigureOption(new ConfigureOption('--' . $option->name, $option->prompt, $option->default));
             }
         }
     }

--- a/src/PhpBrew/Extension/Provider/BitbucketProvider.php
+++ b/src/PhpBrew/Extension/Provider/BitbucketProvider.php
@@ -2,6 +2,8 @@
 
 namespace PhpBrew\Extension\Provider;
 
+use Exception;
+
 class BitbucketProvider implements Provider
 {
     public $site = 'bitbucket.org';
@@ -18,10 +20,16 @@ class BitbucketProvider implements Provider
     public function buildPackageDownloadUrl($version = 'stable')
     {
         if (($this->getOwner() == null) || ($this->getRepository() == null)) {
-            throw new \Exception('Username or Repository invalid.');
+            throw new Exception('Username or Repository invalid.');
         }
 
-        return sprintf('https://%s/%s/%s/get/%s.tar.gz', $this->site, $this->getOwner(), $this->getRepository(), $version);
+        return sprintf(
+            'https://%s/%s/%s/get/%s.tar.gz',
+            $this->site,
+            $this->getOwner(),
+            $this->getRepository(),
+            $version
+        );
     }
 
     public function getOwner()
@@ -119,8 +127,13 @@ class BitbucketProvider implements Provider
 
     public function postExtractPackageCommands($currentPhpExtensionDirectory, $targetFilePath)
     {
-        $targetPkgDir = $currentPhpExtensionDirectory.DIRECTORY_SEPARATOR.$this->getPackageName();
-        $extractDir = $currentPhpExtensionDirectory.DIRECTORY_SEPARATOR.$this->getOwner().'-'.$this->getRepository().'-*';
+        $targetPkgDir = $currentPhpExtensionDirectory . DIRECTORY_SEPARATOR . $this->getPackageName();
+        $extractDir = $currentPhpExtensionDirectory
+            . DIRECTORY_SEPARATOR
+            . $this->getOwner()
+            . '-'
+            . $this->getRepository()
+            . '-*';
 
         $cmds = array(
             "rm -rf $targetPkgDir",

--- a/src/PhpBrew/Extension/Provider/GithubProvider.php
+++ b/src/PhpBrew/Extension/Provider/GithubProvider.php
@@ -24,10 +24,16 @@ class GithubProvider implements Provider
     public function buildPackageDownloadUrl($version = 'master')
     {
         if (($this->getOwner() == null) || ($this->getRepository() == null)) {
-            throw new \Exception('Username or Repository invalid.');
+            throw new Exception('Username or Repository invalid.');
         }
 
-        return sprintf('https://%s/%s/%s/archive/%s.tar.gz', $this->site, $this->getOwner(), $this->getRepository(), $version);
+        return sprintf(
+            'https://%s/%s/%s/archive/%s.tar.gz',
+            $this->site,
+            $this->getOwner(),
+            $this->getRepository(),
+            $version
+        );
     }
 
     /**
@@ -96,7 +102,12 @@ class GithubProvider implements Provider
 
     public function buildKnownReleasesUrl()
     {
-        return sprintf('https://%sapi.github.com/repos/%s/%s/tags', ($this->auth ? $this->auth . '@' : ''), $this->getOwner(), $this->getRepository());
+        return sprintf(
+            'https://%sapi.github.com/repos/%s/%s/tags',
+            ($this->auth ? $this->auth . '@' : ''),
+            $this->getOwner(),
+            $this->getRepository()
+        );
     }
 
     public function parseKnownReleasesResponse($content)

--- a/src/PhpBrew/Extension/Provider/PeclProvider.php
+++ b/src/PhpBrew/Extension/Provider/PeclProvider.php
@@ -3,11 +3,11 @@
 namespace PhpBrew\Extension\Provider;
 
 use CLIFramework\Logger;
-use GetOptionKit\OptionResult;
-use PEARX\Channel as PeclChannel;
 use CurlKit\CurlDownloader;
 use DOMDocument;
 use Exception;
+use GetOptionKit\OptionResult;
+use PEARX\Channel as PeclChannel;
 use PhpBrew\Downloader\DownloadFactory;
 
 class PeclProvider implements Provider
@@ -36,28 +36,28 @@ class PeclProvider implements Provider
     {
         $channel = new PeclChannel($this->site);
         $baseUrl = $channel->getRestBaseUrl();
-        $url = "$baseUrl/r/".strtolower($packageName);
+        $url = "$baseUrl/r/" . strtolower($packageName);
 
         $downloader = new CurlDownloader();
         $downloader = DownloadFactory::getInstance($this->logger, $this->options);
 
         // translate version name into numbers
         if (in_array($version, array('stable', 'latest', 'beta'))) {
-            $stabilityTxtUrl = $url.'/'.$version.'.txt';
+            $stabilityTxtUrl = $url . '/' . $version . '.txt';
             if ($ret = $downloader->request($stabilityTxtUrl)) {
                 $version = (string) $ret;
             } else {
-                throw new \Exception("Can not translate stability {$version} into exact version name.");
+                throw new Exception("Can not translate stability {$version} into exact version name.");
             }
         }
-        $xmlUrl = $url.'/'.$version.'.xml';
+        $xmlUrl = $url . '/' . $version . '.xml';
         if ($ret = $downloader->request($xmlUrl)) {
             $dom = new DOMDocument('1.0');
             $dom->strictErrorChecking = false;
             $dom->preserveWhiteSpace = false;
             // $dom->resolveExternals = false;
             if (false === $dom->loadXml($ret)) {
-                throw new \Exception("Error in XMl document: $url");
+                throw new Exception("Error in XMl document: $url");
             }
 
             return $dom;
@@ -69,16 +69,16 @@ class PeclProvider implements Provider
     public function buildPackageDownloadUrl($version = 'stable')
     {
         if ($this->getPackageName() == null) {
-            throw new \Exception('Repository invalid.');
+            throw new Exception('Repository invalid.');
         }
         $xml = $this->getPackageXml($this->getPackageName(), $version);
         if (!$xml) {
-            throw new \Exception('Unable to fetch package xml');
+            throw new Exception('Unable to fetch package xml');
         }
         $g = $xml->getElementsByTagName('g');
         $url = $g->item(0)->nodeValue;
         // just use tgz format file.
-        return $url.'.tgz';
+        return $url . '.tgz';
     }
 
     public function getOwner()
@@ -200,7 +200,7 @@ class PeclProvider implements Provider
 
     public function postExtractPackageCommands($currentPhpExtensionDirectory, $targetFilePath)
     {
-        $targetPkgDir = $currentPhpExtensionDirectory.DIRECTORY_SEPARATOR.$this->getPackageName();
+        $targetPkgDir = $currentPhpExtensionDirectory . DIRECTORY_SEPARATOR . $this->getPackageName();
         $info = pathinfo($targetFilePath);
         $packageName = $this->getPackageName();
 

--- a/src/PhpBrew/InvalidVariantSyntaxException.php
+++ b/src/PhpBrew/InvalidVariantSyntaxException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpBrew;
+
+use Exception;
+
+class InvalidVariantSyntaxException extends Exception
+{
+}

--- a/src/PhpBrew/PatchKit/DiffPatchRule.php
+++ b/src/PhpBrew/PatchKit/DiffPatchRule.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\PatchKit;
 
-use PhpBrew\Buildable;
 use CLIFramework\Logger;
+use PhpBrew\Buildable;
 
 /**
  * DiffPatchRule implements a diff based patch rule.
@@ -67,7 +67,7 @@ class DiffPatchRule
             }
         }
 
-        $diffFile = $dir.DIRECTORY_SEPARATOR.$basename;
+        $diffFile = $dir . DIRECTORY_SEPARATOR . $basename;
         if (false === file_put_contents($diffFile, $content)) {
             $logger->error("Can not write file to $diffFile");
 
@@ -75,7 +75,14 @@ class DiffPatchRule
         }
 
         $logger->info("---> Patching from {$diffFile} ...");
-        $lastline = system('patch --forward --directory '.escapeshellarg($dir)." --backup -p{$this->strip} < ".escapeshellarg($diffFile), $retval);
+        $lastline = system(
+            'patch --forward --directory '
+                . escapeshellarg($dir)
+                . " --backup -p{$this->strip} < "
+                . escapeshellarg($diffFile),
+            $retval
+        );
+
         if ($retval !== 0) {
             $logger->error("patch failed: $lastline");
 

--- a/src/PhpBrew/PatchKit/Patch.php
+++ b/src/PhpBrew/PatchKit/Patch.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\PatchKit;
 
-use PhpBrew\Buildable;
 use CLIFramework\Logger;
+use PhpBrew\Buildable;
 
 /**
  * A patch is consist of a bunch of patch rules.

--- a/src/PhpBrew/PatchKit/PatchRule.php
+++ b/src/PhpBrew/PatchKit/PatchRule.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\PatchKit;
 
-use PhpBrew\Buildable;
 use CLIFramework\Logger;
+use PhpBrew\Buildable;
 
 interface PatchRule
 {

--- a/src/PhpBrew/PatchKit/RegExpPatchRule.php
+++ b/src/PhpBrew/PatchKit/RegExpPatchRule.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\PatchKit;
 
-use PhpBrew\Buildable;
 use CLIFramework\Logger;
+use PhpBrew\Buildable;
 
 /**
  * RegExpPatchRule implements a pcre_replace based patch rule.
@@ -118,7 +118,7 @@ class RegExpPatchRule implements PatchRule
     public function backup(Buildable $build, Logger $logger)
     {
         foreach ($this->files as $file) {
-            $path = $build->getSourceDirectory().DIRECTORY_SEPARATOR.$file;
+            $path = $build->getSourceDirectory() . DIRECTORY_SEPARATOR . $file;
             if (!file_exists($path)) {
                 $logger->error("file $path doesn't exist in the build directory.");
                 continue;
@@ -129,7 +129,7 @@ class RegExpPatchRule implements PatchRule
 
     protected function backupFile($path)
     {
-        $bakPath = $path.'.'.time().'.bak';
+        $bakPath = $path . '.' . time() . '.bak';
         copy($path, $bakPath);
     }
 
@@ -137,7 +137,7 @@ class RegExpPatchRule implements PatchRule
     {
         $patched = 0;
         foreach ($this->files as $file) {
-            $path = $build->getSourceDirectory().DIRECTORY_SEPARATOR.$file;
+            $path = $build->getSourceDirectory() . DIRECTORY_SEPARATOR . $file;
             if (!file_exists($path)) {
                 $logger->error("file $path doesn't exist in the build directory.");
                 continue;

--- a/src/PhpBrew/PatchPHP.php
+++ b/src/PhpBrew/PatchPHP.php
@@ -35,7 +35,7 @@ class PatchPHP
 
     public function getPatchFilename()
     {
-        return ($this->patchName ?: uniqid()).'.patch';
+        return ($this->patchName ?: uniqid()) . '.patch';
     }
 
     /**

--- a/src/PhpBrew/Patches/Apache2ModuleNamePatch.php
+++ b/src/PhpBrew/Patches/Apache2ModuleNamePatch.php
@@ -2,10 +2,10 @@
 
 namespace PhpBrew\Patches;
 
+use CLIFramework\Logger;
 use PhpBrew\Buildable;
 use PhpBrew\PatchKit\Patch;
 use PhpBrew\PatchKit\RegExpPatchRule;
-use CLIFramework\Logger;
 
 class Apache2ModuleNamePatch extends Patch
 {
@@ -40,19 +40,22 @@ class Apache2ModuleNamePatch extends Patch
             ->always()
             ->replaces(
                 '#libphp\$PHP_MAJOR_VERSION\.#',
-                'libphp$PHP_VERSION.');
+                'libphp$PHP_VERSION.'
+            );
 
         $rules[] = RegExpPatchRule::files(array('configure'))
             ->always()
             ->replaces(
                 '#libs/libphp[57].(so|la)#',
-                'libs/libphp\$PHP_VERSION.$1');
+                'libs/libphp\$PHP_VERSION.$1'
+            );
 
         $rules[] = RegExpPatchRule::files(array('Makefile.global'))
             ->always()
             ->replaces(
                 '#libphp\$\(PHP_MAJOR_VERSION\)#',
-                'libphp$(PHP_VERSION)');
+                'libphp$(PHP_VERSION)'
+            );
 
         return $rules;
     }

--- a/src/PhpBrew/Patches/FreeTypePatch.php
+++ b/src/PhpBrew/Patches/FreeTypePatch.php
@@ -2,10 +2,10 @@
 
 namespace PhpBrew\Patches;
 
+use CLIFramework\Logger;
 use PhpBrew\Buildable;
 use PhpBrew\PatchKit\DiffPatchRule;
 use PhpBrew\PatchKit\Patch;
-use CLIFramework\Logger;
 
 /**
  * As of recently, freetype-config has been removed in favor of pkg-config. It has been fixed in PHP 7.4beta1

--- a/src/PhpBrew/Patches/GistContent.php
+++ b/src/PhpBrew/Patches/GistContent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PhpBrew\Patches;
+
+class GistContent
+{
+    public $userId;
+
+    public $gistId;
+
+    public $revision;
+
+    public $filename;
+
+    public function __construct($userId, $gistId, $filename = null, $revision = null)
+    {
+        $this->userId = $userId;
+        $this->gistId = $gistId;
+        $this->filename = $filename;
+        $this->revision = $revision;
+    }
+
+    public static function url($userId, $gistId, $filename = null, $revision = null)
+    {
+        $gist = new self($userId, $gistId, $filename, $revision);
+
+        return $gist->__toString();
+    }
+
+    public function __toString()
+    {
+        $url = "https://gist.githubusercontent.com/{$this->userId}/{$this->gistId}/raw";
+        if ($this->revision) {
+            $url .= "/{$this->revision}";
+        }
+        if ($this->filename) {
+            $url .= "/{$this->filename}";
+        }
+
+        return $url;
+    }
+}

--- a/src/PhpBrew/Patches/IntlWith64bitPatch.php
+++ b/src/PhpBrew/Patches/IntlWith64bitPatch.php
@@ -2,10 +2,10 @@
 
 namespace PhpBrew\Patches;
 
+use CLIFramework\Logger;
 use PhpBrew\Buildable;
 use PhpBrew\PatchKit\Patch;
 use PhpBrew\PatchKit\RegExpPatchRule;
-use CLIFramework\Logger;
 
 class IntlWith64bitPatch extends Patch
 {

--- a/src/PhpBrew/Patches/OpenSSLDSOPatch.php
+++ b/src/PhpBrew/Patches/OpenSSLDSOPatch.php
@@ -2,10 +2,10 @@
 
 namespace PhpBrew\Patches;
 
+use CLIFramework\Logger;
 use PhpBrew\Buildable;
 use PhpBrew\PatchKit\Patch;
 use PhpBrew\PatchKit\RegExpPatchRule;
-use CLIFramework\Logger;
 
 class OpenSSLDSOPatch extends Patch
 {

--- a/src/PhpBrew/Patches/PHP53Patch.php
+++ b/src/PhpBrew/Patches/PHP53Patch.php
@@ -2,49 +2,10 @@
 
 namespace PhpBrew\Patches;
 
-use PhpBrew\Buildable;
-use PhpBrew\PatchKit\Patch;
-use PhpBrew\PatchKit\DiffPatchRule;
 use CLIFramework\Logger;
-
-class GistContent
-{
-    public $userId;
-
-    public $gistId;
-
-    public $revision;
-
-    public $filename;
-
-    public function __construct($userId, $gistId, $filename = null, $revision = null)
-    {
-        $this->userId = $userId;
-        $this->gistId = $gistId;
-        $this->filename = $filename;
-        $this->revision = $revision;
-    }
-
-    public static function url($userId, $gistId, $filename = null, $revision = null)
-    {
-        $gist = new self($userId, $gistId, $filename, $revision);
-
-        return $gist->__toString();
-    }
-
-    public function __toString()
-    {
-        $url = "https://gist.githubusercontent.com/{$this->userId}/{$this->gistId}/raw";
-        if ($this->revision) {
-            $url .= "/{$this->revision}";
-        }
-        if ($this->filename) {
-            $url .= "/{$this->filename}";
-        }
-
-        return $url;
-    }
-}
+use PhpBrew\Buildable;
+use PhpBrew\PatchKit\DiffPatchRule;
+use PhpBrew\PatchKit\Patch;
 
 class PHP53Patch extends Patch
 {
@@ -63,7 +24,14 @@ class PHP53Patch extends Patch
     {
         $rules = array();
         // The patch only works for php5.3.29
-        $rules[] = DiffPatchRule::from(GistContent::url('javian', 'bfcbd5bc5874ee9c539fb3d642cdce3e', 'multi-sapi-5.3.29-homebrew.patch', 'bf079cc68ec76290f02f57981ae85b20a06dd428'))
+        $rules[] = DiffPatchRule::from(
+            GistContent::url(
+                'javian',
+                'bfcbd5bc5874ee9c539fb3d642cdce3e',
+                'multi-sapi-5.3.29-homebrew.patch',
+                'bf079cc68ec76290f02f57981ae85b20a06dd428',
+            )
+        )
             ->strip(1)
             ->sha256('3c3157bc5c4346108a398798b84dbbaa13409c43d3996bea2ddacb3277e0cee2');
 

--- a/src/PhpBrew/Platform/Linux.php
+++ b/src/PhpBrew/Platform/Linux.php
@@ -2,9 +2,8 @@
 
 namespace PhpBrew\Platform;
 
-use PhpBrew\Platform\Linux\Distribution;
-use PhpBrew\Platform\Linux\Debian;
 use PhpBrew\Platform\Linux\CentOS;
+use PhpBrew\Platform\Linux\Debian;
 use PhpBrew\Platform\Linux\UnknownDistribution;
 
 class Linux implements Platform

--- a/src/PhpBrew/Process.php
+++ b/src/PhpBrew/Process.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Symfony package.
  *
@@ -9,6 +10,8 @@
  */
 
 namespace PhpBrew;
+
+use RuntimeException;
 
 /**
  * Process is a thin wrapper around proc_* functions to ease
@@ -44,7 +47,7 @@ class Process
      * @param int    $timeout     The timeout in seconds
      * @param array  $options     An array of options for proc_open
      *
-     * @throws \RuntimeException When proc_open is not installed
+     * @throws RuntimeException When proc_open is not installed
      *
      * @api
      */
@@ -57,7 +60,7 @@ class Process
         array $options = array()
     ) {
         if (!function_exists('proc_open')) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'The Process class relies on proc_open, which is not available on your PHP installation.'
             );
         }
@@ -97,7 +100,7 @@ class Process
      *
      * @return int The exit status code
      *
-     * @throws \RuntimeException When process can't be launch or is stopped
+     * @throws RuntimeException When process can't be launch or is stopped
      *
      * @api
      */
@@ -125,7 +128,7 @@ class Process
         $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 
         if (!is_resource($process)) {
-            throw new \RuntimeException('Unable to launch a new process.');
+            throw new RuntimeException('Unable to launch a new process.');
         }
 
         foreach ($pipes as $pipe) {
@@ -157,7 +160,7 @@ class Process
             } elseif ($n === 0) {
                 proc_terminate($process);
 
-                throw new \RuntimeException('The process timed out.');
+                throw new RuntimeException('The process timed out.');
             }
 
             if ($w) {
@@ -199,7 +202,9 @@ class Process
         $exitCode = proc_close($process);
 
         if ($this->status['signaled']) {
-            throw new \RuntimeException(sprintf('The process stopped because of a "%s" signal.', $this->status['stopsig']));
+            throw new RuntimeException(
+                sprintf('The process stopped because of a "%s" signal.', $this->status['stopsig'])
+            );
         }
 
         //The exit code returned by the process (which is only meaningful if

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -3,8 +3,8 @@
 namespace PhpBrew;
 
 use CLIFramework\Logger;
-use GetOptionKit\OptionResult;
 use Exception;
+use GetOptionKit\OptionResult;
 use PhpBrew\Downloader\DownloadFactory;
 use RuntimeException;
 
@@ -52,7 +52,7 @@ class ReleaseList
 
             return $releases;
         } else {
-            throw new RuntimeException("Can't decode release json, invalid JSON string: ".substr($json, 0, 125));
+            throw new RuntimeException("Can't decode release json, invalid JSON string: " . substr($json, 0, 125));
         }
     }
 
@@ -70,7 +70,7 @@ class ReleaseList
         $latestMajor = array_shift($releases);
         $latest = array_shift($latestMajor);
         if (!$latest) {
-            throw new \Exception('Latest major version not found.');
+            throw new Exception('Latest major version not found.');
         }
 
         return $latest['version'];
@@ -127,7 +127,7 @@ class ReleaseList
         $localFilepath = Config::getPHPReleaseListPath();
         $json = json_encode($this->releases, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         if (false === file_put_contents($localFilepath, $json)) {
-            throw new \Exception("Can't store release json file");
+            throw new Exception("Can't store release json file");
         }
     }
 
@@ -180,7 +180,7 @@ class ReleaseList
                 list($o, $major, $minor) = $matches;
                 $release = array('version' => $k);
                 if (isset($v['announcement']['English'])) {
-                    $release['announcement'] = 'https://php.net'.$v['announcement']['English'];
+                    $release['announcement'] = 'https://php.net' . $v['announcement']['English'];
                 }
 
                 if (isset($v['date'])) {

--- a/src/PhpBrew/Tasks/AfterConfigureTask.php
+++ b/src/PhpBrew/Tasks/AfterConfigureTask.php
@@ -26,7 +26,7 @@ class AfterConfigureTask extends BaseTask
             $patches[] = new IntlWith64bitPatch();
             $patches[] = new OpenSSLDSOPatch();
             foreach ($patches as $patch) {
-                $this->logger->info('Checking patch for '.$patch->desc());
+                $this->logger->info('Checking patch for ' . $patch->desc());
                 if ($patch->match($build, $this->logger)) {
                     $patched = $patch->apply($build, $this->logger);
                     $this->logger->info("$patched changes patched.");

--- a/src/PhpBrew/Tasks/Apxs2CheckTask.php
+++ b/src/PhpBrew/Tasks/Apxs2CheckTask.php
@@ -3,8 +3,8 @@
 namespace PhpBrew\Tasks;
 
 use Exception;
-use PhpBrew\Utils;
 use PhpBrew\Build;
+use PhpBrew\Utils;
 
 class Apxs2CheckTask extends BaseTask
 {
@@ -19,26 +19,37 @@ class Apxs2CheckTask extends BaseTask
         }
 
         if (!is_executable($apxs)) {
-            throw new \Exception("apxs binary is not executable: $apxs");
+            throw new Exception("apxs binary is not executable: $apxs");
         }
 
         // use apxs to check module dir permission
         if ($apxs && $libdir = trim(Utils::pipeExecute("$apxs -q LIBEXECDIR"))) {
             if (false === is_writable($libdir)) {
-                $this->logger->error("Apache module dir $libdir is not writable.\nPlease consider using chmod to change the folder permission:");
-                $this->logger->error("    \$ sudo chmod -R oga+rw $libdir");
-                $this->logger->error('Warnings: the command above is not safe for public systems. please use with discretion.');
-                throw new \Exception();
+                $this->logger->error(
+                    <<<EOF
+Apache module dir $libdir is not writable.
+Please consider using chmod to change the folder permission:
+    \$ sudo chmod -R oga+rw $libdir
+Warnings: the command above is not safe for public systems. Please use with discretion.
+EOF
+                );
+
+                throw new Exception();
             }
         }
 
         if ($apxs && $confdir = trim(Utils::pipeExecute("$apxs -q SYSCONFDIR"))) {
             if (false === is_writable($confdir)) {
-                $this->logger->error("Apache conf dir $confdir is not writable for phpbrew.");
-                $this->logger->error('Please consider using chmod to change the folder permission: ');
-                $this->logger->error("    \$ sudo chmod -R oga+rw $confdir");
-                $this->logger->error('Warnings: the command above is not safe for public systems. please use with discretion.');
-                throw new \Exception();
+                $this->logger->error(
+                    <<<EOF
+Apache conf dir $confdir is not writable for phpbrew.
+Please consider using chmod to change the folder permission:
+    \$ sudo chmod -R oga+rw $confdir
+Warnings: the command above is not safe for public systems. Please use with discretion.
+EOF
+                );
+
+                throw new Exception();
             }
         }
     }

--- a/src/PhpBrew/Tasks/BaseTask.php
+++ b/src/PhpBrew/Tasks/BaseTask.php
@@ -7,6 +7,9 @@ use GetOptionKit\OptionResult;
 
 abstract class BaseTask
 {
+    /**
+     * @var Logger
+     */
     public $logger;
 
     public $options;
@@ -53,6 +56,5 @@ abstract class BaseTask
     public function __destruct()
     {
         $this->finishedAt = microtime(true);
-        // $this->logger->debug("---> Task " . get_class($this) . " finished in " . round(($this->finishedAt - $this->startedAt) / 1000,2) . 'ms' );
     }
 }

--- a/src/PhpBrew/Tasks/BeforeConfigureTask.php
+++ b/src/PhpBrew/Tasks/BeforeConfigureTask.php
@@ -2,7 +2,6 @@
 
 namespace PhpBrew\Tasks;
 
-use PhpBrew\Exception\SystemCommandException;
 use PhpBrew\Build;
 use PhpBrew\Patches\Apache2ModuleNamePatch;
 use PhpBrew\Patches\FreeTypePatch;
@@ -20,7 +19,7 @@ class BeforeConfigureTask extends BaseTask
 
     public function run(Build $build)
     {
-        if (!file_exists($build->getSourceDirectory().DIRECTORY_SEPARATOR.'configure')) {
+        if (!file_exists($build->getSourceDirectory() . DIRECTORY_SEPARATOR . 'configure')) {
             $this->debug("configure file not found, running './buildconf --force'...");
 
             $buildConf = new BuildConfTask($this->logger);
@@ -46,7 +45,7 @@ class BeforeConfigureTask extends BaseTask
 
         // let's apply patch for libphp{php version}.so (apxs)
         if ($build->isEnabledVariant('apxs2')) {
-            $apxs2Checker = new \PhpBrew\Tasks\Apxs2CheckTask($this->logger);
+            $apxs2Checker = new Apxs2CheckTask($this->logger);
             $apxs2Checker->check($build, $this->options);
         }
 
@@ -63,7 +62,7 @@ class BeforeConfigureTask extends BaseTask
             );
 
             foreach ($patches as $patch) {
-                $this->logger->info('Checking patch for '.$patch->desc());
+                $this->logger->info('Checking patch for ' . $patch->desc());
                 if ($patch->match($build, $this->logger)) {
                     $patched = $patch->apply($build, $this->logger);
                     $this->logger->info("$patched changes patched.");

--- a/src/PhpBrew/Tasks/BuildTask.php
+++ b/src/PhpBrew/Tasks/BuildTask.php
@@ -2,9 +2,9 @@
 
 namespace PhpBrew\Tasks;
 
-use PhpBrew\Exception\SystemCommandException;
-use PhpBrew\CommandBuilder;
 use PhpBrew\Build;
+use PhpBrew\CommandBuilder;
+use PhpBrew\Exception\SystemCommandException;
 
 /**
  * Task to run `make`.

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -2,10 +2,10 @@
 
 namespace PhpBrew\Tasks;
 
-use PhpBrew\Exception\SystemCommandException;
+use PhpBrew\Build;
 use PhpBrew\CommandBuilder;
 use PhpBrew\Config;
-use PhpBrew\Build;
+use PhpBrew\Exception\SystemCommandException;
 
 /**
  * Task to run `make`.
@@ -41,10 +41,10 @@ class ConfigureTask extends BaseTask
 
         if (!$this->options->{'no-config-cache'}) {
             // $args[] = "-C"; // project wise cache (--config-cache)
-            $args[] = '--cache-file='.Config::getCacheDir().DIRECTORY_SEPARATOR.'config.cache';
+            $args[] = '--cache-file=' . Config::getCacheDir() . DIRECTORY_SEPARATOR . 'config.cache';
         }
 
-        $args[] = '--prefix='.$prefix;
+        $args[] = '--prefix=' . $prefix;
         if ($this->options->{'user-config'}) {
             $args[] = "--with-config-file-path={$prefix}/etc";
             $args[] = "--with-config-file-scan-dir={$prefix}/var/db";
@@ -57,8 +57,8 @@ class ConfigureTask extends BaseTask
             $args = array_merge($args, $variantOptions);
         }
 
-        $this->debug('Enabled variants: ['.implode(', ', array_keys($build->getVariants())).']');
-        $this->debug('Disabled variants: ['.implode(', ', array_keys($build->getDisabledVariants())).']');
+        $this->debug('Enabled variants: [' . implode(', ', array_keys($build->getVariants())) . ']');
+        $this->debug('Disabled variants: [' . implode(', ', array_keys($build->getDisabledVariants())) . ']');
 
         // Options for specific versions
         // todo: extract to BuildPlan class: PHP53 BuildPlan, PHP54 BuildPlan, PHP55 BuildPlan ?
@@ -79,7 +79,7 @@ class ConfigureTask extends BaseTask
 
         $buildLogPath = $build->getBuildLogPath();
         if (file_exists($buildLogPath)) {
-            $newPath = $buildLogPath.'.'.filemtime($buildLogPath);
+            $newPath = $buildLogPath . '.' . filemtime($buildLogPath);
             $this->info("Found existing build.log, renaming it to $newPath");
             rename($buildLogPath, $newPath);
         }

--- a/src/PhpBrew/Tasks/DSymTask.php
+++ b/src/PhpBrew/Tasks/DSymTask.php
@@ -9,14 +9,14 @@ class DSymTask extends BaseTask
     // Fix php.dSYM
     /* Check if php.dSYM exists */
     /**
-     * @param \PhpBrew\Build $build
+     * @param Build $build
      *
      * @return bool
      */
     public function check(Build $build)
     {
-        $phpbin = $build->getBinDirectory().DIRECTORY_SEPARATOR.'php';
-        $dSYM = $build->getBinDirectory().DIRECTORY_SEPARATOR.'php.dSYM';
+        $phpbin = $build->getBinDirectory() . DIRECTORY_SEPARATOR . 'php';
+        $dSYM = $build->getBinDirectory() . DIRECTORY_SEPARATOR . 'php.dSYM';
 
         return !file_exists($phpbin) && file_exists($dSYM);
     }
@@ -26,8 +26,8 @@ class DSymTask extends BaseTask
         if ($this->check($build)) {
             $this->logger->info('---> Moving php.dSYM to php ');
             if (!$options->dryrun) {
-                $phpBin = $build->getBinDirectory().DIRECTORY_SEPARATOR.'php';
-                $dSYM = $build->getBinDirectory().DIRECTORY_SEPARATOR.'php.dSYM';
+                $phpBin = $build->getBinDirectory() . DIRECTORY_SEPARATOR . 'php';
+                $dSYM = $build->getBinDirectory() . DIRECTORY_SEPARATOR . 'php.dSYM';
                 rename($dSYM, $phpBin);
             }
         }

--- a/src/PhpBrew/Tasks/DefaultConfigTask.php
+++ b/src/PhpBrew/Tasks/DefaultConfigTask.php
@@ -14,7 +14,7 @@ class DefaultConfigTask extends BaseTask
         $phpConfigFile = $options->production ? 'php.ini-production' : 'php.ini-development';
 
         $this->logger->info(
-            '---> Copying config file for '.$options->production ? 'production' : 'development'
+            '---> Copying config file for ' . $options->production ? 'production' : 'development'
         );
 
         if (file_exists($phpConfigFile)) {
@@ -28,7 +28,7 @@ class DefaultConfigTask extends BaseTask
                 mkdir($dir, 0755, true);
             }
 
-            $targetConfigPath = Config::getVersionEtcPath($version).DIRECTORY_SEPARATOR.'php.ini';
+            $targetConfigPath = Config::getVersionEtcPath($version) . DIRECTORY_SEPARATOR . 'php.ini';
 
             if (file_exists($targetConfigPath)) {
                 $this->logger->notice("$targetConfigPath exists, do not overwrite.");

--- a/src/PhpBrew/Tasks/DownloadTask.php
+++ b/src/PhpBrew/Tasks/DownloadTask.php
@@ -13,15 +13,15 @@ class DownloadTask extends BaseTask
     public function download($url, $dir, $algo = 'md5', $hash = null)
     {
         if (!is_writable($dir)) {
-            throw new \Exception("Directory is not writable: $dir");
+            throw new Exception("Directory is not writable: $dir");
         }
 
         $downloader = DownloadFactory::getInstance($this->logger, $this->options);
         $basename = $downloader->resolveDownloadFileName($url);
         if (!$basename) {
-            throw new \Exception("Can not parse url: $url");
+            throw new Exception("Can not parse url: $url");
         }
-        $targetFilePath = $dir.DIRECTORY_SEPARATOR.$basename;
+        $targetFilePath = $dir . DIRECTORY_SEPARATOR . $basename;
 
         if (!$this->options->force && file_exists($targetFilePath)) {
             $this->logger->info('Checking distribution checksum...');
@@ -31,7 +31,7 @@ class DownloadTask extends BaseTask
                 $this->logger->info('Re-Downloading...');
                 $downloader->download($url, $targetFilePath);
             } else {
-                $this->logger->info('Checksum matched: '.$hash);
+                $this->logger->info('Checksum matched: ' . $hash);
             }
         } else {
             $downloader->download($url, $targetFilePath);

--- a/src/PhpBrew/Tasks/ExtractTask.php
+++ b/src/PhpBrew/Tasks/ExtractTask.php
@@ -2,8 +2,8 @@
 
 namespace PhpBrew\Tasks;
 
-use PhpBrew\Exception\SystemCommandException;
 use PhpBrew\Build;
+use PhpBrew\Exception\SystemCommandException;
 
 /**
  * Task to download php distributions.
@@ -21,7 +21,7 @@ class ExtractTask extends BaseTask
         if (empty($extractDir)) {
             $extractDir = dirname($targetFilePath);
         }
-        $extractDirTemp = $extractDir.DIRECTORY_SEPARATOR.'tmp.'.time();
+        $extractDirTemp = $extractDir . DIRECTORY_SEPARATOR . 'tmp.' . time();
 
         if (!file_exists($extractDirTemp)) {
             mkdir($extractDirTemp, 0755, true);
@@ -30,10 +30,13 @@ class ExtractTask extends BaseTask
         // This converts: '/opt/phpbrew/distfiles/php-7.0.2.tar.bz2'
         //        to just '/opt/phpbrew/tmp/distfiles/php-7.0.2'
         $distBasename = preg_replace('#\.tar\.(gz|bz2)$#', '', basename($targetFilePath));
-        $extractedDirTemp = $extractDirTemp.DIRECTORY_SEPARATOR.$distBasename;
-        $extractedDir = $extractDir.DIRECTORY_SEPARATOR.$build->getName();
+        $extractedDirTemp = $extractDirTemp . DIRECTORY_SEPARATOR . $distBasename;
+        $extractedDir = $extractDir . DIRECTORY_SEPARATOR . $build->getName();
 
-        if ($build->getState() >= Build::STATE_EXTRACT && file_exists($extractedDir.DIRECTORY_SEPARATOR.'configure')) {
+        if (
+            $build->getState() >= Build::STATE_EXTRACT
+            && file_exists($extractedDir . DIRECTORY_SEPARATOR . 'configure')
+        ) {
             $this->info('===> Distribution file was successfully extracted, skipping...');
 
             return $extractedDir;
@@ -41,14 +44,18 @@ class ExtractTask extends BaseTask
 
         // NOTICE: Always extract to tmp directory prevent incomplete extraction
         $this->info("===> Extracting $targetFilePath to $extractedDirTemp");
-        $lastline = system('tar -C '.escapeshellarg($extractDirTemp).' -xf '.escapeshellarg($targetFilePath), $ret);
+        $lastline = system(
+            'tar -C ' . escapeshellarg($extractDirTemp) . ' -xf ' . escapeshellarg($targetFilePath),
+            $ret
+        );
+
         if ($ret !== 0) {
             throw new SystemCommandException("Extract failed: $lastline", $build);
         }
         clearstatcache(true);
         if (!is_dir($extractedDirTemp)) {
             // retry with github extracted dir path
-            $extractedDirTemp = $extractDirTemp.DIRECTORY_SEPARATOR.'php-src-'.$distBasename;
+            $extractedDirTemp = $extractDirTemp . DIRECTORY_SEPARATOR . 'php-src-' . $distBasename;
             if (!is_dir($extractedDirTemp)) {
                 throw new SystemCommandException("Unable to find $extractedDirTemp", $build);
             }
@@ -56,7 +63,7 @@ class ExtractTask extends BaseTask
 
         if (is_dir($extractedDir)) {
             $this->info("===> Found existing build directory, removing $extractedDir ...");
-            $lastline = system('rm -rf '.escapeshellarg($extractedDir), $ret);
+            $lastline = system('rm -rf ' . escapeshellarg($extractedDir), $ret);
             if ($ret !== 0) {
                 throw new SystemCommandException("Unable to remove $extractedDir: $lastline", $build);
             }

--- a/src/PhpBrew/Tasks/InstallTask.php
+++ b/src/PhpBrew/Tasks/InstallTask.php
@@ -2,9 +2,9 @@
 
 namespace PhpBrew\Tasks;
 
-use PhpBrew\Exception\SystemCommandException;
-use PhpBrew\CommandBuilder;
 use PhpBrew\Build;
+use PhpBrew\CommandBuilder;
+use PhpBrew\Exception\SystemCommandException;
 
 /**
  * Task to run `make install`.

--- a/src/PhpBrew/Tasks/MakeTask.php
+++ b/src/PhpBrew/Tasks/MakeTask.php
@@ -54,7 +54,7 @@ class MakeTask extends BaseTask
      */
     private function make($path, $target = 'all', $build = null)
     {
-        if (!file_exists($path.DIRECTORY_SEPARATOR.'Makefile')) {
+        if (!file_exists($path . DIRECTORY_SEPARATOR . 'Makefile')) {
             $this->logger->error("Makefile not found in path $path");
 
             return false;
@@ -89,10 +89,10 @@ class MakeTask extends BaseTask
 
         $cmd[] = escapeshellarg($target);
         if (!$this->logger->isDebug() && $this->buildLogPath) {
-            $cmd[] = ' >> '.escapeshellarg($this->buildLogPath).' 2>&1';
+            $cmd[] = ' >> ' . escapeshellarg($this->buildLogPath) . ' 2>&1';
         }
 
-        $this->logger->info("===> Running make $target: ".implode(' ', $cmd));
+        $this->logger->info("===> Running make $target: " . implode(' ', $cmd));
 
         return Utils::system($cmd, $this->logger, $build) === 0;
     }

--- a/src/PhpBrew/Tasks/PrepareDirectoryTask.php
+++ b/src/PhpBrew/Tasks/PrepareDirectoryTask.php
@@ -16,7 +16,7 @@ class PrepareDirectoryTask extends BaseTask
         $dirs[] = Config::getDistFileDir();
         $dirs[] = Config::getVariantsDir();
         if ($build) {
-            $dirs[] = Config::getInstallPrefix().DIRECTORY_SEPARATOR.$build->getName();
+            $dirs[] = Config::getInstallPrefix() . DIRECTORY_SEPARATOR . $build->getName();
         }
         foreach ($dirs as $dir) {
             if (!file_exists($dir)) {

--- a/src/PhpBrew/Tasks/TestTask.php
+++ b/src/PhpBrew/Tasks/TestTask.php
@@ -2,9 +2,9 @@
 
 namespace PhpBrew\Tasks;
 
-use PhpBrew\Exception\SystemCommandException;
 use PhpBrew\Build;
 use PhpBrew\CommandBuilder;
+use PhpBrew\Exception\SystemCommandException;
 
 /**
  * Task to run `make test`.
@@ -25,7 +25,7 @@ class TestTask extends BaseTask
         $cmd->setStdout($this->options->{'stdout'});
 
         putenv('NO_INTERACTION=1');
-        $this->debug(''.$cmd);
+        $this->debug('' . $cmd);
         $code = $cmd->execute($lastline);
         if ($code !== 0) {
             throw new SystemCommandException("Test failed: $lastline", $build);

--- a/src/PhpBrew/Testing/CommandTestCase.php
+++ b/src/PhpBrew/Testing/CommandTestCase.php
@@ -2,10 +2,9 @@
 
 namespace PhpBrew\Testing;
 
-use PhpBrew\Console;
-use GetOptionKit\Option;
-use PhpBrew\Testing\VCRAdapter;
 use CLIFramework\Testing\CommandTestCase as BaseCommandTestCase;
+use GetOptionKit\Option;
+use PhpBrew\Console;
 
 abstract class CommandTestCase extends BaseCommandTestCase
 {
@@ -54,7 +53,7 @@ abstract class CommandTestCase extends BaseCommandTestCase
         // putenv('PHPBREW_ROOT=' . getcwd() . '/.phpbrew');
         // putenv('PHPBREW_HOME=' . getcwd() . '/.phpbrew');
 
-        if ($options = \PhpBrew\Console::getInstance()->options) {
+        if ($options = Console::getInstance()->options) {
             $option = new Option('no-progress');
             $option->setValue(true);
             $options->set('no-progress', $option);
@@ -88,7 +87,7 @@ abstract class CommandTestCase extends BaseCommandTestCase
     {
         try {
             if ($this->debug) {
-                fwrite(STDERR, $args.PHP_EOL);
+                fwrite(STDERR, $args . PHP_EOL);
             }
 
             ob_start();

--- a/src/PhpBrew/Testing/PatchTestCase.php
+++ b/src/PhpBrew/Testing/PatchTestCase.php
@@ -2,16 +2,16 @@
 
 namespace PhpBrew\Testing;
 
+use PHPUnit_Framework_TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use PHPUnit_Framework_TestCase;
 
 abstract class PatchTestCase extends PHPUnit_Framework_TestCase
 {
     protected function setupBuildDirectory($version)
     {
         $sourceDirectory = getenv('PHPBREW_BUILD_PHP_DIR');
-        $sourceFixtureDirectory = getenv('PHPBREW_FIXTURES_PHP_DIR').DIRECTORY_SEPARATOR.$version;
+        $sourceFixtureDirectory = getenv('PHPBREW_FIXTURES_PHP_DIR') . DIRECTORY_SEPARATOR . $version;
 
         $source = $sourceFixtureDirectory;
         $dest = $sourceDirectory;
@@ -19,14 +19,15 @@ abstract class PatchTestCase extends PHPUnit_Framework_TestCase
         if (!file_exists($dest)) {
             mkdir($dest, 0755, true);
         }
-        $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($source, \RecursiveDirectoryIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::SELF_FIRST);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
         foreach ($iterator as $item) {
             if ($item->isDir()) {
-                mkdir($dest.DIRECTORY_SEPARATOR.$iterator->getSubPathName(), 0755, true);
+                mkdir($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName(), 0755, true);
             } else {
-                copy($item, $dest.DIRECTORY_SEPARATOR.$iterator->getSubPathName());
+                copy($item, $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
             }
         }
     }

--- a/src/PhpBrew/Testing/TemporaryFileFixture.php
+++ b/src/PhpBrew/Testing/TemporaryFileFixture.php
@@ -59,7 +59,7 @@ class TemporaryFileFixture
     public function withFile($destFileName, $callback)
     {
         $contents = file_get_contents($this->sourcePath);
-        $destPath = $this->temporaryDirectory.DIRECTORY_SEPARATOR.$destFileName;
+        $destPath = $this->temporaryDirectory . DIRECTORY_SEPARATOR . $destFileName;
 
         $this->caller->assertFileExists($this->sourcePath);
         file_put_contents($destPath, $contents);

--- a/src/PhpBrew/Topic/ContributionTopic.php
+++ b/src/PhpBrew/Topic/ContributionTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class ContributionTopic  extends GitHubTopic
+class ContributionTopic extends GitHubTopic
 {
     public $id = 'contribution';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Contribution.md';

--- a/src/PhpBrew/Topic/CookbookTopic.php
+++ b/src/PhpBrew/Topic/CookbookTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class CookbookTopic  extends GitHubTopic
+class CookbookTopic extends GitHubTopic
 {
     public $id = 'cookbook';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Cookbook.md';

--- a/src/PhpBrew/Topic/HomeTopic.php
+++ b/src/PhpBrew/Topic/HomeTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class HomeTopic  extends GitHubTopic
+class HomeTopic extends GitHubTopic
 {
     public $id = 'home';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Home.md';

--- a/src/PhpBrew/Topic/MigratingFromHomebrewPhpToPhpbrewTopic.php
+++ b/src/PhpBrew/Topic/MigratingFromHomebrewPhpToPhpbrewTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class MigratingFromHomebrewPhpToPhpbrewTopic  extends GitHubTopic
+class MigratingFromHomebrewPhpToPhpbrewTopic extends GitHubTopic
 {
     public $id = 'migrating-from-homebrew-php-to-phpbrew';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Migrating-from-homebrew-php-to-phpbrew.md';

--- a/src/PhpBrew/Topic/PHPBrewJATopic.php
+++ b/src/PhpBrew/Topic/PHPBrewJATopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class PHPBrewJATopic  extends GitHubTopic
+class PHPBrewJATopic extends GitHubTopic
 {
     public $id = 'phpbrew-ja';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/PHPBrew JA 日語指引.md';

--- a/src/PhpBrew/Topic/ReleaseProcessTopic.php
+++ b/src/PhpBrew/Topic/ReleaseProcessTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class ReleaseProcessTopic  extends GitHubTopic
+class ReleaseProcessTopic extends GitHubTopic
 {
     public $id = 'release-process';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Release-Process.md';

--- a/src/PhpBrew/Topic/RequirementTopic.php
+++ b/src/PhpBrew/Topic/RequirementTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class RequirementTopic  extends GitHubTopic
+class RequirementTopic extends GitHubTopic
 {
     public $id = 'requirement';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Requirement.md';

--- a/src/PhpBrew/Topic/SettingUpConfigurationTopic.php
+++ b/src/PhpBrew/Topic/SettingUpConfigurationTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class SettingUpConfigurationTopic  extends GitHubTopic
+class SettingUpConfigurationTopic extends GitHubTopic
 {
     public $id = 'setting-up-configuration';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Setting-up-Configuration.md';

--- a/src/PhpBrew/Topic/TroubleshootingTopic.php
+++ b/src/PhpBrew/Topic/TroubleshootingTopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
 Please DO NOT modify this file directly.
 */
@@ -7,7 +8,7 @@ namespace PhpBrew\Topic;
 
 use CLIFramework\Topic\GitHubTopic;
 
-class TroubleshootingTopic  extends GitHubTopic
+class TroubleshootingTopic extends GitHubTopic
 {
     public $id = 'troubleshooting';
     public $url = 'https://github.com/phpbrew/phpbrew/wiki/Troubleshooting.md';

--- a/src/PhpBrew/Utils.php
+++ b/src/PhpBrew/Utils.php
@@ -4,7 +4,6 @@ namespace PhpBrew;
 
 use CLIFramework\Logger;
 use PhpBrew\Exception\SystemCommandException;
-use PhpBrew\Platform\PlatformInfo;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -27,7 +26,7 @@ class Utils
     public static function canonicalizeBuildName($version)
     {
         if (!preg_match('/^php-/', $version)) {
-            return 'php-'.$version;
+            return 'php-' . $version;
         }
 
         return $version;
@@ -62,13 +61,13 @@ class Utils
         $prefixes = self::getLookupPrefixes();
 
         foreach ($prefixes as $prefix) {
-            $binPath = $prefix.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.$bin;
+            $binPath = $prefix . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . $bin;
 
             if (file_exists($binPath)) {
                 return $binPath;
             }
 
-            $binPath = $prefix.DIRECTORY_SEPARATOR.'sbin'.DIRECTORY_SEPARATOR.$bin;
+            $binPath = $prefix . DIRECTORY_SEPARATOR . 'sbin' . DIRECTORY_SEPARATOR . $bin;
 
             if (file_exists($binPath)) {
                 return $binPath;
@@ -144,7 +143,7 @@ class Utils
         $prefixes = self::getLookupPrefixes();
         foreach ($prefixes as $prefix) {
             foreach ($files as $file) {
-                $path = $prefix.DIRECTORY_SEPARATOR.'include'.DIRECTORY_SEPARATOR.$file;
+                $path = $prefix . DIRECTORY_SEPARATOR . 'include' . DIRECTORY_SEPARATOR . $file;
                 if (file_exists($path)) {
                     return $prefix;
                 }
@@ -161,7 +160,7 @@ class Utils
 
         foreach ($prefixes as $prefix) {
             foreach ($files as $file) {
-                $p = $prefix.DIRECTORY_SEPARATOR.$file;
+                $p = $prefix . DIRECTORY_SEPARATOR . $file;
                 if (file_exists($p)) {
                     return $prefix;
                 }
@@ -178,7 +177,7 @@ class Utils
 
         foreach ($prefixes as $prefix) {
             foreach ($files as $file) {
-                $path = $prefix.DIRECTORY_SEPARATOR.'include'.DIRECTORY_SEPARATOR.$file;
+                $path = $prefix . DIRECTORY_SEPARATOR . 'include' . DIRECTORY_SEPARATOR . $file;
                 if (file_exists($path)) {
                     return $prefix;
                 }
@@ -196,7 +195,7 @@ class Utils
     public static function getPkgConfigPrefix($package)
     {
         if (self::findBin('pkg-config')) {
-            $cmd = 'pkg-config --variable=prefix '.$package;
+            $cmd = 'pkg-config --variable=prefix ' . $package;
             $process = new Process($cmd);
             $code = $process->run();
             if (intval($code) === 0) {
@@ -217,7 +216,7 @@ class Utils
         }
 
         if ($logger) {
-            $logger->debug('Running Command:'.$command);
+            $logger->debug('Running Command:' . $command);
         }
 
         $lastline = system($command, $returnValue);
@@ -240,7 +239,7 @@ class Utils
         $paths = explode(PATH_SEPARATOR, $path);
 
         foreach ($paths as $path) {
-            $f = $path.DIRECTORY_SEPARATOR.$bin;
+            $f = $path . DIRECTORY_SEPARATOR . $bin;
             // realpath will handle file existence or symbolic link automatically
             $f = realpath($f);
             if ($f !== false) {
@@ -310,9 +309,10 @@ class Utils
 
             if ($fp !== false) {
                 while ($file = readdir($fp)) {
-                    if ($file === '.'
+                    if (
+                        $file === '.'
                         || $file === '..'
-                        || is_file($buildDir.DIRECTORY_SEPARATOR.$file)
+                        || is_file($buildDir . DIRECTORY_SEPARATOR . $file)
                     ) {
                         continue;
                     }
@@ -332,7 +332,7 @@ class Utils
             }
 
             if ($hasPrefix == true && $foundVersion !== false) {
-                $foundVersion = 'php-'.$foundVersion;
+                $foundVersion = 'php-' . $foundVersion;
             }
         }
 
@@ -344,7 +344,7 @@ class Utils
         $directoryIterator = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
         $it = new RecursiveIteratorIterator($directoryIterator, RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($it as $file) {
-            $logger->debug('Deleting '.$file->getPathname());
+            $logger->debug('Deleting ' . $file->getPathname());
             if ($file->isDir()) {
                 rmdir($file->getPathname());
             } else {

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -11,12 +11,14 @@ use PhpBrew\PrefixFinder\PkgConfigPrefixFinder;
 
 function first_existing_executable($possiblePaths)
 {
-    $existingPaths =
+    $existingPaths = array_filter(
         array_filter(
-            array_filter(
-                array_filter($possiblePaths, 'file_exists'),
-                'is_file'),
-            'is_executable');
+            array_filter($possiblePaths, 'file_exists'),
+            'is_file'
+        ),
+        'is_executable'
+    );
+
     if (!empty($existingPaths)) {
         return realpath($existingPaths[0]);
     }
@@ -368,13 +370,13 @@ class VariantBuilder
             if ($bin = Utils::findBin('brew')) {
                 if ($output = exec_line("$bin --prefix readline")) {
                     if (file_exists($output)) {
-                        return '--with-readline='.$output;
+                        return '--with-readline=' . $output;
                     }
                     echo "homebrew prefix '$output' doesn't exist. you forgot to install?\n";
                 }
             }
-            if ($prefix = Utils::findIncludePrefix('readline'.DIRECTORY_SEPARATOR.'readline.h')) {
-                return '--with-readline='.$prefix;
+            if ($prefix = Utils::findIncludePrefix('readline' . DIRECTORY_SEPARATOR . 'readline.h')) {
+                return '--with-readline=' . $prefix;
             }
             return '--with-readline';
         };
@@ -394,7 +396,7 @@ class VariantBuilder
             } elseif ($bin = Utils::findBin('brew')) {
                 if ($output = exec_line("$bin --prefix libedit")) {
                     if (file_exists($output)) {
-                        return '--with-libedit='.$output;
+                        return '--with-libedit=' . $output;
                     }
                     echo "homebrew prefix '$output' doesn't exist. you forgot to install?\n";
                 } else {
@@ -448,10 +450,12 @@ class VariantBuilder
                 $opts[] = '--enable-gd-native-ttf';
             }
 
-            if (($prefix = Utils::findPrefix(array(
+            if (
+                ($prefix = Utils::findPrefix(array(
                 new IncludePrefixFinder('jpeglib.h'),
                 new BrewPrefixFinder('libjpeg'),
-            ))) !== null) {
+                ))) !== null
+            ) {
                 if ($build->compareVersion('7.4') < 0) {
                     $flag = '--with-jpeg-dir';
                 } else {
@@ -461,11 +465,13 @@ class VariantBuilder
                 $opts[] = sprintf('%s=%s', $flag, $prefix);
             }
 
-            if ($build->compareVersion('7.4') < 0 && ($prefix = Utils::findPrefix(array(
+            if (
+                $build->compareVersion('7.4') < 0 && ($prefix = Utils::findPrefix(array(
                 new IncludePrefixFinder('png.h'),
                 new IncludePrefixFinder('libpng12/pngconf.h'),
                 new BrewPrefixFinder('libpng'),
-            ))) !== null) {
+                ))) !== null
+            ) {
                 $opts[] = '--with-png-dir=' . $prefix;
             }
 
@@ -474,11 +480,13 @@ class VariantBuilder
             //
             // from configure:
             //   for path in $i/include/freetype2/freetype/freetype.h
-            if (($prefix = Utils::findPrefix(array(
+            if (
+                ($prefix = Utils::findPrefix(array(
                 new IncludePrefixFinder('freetype2/freetype.h'),
                 new IncludePrefixFinder('freetype2/freetype/freetype.h'),
                 new BrewPrefixFinder('freetype'),
-            ))) !== null) {
+                ))) !== null
+            ) {
                 if ($build->compareVersion('7.4') < 0) {
                     $flag = '--with-freetype-dir';
                 } else {
@@ -519,15 +527,13 @@ class VariantBuilder
             $icuOption = $build->settings->grepExtraOptionsByPattern('#--with-icu-dir#');
             if (!$build->settings->isEnabledVariant('icu') || empty($icuOption)) {
                 if ($bin = Utils::findBin('icu-config')) {
-
                     /*
                     * let autoconf find it's own icu-config
                     * The build-in acinclude.m4 will find the icu-config from $PATH:/usr/local/bin
                     */
                 } elseif ($prefix = Utils::getPkgConfigPrefix('icu-i18n')) {
-
                     // For macports or linux
-                    $opts[] = '--with-icu-dir='.$prefix;
+                    $opts[] = '--with-icu-dir=' . $prefix;
                 } elseif ($bin = Utils::findBin('brew')) {
                     // For homebrew
                     if ($output = exec_line("$bin --prefix icu4c")) {
@@ -551,7 +557,7 @@ class VariantBuilder
          */
         $this->variants['icu'] = function (Build $build, $val = null) {
             if ($val) {
-                return '--with-icu-dir='.$val;
+                return '--with-icu-dir=' . $val;
             }
         };
 
@@ -590,7 +596,7 @@ class VariantBuilder
             $possiblePrefixes = array('/usr/local/opt/openssl');
             $foundPrefixes = array_filter($possiblePrefixes, 'file_exists');
             if (count($foundPrefixes) > 0) {
-                return '--with-openssl='.$foundPrefixes[0];
+                return '--with-openssl=' . $foundPrefixes[0];
             }
 
             // This will create openssl.so file for dynamic loading.
@@ -686,7 +692,7 @@ class VariantBuilder
 
         $this->variants['sqlite'] = function (Build $build, $prefix = null) {
             $opts = array(
-                '--with-sqlite3'.($prefix ? "=$prefix" : ''),
+                '--with-sqlite3' . ($prefix ? "=$prefix" : ''),
             );
 
             if ($build->hasVariant('pdo')) {
@@ -751,12 +757,14 @@ class VariantBuilder
             if ($build->compareVersion('7.4') < 0) {
                 $options[] = '--enable-libxml';
 
-                if (($prefix = Utils::findPrefix(array(
+                if (
+                    ($prefix = Utils::findPrefix(array(
                     new BrewPrefixFinder('libxml2'),
                     new PkgConfigPrefixFinder('libxml'),
                     new IncludePrefixFinder('libxml2/libxml/globals.h'),
                     new LibPrefixFinder('libxml2.a'),
-                ))) !== null) {
+                    ))) !== null
+                ) {
                     $options[] = '--with-libxml-dir=' . $prefix;
                 }
             } else {
@@ -778,13 +786,13 @@ class VariantBuilder
         $this->variants['apxs2'] = function (Build $build, $prefix = null) {
             $a = '--with-apxs2';
             if ($prefix) {
-                return '--with-apxs2='.$prefix;
+                return '--with-apxs2=' . $prefix;
             }
 
             if ($bin = Utils::findBinByPrefix('apxs2')) {
-                return '--with-apxs2='.$bin;
+                return '--with-apxs2=' . $bin;
             } elseif ($bin = Utils::findBinByPrefix('apxs')) {
-                return '--with-apxs2='.$bin;
+                return '--with-apxs2=' . $bin;
             }
 
             /* Special paths for homebrew */
@@ -809,11 +817,11 @@ class VariantBuilder
 
         $this->variants['gettext'] = function (Build $build, $prefix = null) {
             if ($prefix) {
-                return '--with-gettext='.$prefix;
+                return '--with-gettext=' . $prefix;
             }
 
             if ($prefix = Utils::findIncludePrefix('libintl.h')) {
-                return '--with-gettext='.$prefix;
+                return '--with-gettext=' . $prefix;
             }
 
             if ($bin = Utils::findBin('brew')) {
@@ -931,14 +939,14 @@ class VariantBuilder
             if ($conflicts = $this->getConflict($build, 'apxs2')) {
                 $msgs = array();
                 $msgs[] = 'PHP Version lower than 5.4.0 can only build one SAPI at the same time.';
-                $msgs[] = '+apxs2 is in conflict with '.implode(',', $conflicts);
+                $msgs[] = '+apxs2 is in conflict with ' . implode(',', $conflicts);
 
                 foreach ($conflicts as $c) {
                     $msgs[] = "Disabling $c";
                     $build->disableVariant($c);
                 }
 
-                echo implode("\n", $msgs)."\n";
+                echo implode("\n", $msgs) . "\n";
             }
         }
 
@@ -949,7 +957,7 @@ class VariantBuilder
     {
         $prefix = Utils::getPkgConfigPrefix($pkgName);
 
-        return $prefix ? $option.'='.$prefix : $option;
+        return $prefix ? $option . '=' . $prefix : $option;
     }
 
     public function getVariantNames()
@@ -972,7 +980,7 @@ class VariantBuilder
     public function buildVariant(Build $build, $feature, $userValue = null)
     {
         if (!isset($this->variants[ $feature ])) {
-            throw new \Exception("Variant '$feature' is not defined.");
+            throw new Exception("Variant '$feature' is not defined.");
         }
 
         // Skip if we've built it
@@ -1004,11 +1012,11 @@ class VariantBuilder
     public function buildDisableVariant(Build $build, $feature, $userValue = null)
     {
         if (isset($this->variants[$feature])) {
-            if (in_array('-'.$feature, $this->builtList)) {
+            if (in_array('-' . $feature, $this->builtList)) {
                 return array();
             }
 
-            $this->builtList[] = '-'.$feature;
+            $this->builtList[] = '-' . $feature;
             $func = $this->variants[ $feature ];
 
             // build the option from enabled variant,
@@ -1021,7 +1029,7 @@ class VariantBuilder
             } elseif (is_callable($func)) {
                 $disableOptions = (array) call_user_func_array($func, $args);
             } else {
-                throw new \Exception('Unsupported variant handler type. neither string nor callable.');
+                throw new Exception('Unsupported variant handler type. neither string nor callable.');
             }
 
             $resultOptions = array();
@@ -1041,7 +1049,7 @@ class VariantBuilder
             return $resultOptions;
         }
 
-        throw new \Exception("Variant $feature is not defined.");
+        throw new Exception("Variant $feature is not defined.");
     }
 
     public function addOptions($options)
@@ -1065,7 +1073,7 @@ class VariantBuilder
      *
      * @return array|void
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function build(Build $build)
     {
@@ -1101,7 +1109,7 @@ class VariantBuilder
             }
 
             if ($prefix = Utils::findIncludePrefix('zlib.h')) {
-                $this->addOptions('--with-zlib='.$prefix);
+                $this->addOptions('--with-zlib=' . $prefix);
             }
         }
 

--- a/src/PhpBrew/VariantParser.php
+++ b/src/PhpBrew/VariantParser.php
@@ -2,12 +2,6 @@
 
 namespace PhpBrew;
 
-use Exception;
-
-class InvalidVariantSyntaxException extends Exception
-{
-}
-
 class VariantParser
 {
     public static function splitVariantValue($str)
@@ -42,7 +36,9 @@ class VariantParser
 
             if ($arg[0] === '+' || $arg[0] === '-') {
                 if (substr($arg, 0, 2) === '--') {
-                    throw new InvalidVariantSyntaxException("Invalid variant syntax exception start with '--': ".$arg);
+                    throw new InvalidVariantSyntaxException(
+                        "Invalid variant syntax exception start with '--': " . $arg
+                    );
                 }
                 preg_match_all('#[+-][\w_]+(=[\"\'\.\/\w_-]+)?#', $arg, $variantStrings);
 
@@ -56,7 +52,7 @@ class VariantParser
                             $a = self::splitVariantValue(substr($str, 1));
                             $disabledVariants = array_merge($disabledVariants, $a);
                         } else {
-                            throw new InvalidVariantSyntaxException($str.' is invalid syntax');
+                            throw new InvalidVariantSyntaxException($str . ' is invalid syntax');
                         }
                     }
                 }
@@ -80,16 +76,16 @@ class VariantParser
         $out = '';
 
         foreach ($info['enabled_variants'] as $k => $v) {
-            $out .= ' +'.$k;
+            $out .= ' +' . $k;
             if (!is_bool($v)) {
-                $out .= '='.$v.' ';
+                $out .= '=' . $v . ' ';
             }
         }
         if (!empty($info['disabled_variants'])) {
-            $out .= ' -'.implode('-', array_keys($info['disabled_variants']));
+            $out .= ' -' . implode('-', array_keys($info['disabled_variants']));
         }
         if (!empty($info['extra_options'])) {
-            $out .= ' -- '.implode(' ', $info['extra_options']);
+            $out .= ' -- ' . implode(' ', $info['extra_options']);
         }
 
         return $out;

--- a/src/PhpBrew/Version.php
+++ b/src/PhpBrew/Version.php
@@ -124,7 +124,7 @@ class Version
      */
     public function getCanonicalizedVersionName()
     {
-        return $this->dist.'-'.$this->version;
+        return $this->dist . '-' . $this->version;
     }
 
     public function __toString()

--- a/src/PhpBrew/VersionDslParser.php
+++ b/src/PhpBrew/VersionDslParser.php
@@ -29,7 +29,13 @@ class VersionDslParser
         $url = str_replace(self::$schemes, 'https://github.com/', $dsl);
 
         // parse github fork owner and branch
-        if (preg_match("#https?://(www\.)?github\.com/([0-9a-zA-Z-._]+)/php-src(@([0-9a-zA-Z-._]+))?#", $url, $matches)) {
+        if (
+            preg_match(
+                "#https?://(www\.)?github\.com/([0-9a-zA-Z-._]+)/php-src(@([0-9a-zA-Z-._]+))?#",
+                $url,
+                $matches
+            )
+        ) {
             $owner = $matches[2];
             $branch = isset($matches[4]) ? $matches[4] : 'master';
             $version = preg_replace('/^php-/', '', $branch);
@@ -47,7 +53,7 @@ class VersionDslParser
         // non github url
         if (preg_match('#^https?://#', $url)) {
             if (!preg_match('#(php-(\d.\d+.\d+(?:(?:RC|alpha|beta)\d+)?)\.tar\.(?:gz|bz2))#', $url, $matches)) {
-                throw new \Exception("Can not find version name from the given URL: $url");
+                throw new Exception("Can not find version name from the given URL: $url");
             }
 
             return array(

--- a/tests/PhpBrew/BuildRegisterTest.php
+++ b/tests/PhpBrew/BuildRegisterTest.php
@@ -1,16 +1,20 @@
 <?php
+
+namespace PhpBrew\Tests;
+
 use PhpBrew\Build;
 use PhpBrew\BuildRegister;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class BuildRegisterTest extends \PHPUnit\Framework\TestCase
+class BuildRegisterTest extends TestCase
 {
     public function testBuildRegister()
     {
         $b = new Build('5.4.19');
-        $pool = new BuildRegister;
+        $pool = new BuildRegister();
 
         $this->assertTrue($pool->register($b));
         $this->assertTrue($pool->deregister($b));

--- a/tests/PhpBrew/BuildSettings/BuildSettingsTest.php
+++ b/tests/PhpBrew/BuildSettings/BuildSettingsTest.php
@@ -1,10 +1,11 @@
 <?php
-namespace PhpBrew\BuildSettings;
 
-use PhpBrew\Config;
-use PhpBrew\Testing\TemporaryFileFixture;
+namespace PhpBrew\Tests\BuildSettings;
 
-class BuildSettingsTest extends \PHPUnit\Framework\TestCase
+use PhpBrew\BuildSettings\BuildSettings;
+use PHPUnit\Framework\TestCase;
+
+class BuildSettingsTest extends TestCase
 {
     public function testConstructorWithEnabledVariants()
     {

--- a/tests/PhpBrew/BuildSettings/DefaultBuildSettingsTest.php
+++ b/tests/PhpBrew/BuildSettings/DefaultBuildSettingsTest.php
@@ -1,7 +1,11 @@
 <?php
-namespace PhpBrew\BuildSettings;
 
-class DefaultBuildSettingsTest extends \PHPUnit\Framework\TestCase
+namespace PhpBrew\Tests\BuildSettings;
+
+use PhpBrew\BuildSettings\DefaultBuildSettings;
+use PHPUnit\Framework\TestCase;
+
+class DefaultBuildSettingsTest extends TestCase
 {
     public function testDefaultEnabledVariants()
     {

--- a/tests/PhpBrew/BuildTest.php
+++ b/tests/PhpBrew/BuildTest.php
@@ -1,13 +1,18 @@
 <?php
 
+namespace PhpBrew\Tests;
+
+use PhpBrew\Build;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @small
  */
-class BuildTest extends \PHPUnit\Framework\TestCase
+class BuildTest extends TestCase
 {
     public function testBuildAPI()
     {
-        $build = new PhpBrew\Build('5.3.1');
+        $build = new Build('5.3.1');
 
         $build->setVersion('5.3.1');
         $build->enableVariant('debug');
@@ -18,20 +23,20 @@ class BuildTest extends \PHPUnit\Framework\TestCase
         $build->disableVariant('mysql');
         $build->resolveVariants();
 
-        Same( 1 , $build->compareVersion('5.3.0') );
-        Same( 1 , $build->compareVersion('5.3') );
-        Same( -1 , $build->compareVersion('5.4.0') );
-        Same( -1 , $build->compareVersion('5.4') );
+        Same(1, $build->compareVersion('5.3.0'));
+        Same(1, $build->compareVersion('5.3'));
+        Same(-1, $build->compareVersion('5.4.0'));
+        Same(-1, $build->compareVersion('5.4'));
         Same('php-5.3.1-debug-icu-dev', $build->getIdentifier());
     }
 
     public function testNeutralVirtualVariant()
     {
-        $build = new PhpBrew\Build('5.5.0');
+        $build = new Build('5.5.0');
         $build->setVersion('5.5.0');
         $build->enableVariant('neutral');
         $build->resolveVariants();
 
-        $this->assertTrue($build->hasVariant('neutral') );
+        $this->assertTrue($build->hasVariant('neutral'));
     }
 }

--- a/tests/PhpBrew/Command/AppCommandTest.php
+++ b/tests/PhpBrew/Command/AppCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -23,8 +26,9 @@ class AppCommandTest extends CommandTestCase
     public function testAppGetCommand()
     {
         if (getenv('TRAVIS')) {
-            return $this->markTestSkipped('skip app get command test on travis');
+            $this->markTestSkipped('skip app get command test on travis');
         }
+
         $this->assertCommandSuccess("phpbrew app get phpunit");
     }
 }

--- a/tests/PhpBrew/Command/DownloadCommandTest.php
+++ b/tests/PhpBrew/Command/DownloadCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -9,7 +12,8 @@ use PhpBrew\Testing\CommandTestCase;
 class DownloadCommandTest extends CommandTestCase
 {
 
-    public function versionDataProvider() {
+    public function versionDataProvider()
+    {
         return array(
             array('5.5'),
             array('5.5.15'),
@@ -28,7 +32,9 @@ class DownloadCommandTest extends CommandTestCase
 
         $this->assertCommandSuccess("phpbrew init");
         $this->assertCommandSuccess("phpbrew -q download $versionName");
-        $this->assertCommandSuccess("phpbrew -q download $versionName"); // redownload should just check the checksum instead of extracting it.
+
+        // re-download should just check the checksum instead of extracting it
+        $this->assertCommandSuccess("phpbrew -q download $versionName");
         $this->assertCommandSuccess("phpbrew -q download -f $versionName");
     }
 }

--- a/tests/PhpBrew/Command/EnvCommandTest.php
+++ b/tests/PhpBrew/Command/EnvCommandTest.php
@@ -1,4 +1,8 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
+use PhpBrew\Console;
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -8,10 +12,11 @@ class EnvCommandTest extends CommandTestCase
 {
     public function setupApplication()
     {
-        return new PhpBrew\Console;
+        return new Console();
     }
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         putenv('PHPBREW_HOME=' . getcwd() . '/.phpbrew');
         putenv('PHPBREW_ROOT=' . getcwd() . '/.phpbrew');
@@ -24,6 +29,4 @@ class EnvCommandTest extends CommandTestCase
     {
         $this->assertCommandSuccess("phpbrew env");
     }
-
-
 }

--- a/tests/PhpBrew/Command/ExtensionCommandTest.php
+++ b/tests/PhpBrew/Command/ExtensionCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -7,7 +10,8 @@ use PhpBrew\Testing\CommandTestCase;
  */
 class ExtensionCommandTest extends CommandTestCase
 {
-    public function extensionNameProvider() {
+    public function extensionNameProvider()
+    {
         return array(
             array('APCu', 'latest'),
             array('xdebug', 'latest'),
@@ -18,7 +22,8 @@ class ExtensionCommandTest extends CommandTestCase
      * @outputBuffering enabled
      * @dataProvider extensionNameProvider
      */
-    public function testExtInstallCommand($extensionName, $extensionVersion) {
+    public function testExtInstallCommand($extensionName, $extensionVersion)
+    {
         $this->markTestSkipped("This test can not be run against system php");
         $this->assertTrue($this->runCommandWithStdout("phpbrew ext install $extensionName $extensionVersion"));
     }
@@ -28,7 +33,8 @@ class ExtensionCommandTest extends CommandTestCase
      * @dataProvider extensionNameProvider
      * @depends testExtInstallCommand
      */
-    public function testExtShowCommand($extensionName, $extensionVersion) {
+    public function testExtShowCommand($extensionName, $extensionVersion)
+    {
         $this->assertTrue($this->runCommandWithStdout("phpbrew ext show $extensionName"));
     }
 
@@ -39,7 +45,8 @@ class ExtensionCommandTest extends CommandTestCase
      * @dataProvider extensionNameProvider
      * @depends testExtInstallCommand
      */
-    public function testExtCleanCommand($extensionName, $extensionVersion) {
+    public function testExtCleanCommand($extensionName, $extensionVersion)
+    {
         $this->assertTrue($this->runCommandWithStdout("phpbrew ext clean $extensionName"));
     }
 
@@ -47,9 +54,8 @@ class ExtensionCommandTest extends CommandTestCase
      * @outputBuffering enabled
      * @depends testExtInstallCommand
      */
-    public function testExtListCommand() {
+    public function testExtListCommand()
+    {
         $this->assertTrue($this->runCommandWithStdout('phpbrew ext --show-path --show-options'));
     }
-
-
 }

--- a/tests/PhpBrew/Command/InfoCommandTest.php
+++ b/tests/PhpBrew/Command/InfoCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -10,9 +13,8 @@ class InfoCommandTest extends CommandTestCase
     /**
      * @outputBuffering enabled
      */
-    public function testInfoCommand() {
+    public function testInfoCommand()
+    {
         $this->assertCommandSuccess("phpbrew info");
     }
-
-
 }

--- a/tests/PhpBrew/Command/InitCommandTest.php
+++ b/tests/PhpBrew/Command/InitCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -10,11 +13,10 @@ class InitCommandTest extends CommandTestCase
     /**
      * @outputBuffering enabled
      */
-    public function testInitCommand() {
+    public function testInitCommand()
+    {
         ob_start();
         $this->assertTrue($this->runCommand("phpbrew init"));
         ob_end_clean();
     }
-
-
 }

--- a/tests/PhpBrew/Command/InstallCommandTest.php
+++ b/tests/PhpBrew/Command/InstallCommandTest.php
@@ -1,8 +1,10 @@
 <?php
-use PhpBrew\Testing\CommandTestCase;
-use PhpBrew\Machine;
-use PhpBrew\Config;
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\BuildFinder;
+use PhpBrew\Machine;
+use PhpBrew\Testing\CommandTestCase;
 
 /**
  * The install command tests are heavy.
@@ -33,6 +35,7 @@ class InstallCommandTest extends CommandTestCase
     /**
      * @depends testKnownCommand
      * @group install
+     * @group mayignore
      */
     public function testInstallCommand()
     {
@@ -76,7 +79,9 @@ class InstallCommandTest extends CommandTestCase
             $this->markTestSkipped('Skip heavy test on Travis');
         }
 
-        $this->assertCommandSuccess("phpbrew --debug install --dryrun github:php/php-src@PHP-7.0 as php-7.0.0 +cli+posix");
+        $this->assertCommandSuccess(
+            'phpbrew --debug install --dryrun github:php/php-src@PHP-7.0 as php-7.0.0 +cli+posix'
+        );
     }
 
     /**

--- a/tests/PhpBrew/Command/KnownCommandTest.php
+++ b/tests/PhpBrew/Command/KnownCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -13,7 +16,8 @@ class KnownCommandTest extends CommandTestCase
      * @outputBuffering enabled
      * @group mayignore
      */
-    public function testCommand() {
+    public function testCommand()
+    {
         $this->assertCommandSuccess('phpbrew --quiet known');
     }
 
@@ -21,14 +25,16 @@ class KnownCommandTest extends CommandTestCase
      * @outputBuffering enabled
      * @group mayignore
      */
-    public function testMoreOption() {
+    public function testMoreOption()
+    {
         $this->assertCommandSuccess('phpbrew --quiet known --more');
     }
 
     /**
      * @outputBuffering enabled
      */
-    public function testOldMoreOption() {
+    public function testOldMoreOption()
+    {
         $this->assertCommandSuccess('phpbrew --quiet known --old --more');
     }
 

--- a/tests/PhpBrew/Command/ListCommandTest.php
+++ b/tests/PhpBrew/Command/ListCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -10,9 +13,8 @@ class ListCommandTest extends CommandTestCase
     /**
      * @outputBuffering enabled
      */
-    public function testListCommand() {
+    public function testListCommand()
+    {
         $this->assertCommandSuccess("phpbrew list");
     }
-
-
 }

--- a/tests/PhpBrew/Command/PathCommandTest.php
+++ b/tests/PhpBrew/Command/PathCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -8,7 +11,8 @@ use PhpBrew\Testing\CommandTestCase;
 class PathCommandTest extends CommandTestCase
 {
 
-    public function argumentsProvider() {
+    public function argumentsProvider()
+    {
 
         return array(
             array("build",   "#\.phpbrew/build/.+#"),
@@ -26,7 +30,8 @@ class PathCommandTest extends CommandTestCase
      * @dataProvider argumentsProvider
      * @depends testUseLatestPHP
      */
-    public function testPathCommand($arg, $pattern) {
+    public function testPathCommand($arg, $pattern)
+    {
         ob_start();
         $this->runCommandWithStdout("phpbrew path $arg");
         $path = ob_get_clean();

--- a/tests/PhpBrew/Command/UpdateCommandTest.php
+++ b/tests/PhpBrew/Command/UpdateCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**

--- a/tests/PhpBrew/Command/VariantsCommandTest.php
+++ b/tests/PhpBrew/Command/VariantsCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PhpBrew\Tests\Command;
+
 use PhpBrew\Testing\CommandTestCase;
 
 /**
@@ -10,9 +13,8 @@ class VariantsCommandTest extends CommandTestCase
     /**
      * @outputBuffering enabled
      */
-    public function testVariantsCommand() {
+    public function testVariantsCommand()
+    {
         $this->assertCommandSuccess("phpbrew variants");
     }
-
-
 }

--- a/tests/PhpBrew/CommandBuilderTest.php
+++ b/tests/PhpBrew/CommandBuilderTest.php
@@ -1,14 +1,19 @@
 <?php
 
+namespace PhpBrew\Tests;
+
+use PhpBrew\CommandBuilder;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @small
  */
-class CommandBuilderTest extends \PHPUnit\Framework\TestCase
+class CommandBuilderTest extends TestCase
 {
     public function test()
     {
         ob_start();
-        $cmd = new PhpBrew\CommandBuilder('ls');
+        $cmd = new CommandBuilder('ls');
         $this->assertEquals(0, $cmd->execute());
         ob_end_clean();
     }
@@ -18,7 +23,7 @@ class CommandBuilderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCommand($appendLog, $stdout, $logPath, $expected)
     {
-        $cmd = new PhpBrew\CommandBuilder('ls');
+        $cmd = new CommandBuilder('ls');
         $cmd->setAppendLog($appendLog);
         $cmd->setStdout($stdout);
         $cmd->setLogPath($logPath);

--- a/tests/PhpBrew/ConfigTest.php
+++ b/tests/PhpBrew/ConfigTest.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace PhpBrew\Tests;
+
+use PhpBrew\Config;
+use PHPUnit\Framework\TestCase;
+
 /**
  * You should use predefined $PHPBREW_HOME and $PHPBREW_ROOT (defined
  * in phpunit.xml), because they are used to create directories in
@@ -8,13 +13,11 @@
  * the value to the corresponding environment variable.
  * @small
  */
-class ConfigTest extends \PHPUnit\Framework\TestCase
+class ConfigTest extends TestCase
 {
     public function test()
     {
-        $versions = PhpBrew\Config::getInstalledPhpVersions();
-        // ok( $versions );
-        // var_dump( $versions );
+        Config::getInstalledPhpVersions();
     }
 
     /**
@@ -27,8 +30,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             'PHPBREW_ROOT' => null,
             'HOME'         => null
         );
-        $this->withEnv($env, function() {
-            PhpBrew\Config::getHome();
+        $this->withEnv($env, function () {
+            Config::getHome();
         });
     }
 
@@ -38,22 +41,22 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             'HOME'         => getenv('PHPBREW_ROOT'),
             'PHPBREW_HOME' => null
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew/.phpbrew', PhpBrew\Config::getHome());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew/.phpbrew', Config::getHome());
         });
     }
 
-    public function testGetPhpbrewHomeWhenPHPBREW_HOMEIsDefined()
+    public function testGetPhpbrewHomeWhenPhpBrewHomeIsDefined()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getHome());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew', Config::getHome());
         });
     }
 
-    public function testGetPhpbrewRootWhenPHPBREW_ROOTIsDefined()
+    public function testGetPhpbrewRootWhenPhpBrewRootIsDefined()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getRoot());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew', Config::getRoot());
         });
     }
 
@@ -63,87 +66,87 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             'HOME'         => getenv('PHPBREW_ROOT'),
             'PHPBREW_ROOT' => null
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew/.phpbrew', PhpBrew\Config::getRoot());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew/.phpbrew', Config::getRoot());
         });
     }
 
     public function testGetVariants()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/variants', PhpBrew\Config::getVariantsDir());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/variants', Config::getVariantsDir());
         });
     }
 
     public function testGetBuildDir()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/build', PhpBrew\Config::getBuildDir());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/build', Config::getBuildDir());
         });
     }
 
     public function testGetDistFileDir()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/distfiles', PhpBrew\Config::getDistFileDir());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/distfiles', Config::getDistFileDir());
         });
     }
 
     public function testGetTempFileDir()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/tmp', PhpBrew\Config::getTempFileDir());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/tmp', Config::getTempFileDir());
         });
     }
 
     public function testGetCurrentPhpName()
     {
         $env = array('PHPBREW_PHP' => '5.6.3');
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('5.6.3', PhpBrew\Config::getCurrentPhpName());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('5.6.3', Config::getCurrentPhpName());
         });
     }
 
     public function testGetCurrentBuildDir()
     {
         $env = array('PHPBREW_PHP' => '5.6.3');
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew/build/5.6.3', PhpBrew\Config::getCurrentBuildDir());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew/build/5.6.3', Config::getCurrentBuildDir());
         });
     }
 
     public function testGetPHPReleaseListPath()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/php-releases.json', PhpBrew\Config::getPHPReleaseListPath());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php-releases.json', Config::getPHPReleaseListPath());
         });
     }
 
     public function testGetInstallPrefix()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/php', PhpBrew\Config::getInstallPrefix());
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php', Config::getInstallPrefix());
         });
     }
 
     public function testGetVersionInstallPrefix()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/php/5.5.1', PhpBrew\Config::getVersionInstallPrefix('5.5.1'));
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1', Config::getVersionInstallPrefix('5.5.1'));
         });
     }
 
     public function testGetVersionEtcPath()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/php/5.5.1/etc', PhpBrew\Config::getVersionEtcPath('5.5.1'));
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/etc', Config::getVersionEtcPath('5.5.1'));
         });
     }
 
     public function testGetVersionBinPath()
     {
-        $this->withEnv(array(), function($self) {
-            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin', PhpBrew\Config::getVersionBinPath('5.5.1'));
+        $this->withEnv(array(), function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin', Config::getVersionBinPath('5.5.1'));
         });
     }
 
@@ -152,8 +155,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $env = array(
             'PHPBREW_PHP'  => '5.5.1'
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin/php-config', PhpBrew\Config::getCurrentPhpConfigBin());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin/php-config', Config::getCurrentPhpConfigBin());
         });
     }
 
@@ -162,8 +165,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $env = array(
             'PHPBREW_PHP'  => '5.5.1'
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin/phpize', PhpBrew\Config::getCurrentPhpizeBin());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/bin/phpize', Config::getCurrentPhpizeBin());
         });
     }
 
@@ -172,8 +175,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $env = array(
             'PHPBREW_PHP'  => '5.5.1'
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew/php/5.5.1/var/db', PhpBrew\Config::getCurrentPhpConfigScanPath());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1/var/db', Config::getCurrentPhpConfigScanPath());
         });
     }
 
@@ -182,8 +185,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $env = array(
             'PHPBREW_PHP'  => '5.5.1'
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew/php/5.5.1', PhpBrew\Config::getCurrentPhpDir());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew/php/5.5.1', Config::getCurrentPhpDir());
         });
     }
 
@@ -192,8 +195,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $env = array(
             'PHPBREW_LOOKUP_PREFIX' => getenv('PHPBREW_ROOT'),
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getLookupPrefix());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew', Config::getLookupPrefix());
         });
     }
 
@@ -202,8 +205,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $env = array(
             'PHPBREW_PATH' => getenv('PHPBREW_ROOT'),
         );
-        $this->withEnv($env, function($self) {
-            $self->assertStringEndsWith('.phpbrew', PhpBrew\Config::getCurrentPhpBin());
+        $this->withEnv($env, function ($self) {
+            $self->assertStringEndsWith('.phpbrew', Config::getCurrentPhpBin());
         });
     }
 
@@ -214,11 +217,11 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             // 'PHPBREW_ROOT' => __DIR__ . '/../fixtures',
             'PHPBREW_ROOT' => 'tests/fixtures',
         );
-        $this->withEnv($env, function($self) {
-            $config = PhpBrew\Config::getConfig();
+        $this->withEnv($env, function ($self) {
+            $config = Config::getConfig();
             $self->assertSame(array('key1' => 'value1', 'key2' => 'value2'), $config);
-            $self->assertEquals('value1', PhpBrew\Config::getConfigParam('key1'));
-            $self->assertEquals('value2', PhpBrew\Config::getConfigParam('key2'));
+            $self->assertEquals('value1', Config::getConfigParam('key1'));
+            $self->assertEquals('value2', Config::getConfigParam('key2'));
         });
     }
 

--- a/tests/PhpBrew/Distribution/DistributionUrlPolicyTest.php
+++ b/tests/PhpBrew/Distribution/DistributionUrlPolicyTest.php
@@ -1,10 +1,14 @@
 <?php
-namespace PhpBrew\Distribution;
+
+namespace PhpBrew\Tests\Distribution;
+
+use PhpBrew\Distribution\DistributionUrlPolicy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class DistributionUrlPolicyTest extends \PHPUnit\Framework\TestCase
+class DistributionUrlPolicyTest extends TestCase
 {
     public $policy;
 
@@ -25,7 +29,8 @@ class DistributionUrlPolicyTest extends \PHPUnit\Framework\TestCase
     }
 
 
-    public function versionDataProvider() {
+    public function versionDataProvider()
+    {
         return array(
             array("5.3.29", "php-5.3.29.tar.bz2", "https://museum.php.net/php5/php-5.3.29.tar.bz2", true),
             array("5.4.7", "php-5.4.7.tar.bz2", "https://museum.php.net/php5/php-5.4.7.tar.bz2", true),

--- a/tests/PhpBrew/Downloader/DownloaderTest.php
+++ b/tests/PhpBrew/Downloader/DownloaderTest.php
@@ -1,24 +1,18 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: xiami
- * Date: 2015/12/30
- * Time: 12:23
- */
 
-namespace PhpBrew\Downloader;
+namespace PhpBrew\Tests\Downloader;
 
-
-use PhpBrew\Config;
 use CLIFramework\Logger;
 use GetOptionKit\OptionResult;
+use PhpBrew\Config;
+use PhpBrew\Downloader\DownloadFactory;
 use PhpBrew\Testing\VCRAdapter;
-use \PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @large
  */
-class DownloaderTest extends \PHPUnit\Framework\TestCase
+class DownloaderTest extends TestCase
 {
     public $logger;
 
@@ -30,7 +24,8 @@ class DownloaderTest extends \PHPUnit\Framework\TestCase
         VCRAdapter::enableVCR($this);
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         VCRAdapter::disableVCR();
     }
 
@@ -39,7 +34,7 @@ class DownloaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testDownloadByWgetCommand()
     {
-        $this->_test('PhpBrew\Downloader\WgetCommandDownloader');
+        $this->assertDownloaderWorks('PhpBrew\Downloader\WgetCommandDownloader');
     }
 
     /**
@@ -47,22 +42,22 @@ class DownloaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testDownloadByCurlCommand()
     {
-        $this->_test('PhpBrew\Downloader\CurlCommandDownloader');
+        $this->assertDownloaderWorks('PhpBrew\Downloader\CurlCommandDownloader');
     }
 
     public function testDownloadByCurlExtension()
     {
-        $this->_test('PhpBrew\Downloader\PhpCurlDownloader');
+        $this->assertDownloaderWorks('PhpBrew\Downloader\PhpCurlDownloader');
     }
 
     public function testDownloadByFileFunction()
     {
-        $this->_test('PhpBrew\Downloader\PhpStreamDownloader');
+        $this->assertDownloaderWorks('PhpBrew\Downloader\PhpStreamDownloader');
     }
 
-    private function _test($downloader)
+    private function assertDownloaderWorks($downloader)
     {
-        $instance = DownloadFactory::getInstance($this->logger, new OptionResult, $downloader);
+        $instance = DownloadFactory::getInstance($this->logger, new OptionResult(), $downloader);
         if ($instance->hasSupport(false)) {
             $actualFilePath = tempnam(Config::getTempFileDir(), '');
             $instance->download('http://httpbin.org/', $actualFilePath);

--- a/tests/PhpBrew/Extension/ExtensionInstallerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionInstallerTest.php
@@ -1,17 +1,14 @@
 <?php
-use PhpBrew\Utils;
-use PhpBrew\Config;
-use PhpBrew\Extension;
-use CLIFramework\Logger;;
+
+namespace PhpBrew\Tests\Extension;
+
+use CLIFramework\Logger;
 use GetOptionKit\OptionResult;
-use PhpBrew\Testing\VCRAdapter;
-use \PHPUnit\Framework\TestCase;
-use PhpBrew\Testing\CommandTestCase;
+use PhpBrew\Extension\ExtensionDownloader;
 use PhpBrew\Extension\ExtensionFactory;
 use PhpBrew\Extension\ExtensionManager;
-use PhpBrew\Extension\ExtensionDownloader;
 use PhpBrew\Extension\Provider\PeclProvider;
-use PhpBrew\Extension\PeclExtensionInstaller;
+use PhpBrew\Testing\CommandTestCase;
 
 /**
  * NOTE: This depends on an existing installed php build. we need to ensure
@@ -23,7 +20,8 @@ use PhpBrew\Extension\PeclExtensionInstaller;
 class ExtensionInstallerTest extends CommandTestCase
 {
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $versionName = $this->getPrimaryVersion();
         $this->runCommand("phpbrew use php-{$versionName}");
@@ -34,10 +32,10 @@ class ExtensionInstallerTest extends CommandTestCase
      */
     public function testPackageUrl()
     {
-        $logger = new Logger;
+        $logger = new Logger();
         $logger->setQuiet();
-        $peclProvider = new PeclProvider($logger, new OptionResult);
-        $downloader = new ExtensionDownloader($logger, new OptionResult);
+        $peclProvider = new PeclProvider($logger, new OptionResult());
+        $downloader = new ExtensionDownloader($logger, new OptionResult());
         $peclProvider->setPackageName('APCu');
         $extractPath = $downloader->download($peclProvider, 'latest');
         $this->assertFileExists($extractPath);
@@ -62,11 +60,11 @@ class ExtensionInstallerTest extends CommandTestCase
             $this->markTestSkipped('skip extension build test');
             return;
         }
-        $logger = new Logger;
+        $logger = new Logger();
         $logger->setDebug();
         $manager = new ExtensionManager($logger);
-        $peclProvider = new PeclProvider;
-        $downloader = new ExtensionDownloader($logger, new OptionResult);
+        $peclProvider = new PeclProvider();
+        $downloader = new ExtensionDownloader($logger, new OptionResult());
         $peclProvider->setPackageName($extensionName);
         $downloader->download($peclProvider, $extensionVersion);
         $ext = ExtensionFactory::lookup($extensionName);

--- a/tests/PhpBrew/Extension/ExtensionManagerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionManagerTest.php
@@ -1,9 +1,12 @@
 <?php
-namespace PhpBrew\Extension;
 
-use PhpBrew\Buildable;
+namespace PhpBrew\Tests\Extension;
+
 use CLIFramework\Logger;
+use PhpBrew\Extension\ExtensionFactory;
+use PhpBrew\Extension\ExtensionManager;
 use PhpBrew\Testing\VCRAdapter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ExtensionManagerTest
@@ -11,7 +14,7 @@ use PhpBrew\Testing\VCRAdapter;
  * @large
  * @group extension
  */
-class ExtensionManagerTest extends \PHPUnit\Framework\TestCase
+class ExtensionManagerTest extends TestCase
 {
     private $manager;
 

--- a/tests/PhpBrew/Extension/ExtensionTest.php
+++ b/tests/PhpBrew/Extension/ExtensionTest.php
@@ -1,12 +1,10 @@
 <?php
-namespace PhpBrew\Extension;
 
-use PhpBrew\Testing\VCRAdapter;
-use \PHPUnit\Framework\TestCase;
-use PhpBrew\Extension\Extension;
-use PhpBrew\Extension\M4Extension;
-use PhpBrew\Extension\PeclExtension;
+namespace PhpBrew\Tests\Extension;
+
 use PhpBrew\Extension\ExtensionFactory;
+use PhpBrew\Testing\VCRAdapter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ExtensionTest
@@ -14,7 +12,7 @@ use PhpBrew\Extension\ExtensionFactory;
  * @large
  * @group extension
  */
-class ExtensionTest extends \PHPUnit\Framework\TestCase
+class ExtensionTest extends TestCase
 {
     public function setUp()
     {
@@ -96,11 +94,12 @@ class ExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($ext->isZend());
     }
 
-    public function extensionNameProvider() {
+    public function extensionNameProvider()
+    {
         $extNames = scandir(getenv('PHPBREW_EXTENSION_DIR'));
         $data = array();
 
-        foreach( $extNames as $extName) {
+        foreach ($extNames as $extName) {
             if ($extName == "." || $extName == "..") {
                 continue;
             }
@@ -113,7 +112,8 @@ class ExtensionTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider extensionNameProvider
      */
-    public function testGenericExtensionMetaInformation($extName) {
+    public function testGenericExtensionMetaInformation($extName)
+    {
         $ext = ExtensionFactory::lookup($extName, array(getenv('PHPBREW_EXTENSION_DIR')));
         $this->assertInstanceOf('PhpBrew\Extension\Extension', $ext);
         $this->assertNotEmpty($ext->getName());

--- a/tests/PhpBrew/Extension/KnownCommandTest.php
+++ b/tests/PhpBrew/Extension/KnownCommandTest.php
@@ -1,31 +1,33 @@
 <?php
 
-namespace PhpBrew\Extension;
+namespace PhpBrew\Tests\Extension;
 
 use CLIFramework\Logger;
 use GetOptionKit\OptionResult;
+use PhpBrew\Extension\ExtensionDownloader;
 use PhpBrew\Extension\Provider\BitbucketProvider;
 use PhpBrew\Extension\Provider\GithubProvider;
 use PhpBrew\Extension\Provider\PeclProvider;
 use PhpBrew\Testing\CommandTestCase;
 
-class KnownCommandTest extends CommandTestCase {
+class KnownCommandTest extends CommandTestCase
+{
 
     public $usesVCR = true;
 
-    public function testPeclPackage() {
+    public function testPeclPackage()
+    {
 
-        $logger = new Logger;
+        $logger = new Logger();
         $logger->setQuiet();
 
         $provider = new PeclProvider($logger, new OptionResult());
         $provider->setPackageName('xdebug');
 
-        $extensionDownloader = new ExtensionDownloader($logger, new OptionResult);
+        $extensionDownloader = new ExtensionDownloader($logger, new OptionResult());
         $versionList = $extensionDownloader->knownReleases($provider);
 
         $this->assertNotCount(0, $versionList);
-
     }
 
     public function testGithubPackage()
@@ -34,25 +36,26 @@ class KnownCommandTest extends CommandTestCase {
             $this->markTestSkipped('Avoid bugging GitHub on Travis since the test is likely to fail because of a 403');
         }
 
-        $logger = new Logger;
+        $logger = new Logger();
         $logger->setQuiet();
 
         $provider = new GithubProvider();
         $provider->setOwner('phalcon');
         $provider->setRepository('cphalcon');
         $provider->setPackageName('phalcon');
-        if(getenv('github_token')) { //load token from travis-ci
+        if (getenv('github_token')) { //load token from travis-ci
             $provider->setAuth(getenv('github_token'));
         }
 
-        $extensionDownloader = new ExtensionDownloader($logger, new OptionResult);
+        $extensionDownloader = new ExtensionDownloader($logger, new OptionResult());
         $versionList = $extensionDownloader->knownReleases($provider);
         $this->assertNotCount(0, $versionList);
     }
 
-    public function testBitbucketPackage() {
+    public function testBitbucketPackage()
+    {
 
-        $logger = new Logger;
+        $logger = new Logger();
         $logger->setQuiet();
 
         $provider = new BitbucketProvider();
@@ -60,12 +63,9 @@ class KnownCommandTest extends CommandTestCase {
         $provider->setRepository('pecl-event');
         $provider->setPackageName('event');
 
-        $extensionDownloader = new ExtensionDownloader($logger, new OptionResult);
+        $extensionDownloader = new ExtensionDownloader($logger, new OptionResult());
         $versionList = $extensionDownloader->knownReleases($provider);
 
         $this->assertNotCount(0, $versionList);
-
     }
-
 }
-

--- a/tests/PhpBrew/Extension/Provider/RepositoryDslParserTest.php
+++ b/tests/PhpBrew/Extension/Provider/RepositoryDslParserTest.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace PhpBrew\Extension\Provider;
+namespace PhpBrew\Tests\Extension\Provider;
+
+use PhpBrew\Extension\Provider\RepositoryDslParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ExtensionDslParserTest
@@ -8,20 +11,20 @@ namespace PhpBrew\Extension\Provider;
  * @small
  * @group extension
  */
-class ExtensionDslParserTest extends \PHPUnit\Framework\TestCase
+class ExtensionDslParserTest extends TestCase
 {
     protected $parser;
 
     public function setUp()
     {
-        $this->parser = new RepositoryDslParser;
+        $this->parser = new RepositoryDslParser();
     }
 
-    public function DslProvider()
+    public static function dslProvider()
     {
         return array(
             // pecl
-            array('xdebug', 'pecl', null, 'xdebug'), // standard pecl package namce
+            array('xdebug', 'pecl', null, 'xdebug'), // standard pecl package name
             array('APCu', 'pecl', null, 'APCu'), // pecl package name with mixed uppercase/lowercase
             array('com_dotnet', 'pecl', null, 'com_dotnet'), // pecl package name with _
             // github
@@ -29,22 +32,28 @@ class ExtensionDslParserTest extends \PHPUnit\Framework\TestCase
             array('git@github.com:foo/bar', 'github', 'foo', 'bar'), // long github dsl
             array('http://github.com/foo/bar', 'github', 'foo', 'bar'), // raw http guthub url
             array('https://github.com/foo/bar', 'github', 'foo', 'bar'), // raw https guthub url
-            array('https://www.github.com/foo/bar', 'github', 'foo', 'bar'), // somebody really likes to type githubs urls...
+
+            // somebody really likes to type GitHub URLs...
+            array('https://www.github.com/foo/bar', 'github', 'foo', 'bar'),
             // bitbucket
             array('bitbucket:foo/bar', 'bitbucket', 'foo', 'bar'), // short bitbucket dsl
             array('git@bitbucket.org:foo/bar', 'bitbucket', 'foo', 'bar'), // long bitbucket dsl
             array('http://bitbucket.org/foo/bar', 'bitbucket', 'foo', 'bar'), // raw http bitbucket url
             array('https://bitbucket.org/foo/bar', 'bitbucket', 'foo', 'bar'), // raw https bitbucket url
-            array('http://www.bitbucket.org/foo/bar', 'bitbucket', 'foo', 'bar'), // somebody really likes to type bitbuckets urls...
+
+            // somebody really likes to type BitBuckets URLs...
+            array('http://www.bitbucket.org/foo/bar', 'bitbucket', 'foo', 'bar'),
             // user is feeling luky and finds extension that is not on github or bitbucket
             array('http://luky.feelings.org/foo/bar', 'luky', 'foo', 'bar'), // raw http luky url
             array('https://luky.feelings.org/foo/bar', 'luky', 'foo', 'bar'), // raw https luky url
-            array('http://www.luky.feelings.org/foo/bar', 'luky', 'foo', 'bar'), // somebody is really luky if this ext compiles...
+
+            // somebody is really luky if this ext compiles...
+            array('http://www.luky.feelings.org/foo/bar', 'luky', 'foo', 'bar'),
         );
     }
 
     /**
-     * @dataProvider DslProvider
+     * @dataProvider dslProvider
      */
     public function testGithubDsl($dsl, $repo, $owner, $package)
     {

--- a/tests/PhpBrew/MachineTest.php
+++ b/tests/PhpBrew/MachineTest.php
@@ -1,14 +1,17 @@
 <?php
 
-use PhpBrew\Machine;
+namespace PhpBrew\Tests;
 
-class MachineTest extends \PHPUnit\Framework\TestCase
+use PhpBrew\Machine;
+use PHPUnit\Framework\TestCase;
+
+class MachineTest extends TestCase
 {
     public function testDetectProcessorNumber()
     {
         $machine = new MachineForTest();
         if (!$machine->detectProcessorNumber()) {
-            return $this->markTestSkipped('processor number detect failed.');
+            $this->markTestSkipped('processor number detect failed.');
         }
 
         ok($machine->detectProcessorNumber() > 0);

--- a/tests/PhpBrew/PatchUtilsTest.php
+++ b/tests/PhpBrew/PatchUtilsTest.php
@@ -1,14 +1,18 @@
 <?php
+
+namespace PhpBrew\Tests;
+
 use PhpBrew\PatchUtils;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class PatchUtilsTest extends \PHPUnit\Framework\TestCase
+class PatchUtilsTest extends TestCase
 {
     public function test()
     {
-        $diff =<<<'PATCH'
+        $diff = <<<'PATCH'
 --- tests/a.txt	2014-10-11 23:04:39.000000000 +0800
 +++ tests/b.txt	2014-10-11 23:04:50.000000000 +0800
 @@ -1 +1 @@

--- a/tests/PhpBrew/Patches/Apache2ModuleNamePatchTest.php
+++ b/tests/PhpBrew/Patches/Apache2ModuleNamePatchTest.php
@@ -1,9 +1,10 @@
 <?php
+
+namespace PhpBrew\Tests\Patches;
+
 use CLIFramework\Logger;
 use PhpBrew\Build;
-use PhpBrew\Patches\IntlWith64bitPatch;
 use PhpBrew\Patches\Apache2ModuleNamePatch;
-use PhpBrew\Utils;
 use PhpBrew\Testing\PatchTestCase;
 
 /**
@@ -21,7 +22,7 @@ class Apache2ModuleNamePatchTest extends PatchTestCase
         $sourceDirectory = getenv('PHPBREW_BUILD_PHP_DIR');
 
         if (!is_dir($sourceDirectory)) {
-            return $this->markTestSkipped("$sourceDirectory does not exist.");
+            $this->markTestSkipped("$sourceDirectory does not exist.");
         }
 
         $this->setupBuildDirectory($fromVersion);
@@ -31,14 +32,14 @@ class Apache2ModuleNamePatchTest extends PatchTestCase
         $build->enableVariant('apxs2');
         $this->assertTrue($build->hasVariant('apxs2'), 'apxs2 enabled');
 
-        $patch = new Apache2ModuleNamePatch;
+        $patch = new Apache2ModuleNamePatch();
         $matched = $patch->match($build, $logger);
         $this->assertTrue($matched, 'patch matched');
         $patchedCount = $patch->apply($build, $logger);
         $this->assertEquals(107, $patchedCount);
 
         $sourceExpectedDirectory = getenv('PHPBREW_EXPECTED_PHP_DIR') . DIRECTORY_SEPARATOR . '5.5.17-apxs-patch';
-        $this->assertFileEquals($sourceExpectedDirectory. '/Makefile.global', $sourceDirectory . '/Makefile.global');
-        $this->assertFileEquals($sourceExpectedDirectory. '/configure', $sourceDirectory . '/configure');
+        $this->assertFileEquals($sourceExpectedDirectory . '/Makefile.global', $sourceDirectory . '/Makefile.global');
+        $this->assertFileEquals($sourceExpectedDirectory . '/configure', $sourceDirectory . '/configure');
     }
 }

--- a/tests/PhpBrew/Patches/IntlWith64bitPatchTest.php
+++ b/tests/PhpBrew/Patches/IntlWith64bitPatchTest.php
@@ -1,8 +1,10 @@
 <?php
+
+namespace PhpBrew\Tests\Patches;
+
 use CLIFramework\Logger;
 use PhpBrew\Build;
 use PhpBrew\Patches\IntlWith64bitPatch;
-use PhpBrew\Utils;
 use PhpBrew\Testing\PatchTestCase;
 
 class IntlWith64bitPatchTest extends PatchTestCase
@@ -17,7 +19,7 @@ class IntlWith64bitPatchTest extends PatchTestCase
         $sourceDirectory = getenv('PHPBREW_BUILD_PHP_DIR');
 
         if (!is_dir($sourceDirectory)) {
-            return $this->markTestSkipped("$sourceDirectory does not exist.");
+            $this->markTestSkipped("$sourceDirectory does not exist.");
         }
 
         // Copy the source Makefile to the Makefile
@@ -29,13 +31,13 @@ class IntlWith64bitPatchTest extends PatchTestCase
         $build->enableVariant('intl');
         $this->assertTrue($build->hasVariant('intl'), 'intl enabled');
 
-        $patch = new IntlWith64bitPatch;
+        $patch = new IntlWith64bitPatch();
         $matched = $patch->match($build, $logger);
         $this->assertTrue($matched, 'patch matched');
         $patchedCount = $patch->apply($build, $logger);
         $this->assertEquals(3, $patchedCount);
 
         $sourceExpectedDirectory = getenv('PHPBREW_EXPECTED_PHP_DIR') . DIRECTORY_SEPARATOR . $fromVersion;
-        $this->assertFileEquals($sourceExpectedDirectory. '/Makefile', $sourceDirectory . '/Makefile');
+        $this->assertFileEquals($sourceExpectedDirectory . '/Makefile', $sourceDirectory . '/Makefile');
     }
 }

--- a/tests/PhpBrew/Patches/OpenSSLDSOPatchTest.php
+++ b/tests/PhpBrew/Patches/OpenSSLDSOPatchTest.php
@@ -1,10 +1,10 @@
 <?php
+
+namespace PhpBrew\Tests\Patches;
+
 use CLIFramework\Logger;
 use PhpBrew\Build;
-use PhpBrew\Patches\IntlWith64bitPatch;
-use PhpBrew\Patches\Apache2ModuleNamePatch;
 use PhpBrew\Patches\OpenSSLDSOPatch;
-use PhpBrew\Utils;
 use PhpBrew\Testing\PatchTestCase;
 
 /**
@@ -15,7 +15,7 @@ class OpenSSLDSOPatchTest extends PatchTestCase
     public function testPatch()
     {
         if (PHP_OS !== "Darwin") {
-            return $this->markTestSkipped('openssl DSO patch test only runs on darwin platform');
+            $this->markTestSkipped('openssl DSO patch test only runs on darwin platform');
         }
 
         $logger = new Logger();
@@ -33,17 +33,10 @@ class OpenSSLDSOPatchTest extends PatchTestCase
         $this->assertTrue($build->hasVariant('openssl'), 'openssl enabled');
 
 
-        $patch = new OpenSSLDSOPatch;
+        $patch = new OpenSSLDSOPatch();
         $matched = $patch->match($build, $logger);
         $this->assertTrue($matched, 'patch matched');
         $patchedCount = $patch->apply($build, $logger);
         $this->assertEquals(10, $patchedCount);
-        /*
-        We can't assume the file equals because the test may be run on different platform and openssl may be installed 
-        into different locations.
-
-        $sourceExpectedDirectory = getenv('PHPBREW_EXPECTED_PHP_DIR') . DIRECTORY_SEPARATOR . '5.5.17-openssl-dso-patch';
-        $this->assertFileEquals($sourceExpectedDirectory. '/Makefile', $sourceDirectory . '/Makefile');
-         */
     }
 }

--- a/tests/PhpBrew/Platform/Linux/CentOSTest.php
+++ b/tests/PhpBrew/Platform/Linux/CentOSTest.php
@@ -1,10 +1,14 @@
 <?php
-namespace PhpBrew\Platform\Linux;
+
+namespace PhpBrew\Tests\Platform\Linux;
+
+use PhpBrew\Platform\Linux\CentOS;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class CentOSTest extends \PHPUnit\Framework\TestCase
+class CentOSTest extends TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/Linux/DebianTest.php
+++ b/tests/PhpBrew/Platform/Linux/DebianTest.php
@@ -1,10 +1,14 @@
 <?php
-namespace PhpBrew\Platform\Linux;
+
+namespace PhpBrew\Tests\Platform\Linux;
+
+use PhpBrew\Platform\Linux\Debian;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class DebianTest extends \PHPUnit\Framework\TestCase
+class DebianTest extends TestCase
 {
     private $distribution;
 

--- a/tests/PhpBrew/Platform/Linux/UnknownDistributionTest.php
+++ b/tests/PhpBrew/Platform/Linux/UnknownDistributionTest.php
@@ -1,10 +1,14 @@
 <?php
-namespace PhpBrew\Platform\Linux;
+
+namespace PhpBrew\Tests\Platform\Linux;
+
+use PhpBrew\Platform\Linux\UnknownDistribution;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class UnknownDistributionTest extends \PHPUnit\Framework\TestCase
+class UnknownDistributionTest extends TestCase
 {
     private $distribution;
 
@@ -28,4 +32,3 @@ class UnknownDistributionTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->distribution->isCentOS());
     }
 }
-

--- a/tests/PhpBrew/Platform/LinuxTest.php
+++ b/tests/PhpBrew/Platform/LinuxTest.php
@@ -1,12 +1,16 @@
 <?php
-namespace PhpBrew\Platform;
 
+namespace PhpBrew\Tests\Platform;
+
+use PhpBrew\Platform\Hardware;
+use PhpBrew\Platform\Linux;
 use PhpBrew\Platform\Linux\Distribution;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class LinuxTest extends \PHPUnit\Framework\TestCase
+class LinuxTest extends TestCase
 {
     private $hardware;
     private $distribution;

--- a/tests/PhpBrew/Platform/MacTest.php
+++ b/tests/PhpBrew/Platform/MacTest.php
@@ -1,10 +1,15 @@
 <?php
-namespace PhpBrew\Platform;
+
+namespace PhpBrew\Tests\Platform;
+
+use PhpBrew\Platform\Hardware;
+use PhpBrew\Platform\Mac;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class MacTest extends \PHPUnit\Framework\TestCase
+class MacTest extends TestCase
 {
     private $hardware;
     private $platform;

--- a/tests/PhpBrew/Platform/PlatformInfoTest.php
+++ b/tests/PhpBrew/Platform/PlatformInfoTest.php
@@ -1,10 +1,14 @@
 <?php
-namespace PhpBrew\Platform;
+
+namespace PhpBrew\Tests\Platform;
+
+use PhpBrew\Platform\PlatformInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class PlatformInfoTest extends \PHPUnit\Framework\TestCase
+class PlatformInfoTest extends TestCase
 {
     public function testCreateMacPlatform()
     {

--- a/tests/PhpBrew/Platform/UnixLikeHardwareTest.php
+++ b/tests/PhpBrew/Platform/UnixLikeHardwareTest.php
@@ -1,10 +1,14 @@
 <?php
-namespace PhpBrew\Platform;
+
+namespace PhpBrew\Tests\Platform;
+
+use PhpBrew\Platform\UnixLikeHardware;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class UnixLikeHardwareTest extends \PHPUnit\Framework\TestCase
+class UnixLikeHardwareTest extends TestCase
 {
     public function testBitnessWhenHardwareIs64Bit()
     {

--- a/tests/PhpBrew/Platform/UnknownPlatformTest.php
+++ b/tests/PhpBrew/Platform/UnknownPlatformTest.php
@@ -1,10 +1,14 @@
 <?php
-namespace PhpBrew\Platform;
+
+namespace PhpBrew\Tests\Platform;
+
+use PhpBrew\Platform\UnknownPlatform;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class UnknownPlatformTest extends \PHPUnit\Framework\TestCase
+class UnknownPlatformTest extends TestCase
 {
     private $platform;
 

--- a/tests/PhpBrew/ReleaseListTest.php
+++ b/tests/PhpBrew/ReleaseListTest.php
@@ -1,17 +1,21 @@
 <?php
+
+namespace PhpBrew\Tests;
+
 use PhpBrew\ReleaseList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class ReleaseListTest extends \PHPUnit\Framework\TestCase
+class ReleaseListTest extends TestCase
 {
     public $releaseList;
 
     public function setUp()
     {
-        $this->releaseList = new ReleaseList;
-        $this->releaseList->loadJsonFile(__DIR__.'/../fixtures/php-releases.json');
+        $this->releaseList = new ReleaseList();
+        $this->releaseList->loadJsonFile(__DIR__ . '/../fixtures/php-releases.json');
     }
 
     public function testGetVersions()
@@ -31,7 +35,8 @@ class ReleaseListTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function versionDataProvider() {
+    public function versionDataProvider()
+    {
         return array(
             array("7.3", "7.3.0"),
             array("7.2", "7.2.13"),

--- a/tests/PhpBrew/Tasks/MakeTaskTest.php
+++ b/tests/PhpBrew/Tasks/MakeTaskTest.php
@@ -1,14 +1,17 @@
 <?php
-namespace PhpBrew\Tasks;
 
-use GetOptionKit\OptionResult;
+namespace PhpBrew\Tests\Tasks;
+
 use CLIFramework\Logger;
+use GetOptionKit\OptionResult;
 use PhpBrew\Buildable;
+use PhpBrew\Tasks\MakeTask;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class MakeTaskTest extends \PHPUnit\Framework\TestCase
+class MakeTaskTest extends TestCase
 {
     private $make;
 
@@ -72,7 +75,7 @@ class MakeTaskTestBuild implements Buildable
     {
         return null;
     }
-    
+
     public function isBuildable()
     {
         return true;
@@ -90,7 +93,7 @@ class MakeTaskTestNoSuchFileBuild implements Buildable
     {
         return null;
     }
-    
+
     public function isBuildable()
     {
         return false;

--- a/tests/PhpBrew/UtilsTest.php
+++ b/tests/PhpBrew/UtilsTest.php
@@ -1,11 +1,14 @@
 <?php
+
+namespace PhpBrew\Tests;
+
 use PhpBrew\Utils;
-use PhpBrew\Config;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class UtilsTest extends \PHPUnit\Framework\TestCase
+class UtilsTest extends TestCase
 {
     public function test()
     {
@@ -19,8 +22,8 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
 
     public function testFindIcuPkgData()
     {
-        return $this->markTestSkipped('icu/pkgdata.inc is not found on Ubuntu Linux');
-        $this->assertNotNull(Utils::findLibPrefix('icu/pkgdata.inc','icu/Makefile.inc'));
+        $this->markTestSkipped('icu/pkgdata.inc is not found on Ubuntu Linux');
+        $this->assertNotNull(Utils::findLibPrefix('icu/pkgdata.inc', 'icu/Makefile.inc'));
     }
 
     public function testPrefix()

--- a/tests/PhpBrew/VariantBuilderTest.php
+++ b/tests/PhpBrew/VariantBuilderTest.php
@@ -1,12 +1,16 @@
 <?php
-use PhpBrew\VariantBuilder;
+
+namespace PhpBrew\Tests;
+
 use PhpBrew\Build;
+use PhpBrew\VariantBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  * @group macosIncompatible
  */
-class VariantBuilderTest extends \PHPUnit\Framework\TestCase
+class VariantBuilderTest extends TestCase
 {
     public function variantOptionProvider()
     {
@@ -50,7 +54,7 @@ class VariantBuilderTest extends \PHPUnit\Framework\TestCase
             $k = explode('=', $variant, 2);
 
             if (getenv('TRAVIS') && in_array($k[0], array("apxs2","gd","editline"))) {
-                return $this->markTestSkipped("Travis CI doesn't support {$k[0]}.");
+                $this->markTestSkipped("Travis CI doesn't support {$k[0]}.");
             }
 
             if (count($k) == 2) {
@@ -60,7 +64,7 @@ class VariantBuilderTest extends \PHPUnit\Framework\TestCase
             }
         }
         $build->resolveVariants();
-        $variantBuilder = new VariantBuilder;
+        $variantBuilder = new VariantBuilder();
         $options = $variantBuilder->build($build);
 
         $patterns = (array) $optionPattern;
@@ -71,35 +75,35 @@ class VariantBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function test()
     {
-        $variants = new VariantBuilder;
+        $variants = new VariantBuilder();
         $build = new Build('5.3.0');
         $build->enableVariant('debug');
         $build->enableVariant('sqlite');
         $build->enableVariant('xml_all');
-        $build->enableVariant('apxs2','/opt/local/apache2/apxs2');
+        $build->enableVariant('apxs2', '/opt/local/apache2/apxs2');
 
         $build->disableVariant('sqlite');
         $build->disableVariant('mysql');
         $build->resolveVariants();
         $options = $variants->build($build);
-        ok( in_array('--enable-debug',$options) );
-        ok( in_array('--enable-libxml',$options) );
-        ok( in_array('--enable-simplexml',$options) );
+        ok(in_array('--enable-debug', $options));
+        ok(in_array('--enable-libxml', $options));
+        ok(in_array('--enable-simplexml', $options));
 
-        ok( in_array('--with-apxs2=/opt/local/apache2/apxs2',$options) );
+        ok(in_array('--with-apxs2=/opt/local/apache2/apxs2', $options));
 
-        ok( in_array('--without-sqlite3',$options) );
-        ok( in_array('--without-mysql',$options) );
-        ok( in_array('--without-mysqli',$options) );
-        ok( in_array('--disable-all',$options) );
+        ok(in_array('--without-sqlite3', $options));
+        ok(in_array('--without-mysql', $options));
+        ok(in_array('--without-mysqli', $options));
+        ok(in_array('--disable-all', $options));
     }
 
     public function testEverything()
     {
-        $variants = new PhpBrew\VariantBuilder;
+        $variants = new VariantBuilder();
         ok($variants);
 
-        $build = new PhpBrew\Build('5.6.0');
+        $build = new Build('5.6.0');
         $build->enableVariant('everything');
         $build->disableVariant('openssl');
         $build->resolveVariants();
@@ -114,26 +118,26 @@ class VariantBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testMysqlPdoVariant()
     {
-        $variants = new PhpBrew\VariantBuilder;
+        $variants = new VariantBuilder();
         ok($variants);
 
-        $build = new PhpBrew\Build('5.3.0');
+        $build = new Build('5.3.0');
         $build->enableVariant('pdo');
         $build->enableVariant('mysql');
         $build->enableVariant('sqlite');
         $build->resolveVariants();
 
         $options = $variants->build($build);
-        $this->assertContains('--enable-pdo',$options);
-        $this->assertContains('--with-mysql=mysqlnd',$options);
-        $this->assertContains('--with-mysqli=mysqlnd',$options);
-        $this->assertContains('--with-pdo-mysql=mysqlnd',$options);
-        $this->assertContains('--with-pdo-sqlite',$options);
+        $this->assertContains('--enable-pdo', $options);
+        $this->assertContains('--with-mysql=mysqlnd', $options);
+        $this->assertContains('--with-mysqli=mysqlnd', $options);
+        $this->assertContains('--with-pdo-mysql=mysqlnd', $options);
+        $this->assertContains('--with-pdo-sqlite', $options);
     }
 
     public function testAllVariant()
     {
-        $variants = new VariantBuilder;
+        $variants = new VariantBuilder();
         $build = new Build('5.3.0');
         $build->enableVariant('all');
         $build->disableVariant('mysql');
@@ -141,9 +145,9 @@ class VariantBuilderTest extends \PHPUnit\Framework\TestCase
         $build->resolveVariants();
 
         $options = $variants->build($build);
-        $this->assertContains('--enable-all',$options);
-        $this->assertContains('--without-apxs2',$options);
-        $this->assertContains('--without-mysql',$options);
+        $this->assertContains('--enable-all', $options);
+        $this->assertContains('--without-apxs2', $options);
+        $this->assertContains('--without-mysql', $options);
     }
 
     /**
@@ -151,7 +155,7 @@ class VariantBuilderTest extends \PHPUnit\Framework\TestCase
      */
     public function testNeutralVirtualVariant()
     {
-        $variants = new VariantBuilder;
+        $variants = new VariantBuilder();
         $build = new Build('5.3.0');
         // $build->setVersion('5.3.0');
         $build->enableVariant('neutral');

--- a/tests/PhpBrew/VariantParserTest.php
+++ b/tests/PhpBrew/VariantParserTest.php
@@ -1,10 +1,14 @@
 <?php
+
+namespace PhpBrew\Tests;
+
 use PhpBrew\VariantParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class VariantParserTest extends \PHPUnit\Framework\TestCase
+class VariantParserTest extends TestCase
 {
     public function makeArgs($arg)
     {
@@ -76,7 +80,9 @@ class VariantParserTest extends \PHPUnit\Framework\TestCase
 
     public function testVariantUserValueContainsVersion()
     {
-        $variants = $this->makeArgs('+openssl=/usr/local/Cellar/openssl/1.0.2e +gettext=/usr/local/Cellar/gettext/0.19.7');
+        $variants = $this->makeArgs(
+            '+openssl=/usr/local/Cellar/openssl/1.0.2e +gettext=/usr/local/Cellar/gettext/0.19.7'
+        );
         $expected = array(
             'enabled_variants' => array(
                 'openssl' => '/usr/local/Cellar/openssl/1.0.2e',

--- a/tests/PhpBrew/VersionDslParserTest.php
+++ b/tests/PhpBrew/VersionDslParserTest.php
@@ -1,13 +1,16 @@
 <?php
 
-namespace PhpBrew;
+namespace PhpBrew\Tests;
+
+use PhpBrew\VersionDslParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * VersionDslParserTest
  *
  * @small
  */
-class VersionDslParserTest extends \PHPUnit\Framework\TestCase
+class VersionDslParserTest extends TestCase
 {
     /**
      * @var VersionDslParser
@@ -16,20 +19,43 @@ class VersionDslParserTest extends \PHPUnit\Framework\TestCase
 
     public function setUp()
     {
-        $this->parser = new VersionDslParser;
+        $this->parser = new VersionDslParser();
     }
 
-    public function DslProvider()
+    public static function dslProvider()
     {
         return array(
             // official
-            array('github:php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'), // implicit branch
-            array('github:php/php-src@branch', 'https://github.com/php/php-src/archive/branch.tar.gz', 'php-branch'), // explicit branch
-            array('github.com:php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'), // implicit branch
-            array('github.com:php/php-src@branch', 'https://github.com/php/php-src/archive/branch.tar.gz', 'php-branch'), // explicit branch
-            array('git@github.com:php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'), // implicit branch
-            array('git@github.com:php/php-src@branch', 'https://github.com/php/php-src/archive/branch.tar.gz', 'php-branch'), // explicit branch
-            array('git@github.com:php/php-src@php-7.1.0RC3', 'https://github.com/php/php-src/archive/php-7.1.0RC3.tar.gz', 'php-7.1.0RC3'), // tag
+            // implicit branch
+            array(
+                'github:php/php-src',
+                'https://github.com/php/php-src/archive/master.tar.gz',
+                'php-master',
+            ),
+            // explicit branch
+            array('github:php/php-src@branch', 'https://github.com/php/php-src/archive/branch.tar.gz', 'php-branch'),
+            // implicit branch
+            array('github.com:php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'),
+            // explicit branch
+            array(
+                'github.com:php/php-src@branch',
+                'https://github.com/php/php-src/archive/branch.tar.gz',
+                'php-branch',
+            ),
+            // implicit branch
+            array('git@github.com:php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'),
+            // explicit branch
+            array(
+                'git@github.com:php/php-src@branch',
+                'https://github.com/php/php-src/archive/branch.tar.gz',
+                'php-branch',
+            ),
+            // tag
+            array(
+                'git@github.com:php/php-src@php-7.1.0RC3',
+                'https://github.com/php/php-src/archive/php-7.1.0RC3.tar.gz',
+                'php-7.1.0RC3',
+            ),
 
             // pre-release versions without the github: prefix
             array(
@@ -49,28 +75,70 @@ class VersionDslParserTest extends \PHPUnit\Framework\TestCase
             ),
 
             // github urls
-            array('https://www.github.com/php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'),
-            array('http://www.github.com/php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'),
+            array(
+                'https://www.github.com/php/php-src',
+                'https://github.com/php/php-src/archive/master.tar.gz',
+                'php-master',
+            ),
+            array(
+                'http://www.github.com/php/php-src',
+                'https://github.com/php/php-src/archive/master.tar.gz',
+                'php-master',
+            ),
             array('www.github.com/php/php-src', 'https://github.com/php/php-src/archive/master.tar.gz', 'php-master'),
 
             // forks
             array('github:marc/php-src', 'https://github.com/marc/php-src/archive/master.tar.gz', 'php-marc-master'),
-            array('github.com:marc/php-src', 'https://github.com/marc/php-src/archive/master.tar.gz', 'php-marc-master'), // implicit branch
-            array('git@github.com:marc/php-src', 'https://github.com/marc/php-src/archive/master.tar.gz', 'php-marc-master'),
-            array('https://www.github.com/marc/php-src', 'https://github.com/marc/php-src/archive/master.tar.gz', 'php-marc-master'),
-            array('git@github.com:marc/php-src@php-7.1.0RC3', 'https://github.com/marc/php-src/archive/php-7.1.0RC3.tar.gz', 'php-marc-7.1.0RC3'), // tag in fork
+            // implicit branch
+            array(
+                'github.com:marc/php-src',
+                'https://github.com/marc/php-src/archive/master.tar.gz',
+                'php-marc-master',
+            ),
+            array(
+                'git@github.com:marc/php-src',
+                'https://github.com/marc/php-src/archive/master.tar.gz',
+                'php-marc-master',
+            ),
+            array(
+                'https://www.github.com/marc/php-src',
+                'https://github.com/marc/php-src/archive/master.tar.gz',
+                'php-marc-master',
+            ),
+            // tag in fork
+            array(
+                'git@github.com:marc/php-src@php-7.1.0RC3',
+                'https://github.com/marc/php-src/archive/php-7.1.0RC3.tar.gz',
+                'php-marc-7.1.0RC3',
+            ),
 
             // Other URLs
-            array('https://www.php.net/~ab/php-7.0.0alpha1.tar.gz', 'https://www.php.net/~ab/php-7.0.0alpha1.tar.gz', 'php-7.0.0alpha1'),
-            array('https://www.php.net/~ab/php-7.0.0beta2.tar.gz', 'https://www.php.net/~ab/php-7.0.0beta2.tar.gz', 'php-7.0.0beta2'),
-            array('https://www.php.net/~ab/php-7.0.0RC3.tar.gz', 'https://www.php.net/~ab/php-7.0.0RC3.tar.gz', 'php-7.0.0RC3'),
+            array(
+                'https://www.php.net/~ab/php-7.0.0alpha1.tar.gz',
+                'https://www.php.net/~ab/php-7.0.0alpha1.tar.gz',
+                'php-7.0.0alpha1',
+            ),
+            array(
+                'https://www.php.net/~ab/php-7.0.0beta2.tar.gz',
+                'https://www.php.net/~ab/php-7.0.0beta2.tar.gz',
+                'php-7.0.0beta2',
+            ),
+            array(
+                'https://www.php.net/~ab/php-7.0.0RC3.tar.gz',
+                'https://www.php.net/~ab/php-7.0.0RC3.tar.gz',
+                'php-7.0.0RC3',
+            ),
             array('https://www.php.net/~ab/php-7.0.0.tar.gz', 'https://www.php.net/~ab/php-7.0.0.tar.gz', 'php-7.0.0'),
-            array('http://php.net/distributions/php-5.6.14.tar.bz2', 'http://php.net/distributions/php-5.6.14.tar.bz2', 'php-5.6.14'),
-          );
+            array(
+                'http://php.net/distributions/php-5.6.14.tar.bz2',
+                'http://php.net/distributions/php-5.6.14.tar.bz2',
+                'php-5.6.14',
+            ),
+        );
     }
 
     /**
-     * @dataProvider DslProvider
+     * @dataProvider dslProvider
      */
     public function testGithubDsl($dsl, $url, $version)
     {

--- a/tests/PhpBrew/VersionTest.php
+++ b/tests/PhpBrew/VersionTest.php
@@ -1,34 +1,41 @@
 <?php
+
+namespace PhpBrew\Tests;
+
 use PhpBrew\Version;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
  */
-class VersionTest extends \PHPUnit\Framework\TestCase
+class VersionTest extends TestCase
 {
     public function testVersionConstructor()
     {
         $versionA = new Version('php-5.4.22');
         $versionB = new Version('5.4.22', 'php');
 
-        $this->assertEquals('php-5.4.22',$versionA->getCanonicalizedVersionName());
-        $this->assertEquals('php-5.4.22',$versionB->getCanonicalizedVersionName());
-        $this->assertEquals('5.4.22',$versionA->getVersion());
-        $this->assertEquals('5.4.22',$versionB->getVersion());
+        $this->assertEquals('php-5.4.22', $versionA->getCanonicalizedVersionName());
+        $this->assertEquals('php-5.4.22', $versionB->getCanonicalizedVersionName());
+        $this->assertEquals('5.4.22', $versionA->getVersion());
+        $this->assertEquals('5.4.22', $versionB->getVersion());
         $this->assertEquals($versionA->__toString(), $versionB->__toString());
     }
 
-    public function testFindLastPatchVersion() {
+    public function testFindLastPatchVersion()
+    {
         $ret = Version::findLatestPatchVersion('5.5', array('5.5.26', '5.5.25', '5.5.1'));
-        $this->assertEquals('5.5.26',$ret);
+        $this->assertEquals('5.5.26', $ret);
     }
 
-    public function testHasPatchVersion() {
+    public function testHasPatchVersion()
+    {
         $this->assertTrue(Version::hasPatchVersion('5.5.2'));
         $this->assertFalse(Version::hasPatchVersion('5.5'));
     }
 
-    public function testGetPatchVersion() {
+    public function testGetPatchVersion()
+    {
         $version = new Version('php-5.4.22');
         $this->assertSame(22, $version->getPatchVersion());
     }


### PR DESCRIPTION
Additionally:

1. All class FQNs are replaced with imports.
2. Unused imports are removed.
3. Remaining imports are alphabetically sorted.
4. Expressions like `return $this->logger->error()` replaced with `$this->logger->error(); return` since most of the methods with such a combination do not return any value.
5. Removed doc-blocks autogenerated by PhpStorm.