### PR TITLE
Clean up the temporary directory used during a package extraction

### DIFF
--- a/src/PhpBrew/Tasks/ExtractTask.php
+++ b/src/PhpBrew/Tasks/ExtractTask.php
@@ -11,26 +11,26 @@ use PhpBrew\Exception\SystemCommandException;
 class ExtractTask extends BaseTask
 {
     /**
+     * The list of directories to be removed upon task completion.
+     *
+     * @var string[]
+     */
+    private $rmDirs = array();
+
+    /**
      * Unpacks the source tarball file.
      *
      * @param string $targetFilePath absolute file path
      * @param string $extractDir     (the build dir)
+     *
+     * @return string The extracted directory path
      */
     public function extract(Build $build, $targetFilePath, $extractDir = null)
     {
         if (empty($extractDir)) {
             $extractDir = dirname($targetFilePath);
         }
-        $extractDirTemp = $extractDir . DIRECTORY_SEPARATOR . 'tmp.' . time();
 
-        if (!file_exists($extractDirTemp)) {
-            mkdir($extractDirTemp, 0755, true);
-        }
-
-        // This converts: '/opt/phpbrew/distfiles/php-7.0.2.tar.bz2'
-        //        to just '/opt/phpbrew/tmp/distfiles/php-7.0.2'
-        $distBasename = preg_replace('#\.tar\.(gz|bz2)$#', '', basename($targetFilePath));
-        $extractedDirTemp = $extractDirTemp . DIRECTORY_SEPARATOR . $distBasename;
         $extractedDir = $extractDir . DIRECTORY_SEPARATOR . $build->getName();
 
         if (
@@ -42,20 +42,36 @@ class ExtractTask extends BaseTask
             return $extractedDir;
         }
 
+        $extractDirTemp = $extractDir . DIRECTORY_SEPARATOR . 'tmp.' . time();
+
+        if (!file_exists($extractDirTemp)) {
+            mkdir($extractDirTemp, 0755, true);
+        }
+
+        $this->rmDirs[] = $extractDirTemp;
+
+        // This converts: '/opt/phpbrew/distfiles/php-7.0.2.tar.bz2'
+        //        to just '/opt/phpbrew/tmp/distfiles/php-7.0.2'
+        $distBaseName = preg_replace('#\.tar\.(gz|bz2)$#', '', basename($targetFilePath));
+        $extractedDirTemp = $extractDirTemp . DIRECTORY_SEPARATOR . $distBaseName;
+
         // NOTICE: Always extract to tmp directory prevent incomplete extraction
         $this->info("===> Extracting $targetFilePath to $extractedDirTemp");
-        $lastline = system(
+        $lastLine = system(
             'tar -C ' . escapeshellarg($extractDirTemp) . ' -xf ' . escapeshellarg($targetFilePath),
             $ret
         );
 
         if ($ret !== 0) {
-            throw new SystemCommandException("Extract failed: $lastline", $build);
+            throw new SystemCommandException("Extract failed: $lastLine", $build);
         }
+
         clearstatcache(true);
+
         if (!is_dir($extractedDirTemp)) {
             // retry with github extracted dir path
-            $extractedDirTemp = $extractDirTemp . DIRECTORY_SEPARATOR . 'php-src-' . $distBasename;
+            $extractedDirTemp = $extractDirTemp . DIRECTORY_SEPARATOR . 'php-src-' . $distBaseName;
+
             if (!is_dir($extractedDirTemp)) {
                 throw new SystemCommandException("Unable to find $extractedDirTemp", $build);
             }
@@ -63,32 +79,35 @@ class ExtractTask extends BaseTask
 
         if (is_dir($extractedDir)) {
             $this->info("===> Found existing build directory, removing $extractedDir ...");
-            $lastline = system('rm -rf ' . escapeshellarg($extractedDir), $ret);
+            $lastLine = $this->rmDir($extractedDir, $ret);
+
             if ($ret !== 0) {
-                throw new SystemCommandException("Unable to remove $extractedDir: $lastline", $build);
+                throw new SystemCommandException("Unable to remove $extractedDir: $lastLine", $build);
             }
         }
 
         $this->info("===> Moving $extractedDirTemp to $extractedDir");
+
         if (!rename($extractedDirTemp, $extractedDir)) {
             throw new SystemCommandException("Unable to move $extractedDirTemp to $extractedDir", $build);
         }
-        @rmdir($extractDirTemp);
 
         $build->setState(Build::STATE_EXTRACT);
 
         return $extractedDir;
-        /*
-         * XXX: unless we have a fast way to verify the extraction.
-        if ($this->options->force || ! file_exists($extractedDir . DIRECTORY_SEPARATOR . 'configure')) {
-            $this->info("===> Extracting $targetFilePath...");
-            system("tar -C $dir -xjf $targetFilePath", $ret);
-            if ($ret != 0) {
-                die('Extract failed.');
-            }
-        } else {
-            $this->info("Found existing $extractedDir, Skip extracting.");
+    }
+
+    public function __destruct()
+    {
+        foreach ($this->rmDirs as $dir) {
+            $this->rmDir($dir);
         }
-        */
+
+        parent::__destruct();
+    }
+
+    private function rmDir($dir, &$return = null)
+    {
+        return system('rm -rf ' . escapeshellarg($dir), $return);
     }
 }


### PR DESCRIPTION
1. Create a temporary directory only if needed.
2. Remove it in the class destructor.

Fixes #1056.