### PR TITLE
Allow to reference PHP -dev builds without using the php- prefix

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -47,7 +47,7 @@ fi
 
 [[ -z "$PHPBREW_ROOT" ]] && export PHPBREW_ROOT="$HOME/.phpbrew"
 [[ -z "$PHPBREW_BIN" ]] && export PHPBREW_BIN="$PHPBREW_HOME/bin"
-[[ -z "$PHPBREW_VERSION_REGEX" ]] && export PHPBREW_VERSION_REGEX="^([[:digit:]]+\.){2}[[:digit:]]+((alpha|beta|RC)[[:digit:]]+)?$"
+[[ -z "$PHPBREW_VERSION_REGEX" ]] && export PHPBREW_VERSION_REGEX="^([[:digit:]]+\.){2}[[:digit:]]+(-dev|((alpha|beta|RC)[[:digit:]]+))?$"
 
 [[ -e "$PHPBREW_ROOT" ]] || mkdir $PHPBREW_ROOT
 [[ -e "$PHPBREW_HOME" ]] || mkdir $PHPBREW_HOME
@@ -151,7 +151,7 @@ function phpbrew ()
                         __phpbrew_set_path
                     fi
                 else
-                    echo "php version: $_PHP_VERSION not exists."
+                    echo "PHP version $_PHP_VERSION is not installed."
                 fi
             fi
             ;;

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -48,7 +48,7 @@ end
 
 [ -z "$PHPBREW_ROOT" ]; and set -gx PHPBREW_ROOT "$HOME/.phpbrew"
 [ -z "$PHPBREW_BIN" ]; and set -gx PHPBREW_BIN "$PHPBREW_HOME/bin"
-[ -z "$PHPBREW_VERSION_REGEX" ]; and set -gx PHPBREW_VERSION_REGEX '^([[:digit:]]+\.){2}[[:digit:]]+$'
+[ -z "$PHPBREW_VERSION_REGEX" ]; and set -gx PHPBREW_VERSION_REGEX '^([[:digit:]]+\.){2}[[:digit:]]+(-dev|((alpha|beta|RC)[[:digit:]]+))?$'
 
 [ ! -d "$PHPBREW_ROOT" ]; and mkdir $PHPBREW_ROOT
 [ ! -d "$PHPBREW_HOME" ]; and mkdir $PHPBREW_HOME
@@ -136,7 +136,7 @@ function phpbrew
                         __phpbrew_set_path
                     end
                 else
-                    echo "php version: $_PHP_VERSION not exists."
+                    echo "PHP version $_PHP_VERSION is not installed."
                 end
             end
         case cd-src

--- a/src/PhpBrew/BuildFinder.php
+++ b/src/PhpBrew/BuildFinder.php
@@ -33,7 +33,7 @@ class BuildFinder
 
         if ($stripPrefix) {
             $names = array_map(function ($name) {
-                return preg_replace('/^php-(?=(\d+\.\d+\.\d+((alpha|beta|RC)\d+)?)$)/', '', $name);
+                return preg_replace('/^php-(?=(\d+\.\d+\.\d+(-dev|((alpha|beta|RC)\d+))?)$)/', '', $name);
             }, $names);
         }
         uasort($names, 'version_compare'); // ordering version name ascending... 5.5.17, 5.5.12


### PR DESCRIPTION
Similarly to #798, added support for `-dev` versions e.g. `phpbrew use 8.0.0-dev`.