### PR TITLE
Use the proper order of arguments when calling implode()

### DIFF
--- a/src/PhpBrew/PatchKit/RegExpPatchRule.php
+++ b/src/PhpBrew/PatchKit/RegExpPatchRule.php
@@ -101,7 +101,7 @@ class RegExpPatchRule implements PatchRule
             }
         }
 
-        return implode($lines, PHP_EOL);
+        return implode(PHP_EOL, $lines);
     }
 
     /**


### PR DESCRIPTION
Fixes #1061.