### PR TITLE
Updated the CLIFRamework dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "bin/phpbrew"
     ],
     "require": {
-        "corneltek/cliframework": "3.0.x-dev",
+        "corneltek/cliframework": "dev-master#2650a53433854d43b91955e8f967c62ce07869d7",
         "corneltek/class-template": "^2",
         "corneltek/pearx": "dev-master",
         "corneltek/curlkit": "dev-master#9e85064c3a8a642292a8f6122792d2b5b24f7b02",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a85b36c450eaeb7c3794c2a9b2ae4ad",
+    "content-hash": "ef5020a1edc2f4adbac68b3c39325f8b",
     "packages": [
         {
             "name": "corneltek/cachekit",
@@ -97,12 +97,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/CLIFramework.git",
-                "reference": "df9139a84c8aee2cd6952632c31bdfab4855f22f"
+                "reference": "2650a53433854d43b91955e8f967c62ce07869d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/CLIFramework/zipball/df9139a84c8aee2cd6952632c31bdfab4855f22f",
-                "reference": "df9139a84c8aee2cd6952632c31bdfab4855f22f",
+                "url": "https://api.github.com/repos/c9s/CLIFramework/zipball/2650a53433854d43b91955e8f967c62ce07869d7",
+                "reference": "2650a53433854d43b91955e8f967c62ce07869d7",
                 "shasum": ""
             },
             "require": {
@@ -151,7 +151,7 @@
                 "getopt",
                 "zsh"
             ],
-            "time": "2016-03-18T13:55:38+00:00"
+            "time": "2018-02-08T01:22:59+00:00"
         },
         {
             "name": "corneltek/codegen",


### PR DESCRIPTION
Pulling in the following changes: https://github.com/c9s/CLIFramework/compare/df9139a84c8aee2cd6952632c31bdfab4855f22f...2650a53433854d43b91955e8f967c62ce07869d7.

Specifically, it includes the fixes for https://github.com/c9s/CLIFramework/issues/106 and https://github.com/c9s/CLIFramework/issues/108.

Fixes https://github.com/phpbrew/phpbrew/issues/822.

Not upgrading to a release due to incompatibility with PHP 5.3.