### PR TITLE
Updated CurlKit and PEARX dependency constraints to the latest stable versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require": {
         "corneltek/cliframework": "dev-master#2650a53433854d43b91955e8f967c62ce07869d7",
         "corneltek/class-template": "^2",
-        "corneltek/pearx": "dev-master",
-        "corneltek/curlkit": "dev-master#9e85064c3a8a642292a8f6122792d2b5b24f7b02",
+        "corneltek/pearx": "^1.3.4",
+        "corneltek/curlkit": "^1.0.11",
         "symfony/process": "^2.3",
         "symfony/yaml": "^2.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef5020a1edc2f4adbac68b3c39325f8b",
+    "content-hash": "bf25db6df526bc3d5fb1c28896e3813d",
     "packages": [
         {
             "name": "corneltek/cachekit",
@@ -203,16 +203,16 @@
         },
         {
             "name": "corneltek/curlkit",
-            "version": "dev-master",
+            "version": "1.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/CurlKit.git",
-                "reference": "9e85064c3a8a642292a8f6122792d2b5b24f7b02"
+                "reference": "5f0765bd6e81d66ec6f71d24c6312a1509e65c5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/CurlKit/zipball/9e85064c3a8a642292a8f6122792d2b5b24f7b02",
-                "reference": "9e85064c3a8a642292a8f6122792d2b5b24f7b02",
+                "url": "https://api.github.com/repos/c9s/CurlKit/zipball/5f0765bd6e81d66ec6f71d24c6312a1509e65c5f",
+                "reference": "5f0765bd6e81d66ec6f71d24c6312a1509e65c5f",
                 "shasum": ""
             },
             "require": {
@@ -238,7 +238,7 @@
                 "MIT"
             ],
             "description": "Curl Kit",
-            "time": "2019-04-08T10:25:02+00:00"
+            "time": "2019-12-03T23:37:27+00:00"
         },
         {
             "name": "corneltek/getoptionkit",
@@ -284,26 +284,26 @@
         },
         {
             "name": "corneltek/pearx",
-            "version": "dev-master",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbrew/PEARX.git",
-                "reference": "2d361b36e9230390701fd7db46eecd3b13527e25"
+                "reference": "3874d016f483ddd5003351824134d60d315825d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbrew/PEARX/zipball/2d361b36e9230390701fd7db46eecd3b13527e25",
-                "reference": "2d361b36e9230390701fd7db46eecd3b13527e25",
+                "url": "https://api.github.com/repos/phpbrew/PEARX/zipball/3874d016f483ddd5003351824134d60d315825d6",
+                "reference": "3874d016f483ddd5003351824134d60d315825d6",
                 "shasum": ""
             },
             "require": {
                 "corneltek/cachekit": "^1",
-                "corneltek/curlkit": "1.0.x-dev",
+                "corneltek/curlkit": "^1.0.11",
                 "php": ">=5.3.0"
             },
             "require-dev": {
                 "corneltek/phpunit-testmore": "dev-master",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^4.8||^5.7"
             },
             "type": "library",
             "autoload": {
@@ -323,8 +323,8 @@
                 }
             ],
             "description": "PEAR channel client",
-            "homepage": "http://github.com/c9s/PEARX",
-            "time": "2017-06-24T05:53:19+00:00"
+            "homepage": "http://github.com/phpbrew/PEARX",
+            "time": "2019-12-04T01:21:52+00:00"
         },
         {
             "name": "corneltek/serializerkit",
@@ -2401,8 +2401,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "corneltek/cliframework": 20,
-        "corneltek/pearx": 20,
-        "corneltek/curlkit": 20,
         "corneltek/phpunit-testmore": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
- [x] Update the locked version of PEARX to the latest `dev-master` before releasing it (also ensures PHP 5.3 compatibility).
- [x] Run PHPBrew tests on Travis ([#620413265](https://travis-ci.org/phpbrew/phpbrew/builds/620413265)).
- [x] Release a new PEARX version.
- [x] Update the PEARX version constraint to the latest stable.
- [x] Document the changes pulled in from CurlKit and PEARX:
   - https://github.com/c9s/CurlKit/compare/9e85064c3a8a642292a8f6122792d2b5b24f7b02...1.0.11
   - https://github.com/phpbrew/PEARX/compare/2d361b36e9230390701fd7db46eecd3b13527e25...1.3.4
