### PR TITLE
Cleaned up the test suite a bit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="tests/bootstrap.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
          backupGlobals="false"
-         stopOnFailure="false"
-         stopOnError="false"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertErrorsToExceptions="true"
          colors="true"
-         verbose="true">
+         verbose="true"
+>
 
     <php>
       <ini name="safe_mode_allowed_env_var" value="PHP_,PHPBREW"/>
@@ -22,54 +20,9 @@
     </php>
 
     <testsuites>
-        <testsuite name="All">
-            <file>tests/PhpBrew/BuildRegisterTest.php</file>
-            <file>tests/PhpBrew/BuildTest.php</file>
-            <file>tests/PhpBrew/CommandBuilderTest.php</file>
-            <file>tests/PhpBrew/ConfigTest.php</file>
-            <file>tests/PhpBrew/MachineTest.php</file>
-            <file>tests/PhpBrew/PatchUtilsTest.php</file>
-            <file>tests/PhpBrew/ReleaseListTest.php</file>
-            <file>tests/PhpBrew/UtilsTest.php</file>
-            <file>tests/PhpBrew/VariantBuilderTest.php</file>
-            <file>tests/PhpBrew/VariantParserTest.php</file>
-            <file>tests/PhpBrew/VersionDslParserTest.php</file>
-            <file>tests/PhpBrew/VersionTest.php</file>
-
-            <!-- run install command tests before all tests -->
-            <file>tests/PhpBrew/Command/KnownCommandTest.php</file>
-            <file>tests/PhpBrew/Command/InstallCommandTest.php</file>
-            <directory suffix="Test.php">tests</directory>
+        <testsuite name="PHPBrew">
+            <directory>tests</directory>
         </testsuite>
-
-        <testsuite name="Core">
-          <file>tests/PhpBrew/BuildRegisterTest.php</file>
-          <file>tests/PhpBrew/BuildTest.php</file>
-          <file>tests/PhpBrew/CommandBuilderTest.php</file>
-          <file>tests/PhpBrew/ConfigTest.php</file>
-          <file>tests/PhpBrew/MachineTest.php</file>
-          <file>tests/PhpBrew/PatchUtilsTest.php</file>
-          <file>tests/PhpBrew/ReleaseListTest.php</file>
-          <file>tests/PhpBrew/UtilsTest.php</file>
-          <file>tests/PhpBrew/VariantBuilderTest.php</file>
-          <file>tests/PhpBrew/VariantParserTest.php</file>
-          <file>tests/PhpBrew/VersionDslParserTest.php</file>
-          <file>tests/PhpBrew/VersionTest.php</file>
-          <directory suffix="Test.php">tests/PhpBrew/Platform</directory>
-          <directory suffix="Test.php">tests/PhpBrew/Distribution</directory>
-          <directory suffix="Test.php">tests/PhpBrew/Downloader</directory>
-          <directory suffix="Test.php">tests/PhpBrew/PatchKit</directory>
-          <directory suffix="Test.php">tests/PhpBrew/Patches</directory>
-        </testsuite>
-
-        <testsuite name="Command">
-            <directory suffix="Test.php">tests/PhpBrew/Command</directory>
-        </testsuite>
-
-        <testsuite name="Extension">
-            <directory suffix="Test.php">tests/PhpBrew/Extension</directory>
-        </testsuite>
-
     </testsuites>
 
     <filter>
@@ -80,24 +33,5 @@
         </exclude>
       </whitelist>
     </filter>
-
-    <logging>
-
-        <log type="tap" target="build/logs/report.tap" />
-
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
-
-        <log type="coverage-html" 
-            target="build/coverage" 
-            charset="UTF-8" 
-            yui="true" 
-            highlight="true"
-            lowUpperBound="35" 
-            highLowerBound="70"/>
-
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-        <log type="coverage-clover" target="build/logs/clover.xml" />
-        <log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-    </logging>
 
 </phpunit>

--- a/tests/PhpBrew/VariantBuilderTest.php
+++ b/tests/PhpBrew/VariantBuilderTest.php
@@ -27,19 +27,19 @@ class VariantBuilderTest extends TestCase
             array(array('mysql', 'pdo'),  '#--with-pdo-mysql#'),
             array(array('pgsql', 'pdo'),  '#--with-pdo-pgsql#'),
             array(array('default'),       '#..#'),
-            array(array('mcrypt'),        '#--with-mcrypt=#'),
-            array(array('openssl'),       '#--with-openssl=#'),
-            array(array('zlib'),          '#--with-zlib=#'),
-            array(array('curl'),          '#--with-curl=#'),
-            array(array('readline'),      '#--with-readline=#'),
-            array(array('editline'),      '#--with-libedit=#'),
-            array(array('gettext'),       '#--with-gettext=#'),
+            array(array('mcrypt'),        '#--with-mcrypt#'),
+            array(array('openssl'),       '#--with-openssl#'),
+            array(array('zlib'),          '#--with-zlib#'),
+            array(array('curl'),          '#--with-curl#'),
+            array(array('readline'),      '#--with-readline#'),
+            array(array('editline'),      '#--with-libedit#'),
+            array(array('gettext'),       '#--with-gettext#'),
             array(array('ipc'),           array('#--enable-shmop#','#--enable-sysvshm#')),
-            array(array('gmp'),           '#--with-gmp=#'),
-            array(array('mhash'),         '#--with-mhash=#'),
+            array(array('gmp'),           '#--with-gmp#'),
+            array(array('mhash'),         '#--with-mhash#'),
             array(array('iconv'),         '#--with-iconv#'),
             array(array('bz2'),           '#--with-bz2#'),
-            array(array('gd'),            array('#--with-gd=#', '#--with-png-dir#', '#--with-jpeg-dir#')),
+            array(array('gd'),            array('#--with-gd#', '#--with-png-dir#', '#--with-jpeg-dir#')),
         );
     }
 
@@ -86,22 +86,22 @@ class VariantBuilderTest extends TestCase
         $build->disableVariant('mysql');
         $build->resolveVariants();
         $options = $variants->build($build);
-        ok(in_array('--enable-debug', $options));
-        ok(in_array('--enable-libxml', $options));
-        ok(in_array('--enable-simplexml', $options));
 
-        ok(in_array('--with-apxs2=/opt/local/apache2/apxs2', $options));
+        $this->assertContains('--enable-debug', $options);
+        $this->assertContains('--enable-libxml', $options);
+        $this->assertContains('--enable-simplexml', $options);
 
-        ok(in_array('--without-sqlite3', $options));
-        ok(in_array('--without-mysql', $options));
-        ok(in_array('--without-mysqli', $options));
-        ok(in_array('--disable-all', $options));
+        $this->assertContains('--with-apxs2=/opt/local/apache2/apxs2', $options);
+
+        $this->assertContains('--without-sqlite3', $options);
+        $this->assertContains('--without-mysql', $options);
+        $this->assertContains('--without-mysqli', $options);
+        $this->assertContains('--disable-all', $options);
     }
 
     public function testEverything()
     {
         $variants = new VariantBuilder();
-        ok($variants);
 
         $build = new Build('5.6.0');
         $build->enableVariant('everything');
@@ -119,7 +119,6 @@ class VariantBuilderTest extends TestCase
     public function testMysqlPdoVariant()
     {
         $variants = new VariantBuilder();
-        ok($variants);
 
         $build = new Build('5.3.0');
         $build->enableVariant('pdo');


### PR DESCRIPTION
1. Removed test coverage and logging enabled by default.
2. Validated the configuration against the XSD and removed redundant parameters.
3. Removed the breakdown by test suites. All tests are important, slow tests will be moved out later.
4. Fixed accidental failures `VariantBuilderTest`. Depending on the environment, the configure options may or may not have the path specified and it's okay and should not be enforced by the test.
5. Got rid of custom assertions like `ok()`. They are too unspecific. The rest will have to go later.