### PR TITLE
Enforced PHP version in Composer configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,9 @@ addons:
     # packages for apxs2
     - apache2
 install:
-- composer install --no-interaction
-- composer update phpunit/phpunit --with-dependencies
+  - composer install
+  - composer config --unset platform
+  - composer update phpunit/phpunit --with-dependencies
 before_script:
 # see if ccache is working
 - export USE_CCACHE=1

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
             "homepage": "https://github.com/marcioAlmada/"
         }
     ],
+    "config" : {
+        "platform": {
+            "php": "5.3.9"
+        }
+    },
     "bin": [
         "bin/phpbrew"
     ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf25db6df526bc3d5fb1c28896e3813d",
+    "content-hash": "92b746000f2cbf98608d29c431d98162",
     "packages": [
         {
             "name": "corneltek/cachekit",
@@ -2406,5 +2406,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.3.9"
+    }
 }


### PR DESCRIPTION
This is needed in order to make sure we won't update locked dependencies to the versions that are not supported by the oldest supported PHP version while not using this verion during an update. Although, on CI we want to use the latest PHPUnit version that is supports the current PHP version.

The PHP 5.3.9 is used since this is the oldest PHP version that is supported by the currently locked dependencies (symfony/* specifically).