### PR TITLE
When doing a self-update, download the file from GitHub releases instead of the repository

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -33,11 +33,11 @@ phpbrew 能做什么？
 ## 安装
 
 ```bash
-curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
-chmod +x phpbrew
+curl -L -O https://github.com/phpbrew/phpbrew/releases/latest/download/phpbrew.phar
+chmod +x phpbrew.phar
 
-# Move phpbrew to somewhere can be found by your $PATH
-sudo mv phpbrew /usr/local/bin/phpbrew
+# Move the file to some directory within your $PATH
+sudo mv phpbrew.phar /usr/local/bin/phpbrew
 ```
 
 ## 快速入门

--- a/README.ja.md
+++ b/README.ja.md
@@ -34,9 +34,10 @@ PHPをビルドするための開発用パッケージをインストールす�
 ダウンロードするだけ:
 
 ```bash
-curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
-chmod +x phpbrew
-sudo mv phpbrew /usr/local/bin/phpbrew
+curl -L -O https://github.com/phpbrew/phpbrew/releases/latest/download/phpbrew.phar
+chmod +x phpbrew.phar
+
+sudo mv phpbrew.phar /usr/local/bin/phpbrew
 ```
 
 ## 基本的な使い方

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ building PHP.
 ## INSTALL
 
 ```bash
-curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
-chmod +x phpbrew
+curl -L -O https://github.com/phpbrew/phpbrew/releases/latest/download/phpbrew.phar
+chmod +x phpbrew.phar
 
-# Move phpbrew to somewhere can be found by your $PATH
-sudo mv phpbrew /usr/local/bin/phpbrew
+# Move the file to some directory within your $PATH
+sudo mv phpbrew.phar /usr/local/bin/phpbrew
 ```
 
 ## QUICK START

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -33,14 +33,14 @@ desenvolvimento php.
 Faça isso:
 
 ```bash
-curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
-chmod +x phpbrew
+curl -L -O https://github.com/phpbrew/phpbrew/releases/latest/download/phpbrew.phar
+chmod +x phpbrew.phar
 ```
 
 Instale dento da pasta bin do seu sistema:
 
 ```sh
-sudo mv phpbrew /usr/local/bin/phpbrew
+sudo mv phpbrew.phar /usr/local/bin/phpbrew
 ```
 
 Confirme se `/usr/local/bin` está nas `$PATH` variaveis de ambiente do sistema.

--- a/completion/bash/_phpbrew
+++ b/completion/bash/_phpbrew
@@ -6035,7 +6035,7 @@ subcommand_alias=()
 subcommand_signs=()
 options=(["--downloader"]="1" ["--continue"]="1" ["--http-proxy"]="1" ["--http-proxy-auth"]="1" ["--connect-timeout"]="1" )
 options_require_value=(["--downloader"]="1" ["--http-proxy"]="1" ["--http-proxy-auth"]="1" ["--connect-timeout"]="1" )
-local argument_min_length=1
+local argument_min_length=0
 
     # Get the command name chain of the current input, e.g.
     # 
@@ -6105,14 +6105,6 @@ local argument_min_length=1
           return
       fi
       # If the command requires at least $argument_min_length to run, we check the argument
-if [[ $argument_min_length > 0 ]] ; then
-  case $argument_index in
-      0)
-      __complete_meta "$command_signature" "arg" 0 "suggestions"
-      return
-      ;;
-  esac
-  fi
 
                 # If there is no argument support, then user is supposed to give a subcommand name or an option
                 __mycomp "${!options[*]} ${!subcommands[*]} ${!subcommand_alias[*]}"

--- a/completion/zsh/_phpbrew
+++ b/completion/zsh/_phpbrew
@@ -488,7 +488,6 @@ local ret=1
               '--http-proxy=[HTTP proxy address]' \
               '--http-proxy-auth=[HTTP proxy authentication]' \
               '--connect-timeout=[Connection timeout]' \
-              ':branch:{___phpbrewmeta "branch" self-update arg 0 suggestions}' \
                && ret=0
         
         ;;

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -777,7 +777,6 @@ complete -f -c phpbrew -n "__fish_phpbrew_using_command self-update" -l continue
 complete -x -c phpbrew -n "__fish_phpbrew_using_command self-update" -l http-proxy -d "HTTP proxy address"
 complete -x -c phpbrew -n "__fish_phpbrew_using_command self-update" -l http-proxy-auth -d "HTTP proxy authentication"
 complete -x -c phpbrew -n "__fish_phpbrew_using_command self-update" -l connect-timeout -d "Connection timeout"
-complete -x -c phpbrew -n "__fish_phpbrew_using_command self-update" -a "(__fish_phpbrew_arg_meta self-update 0 suggestions)"
 
 # switch
 complete -x -c phpbrew -n "__fish_phpbrew_using_command switch" -a "(__fish_phpbrew_arg_meta switch 0 valid-values)"

--- a/src/PhpBrew/Command/SelfUpdateCommand.php
+++ b/src/PhpBrew/Command/SelfUpdateCommand.php
@@ -4,7 +4,7 @@ namespace PhpBrew\Command;
 
 use CLIFramework\Command;
 use Exception;
-use GetOptionKit\OptionSpecCollection;
+use GetOptionKit\OptionCollection;
 use PhpBrew\Downloader\DownloadFactory;
 use RuntimeException;
 
@@ -21,22 +21,14 @@ class SelfUpdateCommand extends Command
     }
 
     /**
-     * @param OptionSpecCollection $opts
+     * @param OptionCollection $opts
      */
     public function options($opts)
     {
         DownloadFactory::addOptionsForCommand($opts);
     }
 
-    public function arguments($args)
-    {
-        $args->add('branch')->suggestions(function () {
-            /* TODO: maybe fetch tags and remote branches from github? */
-            return array('master', 'develop');
-        });
-    }
-
-    public function execute($branch = 'master')
+    public function execute()
     {
         global $argv;
         $script = realpath($argv[0]);
@@ -46,8 +38,8 @@ class SelfUpdateCommand extends Command
         }
 
         // fetch new version phpbrew
-        $this->logger->info("Updating phpbrew $script from $branch...");
-        $url = "https://raw.githubusercontent.com/phpbrew/phpbrew/$branch/phpbrew";
+        $this->logger->info("Updating phpbrew $script...");
+        $url = 'https://github.com/phpbrew/phpbrew/releases/latest/download/phpbrew.phar';
 
         //download to a tmp file first
         //the phar file is large so we prefer the commands rather than extensions.
@@ -65,12 +57,8 @@ class SelfUpdateCommand extends Command
         //todo we can check the hash here in order to make sure we have download the phar successfully
 
         //move the tmp file to executable path
-        $code = rename($tempFile, $script);
-        if ($code === false) { //fallback to system move
-            $code = system("mv -f $tempFile, $script");
-            if (!$code == 0) {
-                throw new RuntimeException('Update Failed', 3);
-            }
+        if (!rename($tempFile, $script)) {
+            throw new RuntimeException('Update Failed', 3);
         }
 
         $this->logger->info('Version updated.');


### PR DESCRIPTION
Having the built PHAR in the source tree is annoying since IDEs pick up its content and use for static analysis, completion, etc. It's not part of the source tree, cannot be merged, blamed, yadda yadda yadda.

As of now, GitHub supports [linking to the latest release](https://help.github.com/en/github/administering-a-repository/linking-to-releases#linking-to-the-latest-release) which we can leverage instead.

**TODO:**
- [x] Upload the latest release artifacts to the [release page](https://github.com/phpbrew/phpbrew/releases/tag/1.24.1).
- [x] Update the `self-update` command and documentation to point to the GitHub release instead of a blob in the source tree.
- [ ] During the next release, update the PHAR in the source tree for the last time.
- [ ] After some time, remove the PHAR from the source tree.
