### PR TITLE
Add PKG_CONFIG_PATH environment variables to phpbrew build process

### DIFF
--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -61,6 +61,13 @@ class Build implements Serializable, Buildable
     public $osRelease;
 
     /**
+     * PKG_CONFIG_PATH for build environment
+     *
+     * @var array<string,true>
+     */
+    private $pkgConfigPaths = array();
+
+    /**
      * Construct a Build object,.
      *
      * A build object contains the information of all build options, prefix, paths... etc
@@ -81,6 +88,28 @@ class Build implements Serializable, Buildable
         $this->setBuildSettings(new BuildSettings());
         $this->osName = php_uname('s');
         $this->osRelease = php_uname('r');
+    }
+
+    public function getPkgConfigPaths()
+    {
+        return array_keys($this->pkgConfigPaths);
+    }
+
+    public function addPkgConfigPath($path)
+    {
+        $this->pkgConfigPaths[$path] = true;
+    }
+
+    public function putPkgConfigPathsEnv()
+    {
+        $paths = $this->getPkgConfigPaths();
+        $currentPkgConfigPath = getenv('PKG_CONFIG_PATH');
+
+        if ($currentPkgConfigPath !== '' && $currentPkgConfigPath !== false) {
+            $currentPaths = explode(PATH_SEPARATOR, $currentPkgConfigPath);
+            $paths = array_unique(array_merge($paths, $currentPaths));
+        }
+        putenv('PKG_CONFIG_PATH=' . implode(PATH_SEPARATOR, $paths));
     }
 
     public function setName($name)

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -371,6 +371,9 @@ class InstallCommand extends Command
         $this->logger->debug('Source Directory: ' . realpath($targetDir));
         $build->setSourceDirectory($targetDir);
 
+        // Update PKG_CONFIG_PATH gathered from VariantBuilder to build environment
+        $build->putPkgConfigPathsEnv();
+
         if (!$this->options->{'no-clean'} && file_exists($targetDir . DIRECTORY_SEPARATOR . 'Makefile')) {
             $this->logger->info('Found existing Makefile, running make clean to ensure everything will be rebuilt.');
             $this->logger->info(


### PR DESCRIPTION
I try to dig the source code and add `PKG_CONFIG_PATH` to build process, it makes easier for user when build php 7.4.

It is just  a proof of concept, for discussion only.

With the PR, you can build php 7.4, with the following command only, no more `export PKG_CONFIG_PATH=...`.
```bash
$ phpbrew --debug install --jobs "$(nproc)" 7.1.33 +default +dbs +dba +apxs2 +bz2="$(brew --prefix bzip2)" +zlib="$(brew --prefix zlib)" +ftp
```
But, there is a problem when build extensions, take `ftp` and `soap` for example.  You can install it with `phpbrew install 7.4.0 +default +ftp`, the build process will set the PKG_CONFIG_PATH for you.

But, with this PR, you still can't install extension by following command only.
```
phpbrew ext install ftp
phpbrew ext install soap
```
Because the current extension manager install them by `phpize`, `configure`, `make`. Without the capability like `VariantBuilder` add extra settings for you...

So, You still need to export `PKG_CONFIG_PATH`, `LDFLAGS`, `CPPFLAGS` manually. Then, install the extension.

@morozov Need your review and ideas.

Reference: https://github.com/phpbrew/phpbrew/issues/1040#issuecomment-562501149




