### PR TITLE
PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.1",
         "php-vcr/php-vcr": "^1.4",
-        "phpunit/phpunit": "^4.8||^5.7"
+        "phpunit/phpunit": "^4.8||^5.7||^6.5"
     },
     "extra": { "branch-alias": { "dev-master": "1.22.x-dev" } },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc18e330eef8dcce8354aabcc8f1a27f",
+    "content-hash": "6c3b9a739368527e7e8c2dca13ce6ba2",
     "packages": [
         {
             "name": "corneltek/cachekit",

--- a/tests/PhpBrew/ConfigTest.php
+++ b/tests/PhpBrew/ConfigTest.php
@@ -15,11 +15,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigTest extends TestCase
 {
-    public function test()
-    {
-        Config::getInstalledPhpVersions();
-    }
-
     /**
      * @expectedException \Exception
      */

--- a/tests/PhpBrew/Extension/ExtensionManagerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionManagerTest.php
@@ -35,6 +35,6 @@ class ExtensionManagerTest extends TestCase
     public function testCleanExtension()
     {
         $ext = ExtensionFactory::lookup('xdebug', array(getenv('PHPBREW_EXTENSION_DIR')));
-        $this->manager->cleanExtension($ext);
+        $this->assertTrue($this->manager->cleanExtension($ext));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,8 @@ use VCR\VCR;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+class_alias('PHPUnit\\Framework\\TestCase', 'PHPUnit_Framework_TestCase');
+
 VCR::configure()
   ->setCassettePath('tests/fixtures/vcr_cassettes')
   ->enableLibraryHooks(array('curl', 'stream_wrapper'))


### PR DESCRIPTION
Updated the test suite for compatibility with PHPUnit 6 (works with PHP 7.0 and newer).

The `ConfigTest::test()` has been since it covers a deprecated method and doesn't make any assertions. The method is still covered by another test and will be removed in the near future.