### PR TITLE
PHPUnit 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.1",
         "php-vcr/php-vcr": "^1.4",
-        "phpunit/phpunit": "^4.8||^5.7||^6.5"
+        "phpunit/phpunit": "^4.8||^5.7||^6.5||^7.5"
     },
     "extra": { "branch-alias": { "dev-master": "1.22.x-dev" } },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c3b9a739368527e7e8c2dca13ce6ba2",
+    "content-hash": "4cf9b99c2e77fb9708bcc07cea673999",
     "packages": [
         {
             "name": "corneltek/cachekit",

--- a/src/PhpBrew/PatchKit/DiffPatchRule.php
+++ b/src/PhpBrew/PatchKit/DiffPatchRule.php
@@ -8,7 +8,7 @@ use PhpBrew\Buildable;
 /**
  * DiffPatchRule implements a diff based patch rule.
  */
-class DiffPatchRule
+class DiffPatchRule implements PatchRule
 {
     protected $diffFile;
 
@@ -38,6 +38,10 @@ class DiffPatchRule
     public static function from($diffFile)
     {
         return new self($diffFile);
+    }
+
+    public function backup(Buildable $build, Logger $logger)
+    {
     }
 
     public function apply(Buildable $build, Logger $logger)

--- a/src/PhpBrew/PatchKit/Patch.php
+++ b/src/PhpBrew/PatchKit/Patch.php
@@ -22,7 +22,7 @@ abstract class Patch
     /**
      * rules method returns the array of PatchRule class.
      *
-     * @return array<PatchRule>
+     * @return PatchRule[]
      */
     abstract public function rules();
 

--- a/tests/PhpBrew/Command/InstallCommandTest.php
+++ b/tests/PhpBrew/Command/InstallCommandTest.php
@@ -22,7 +22,6 @@ class InstallCommandTest extends CommandTestCase
     public $usesVCR = false;
 
     /**
-     * @depends testKnownCommand
      * @group install
      * @group mayignore
      */

--- a/tests/PhpBrew/Command/PathCommandTest.php
+++ b/tests/PhpBrew/Command/PathCommandTest.php
@@ -13,7 +13,6 @@ class PathCommandTest extends CommandTestCase
 
     public function argumentsProvider()
     {
-
         return array(
             array("build",   "#\.phpbrew/build/.+#"),
             array("ext-src", "#\.phpbrew/build/.+/ext$#"),
@@ -28,10 +27,11 @@ class PathCommandTest extends CommandTestCase
     /**
      * @outputBuffering enabled
      * @dataProvider argumentsProvider
-     * @depends testUseLatestPHP
      */
     public function testPathCommand($arg, $pattern)
     {
+        putenv('PHPBREW_PHP=7.4.0');
+
         ob_start();
         $this->runCommandWithStdout("phpbrew path $arg");
         $path = ob_get_clean();

--- a/tests/PhpBrew/VariantBuilderTest.php
+++ b/tests/PhpBrew/VariantBuilderTest.php
@@ -17,7 +17,7 @@ class VariantBuilderTest extends TestCase
         return array(
             array(array('debug'),  '#--enable-debug#'),
             array(array('intl'),   '#--enable-intl#'),
-            array(array('apxs2'),  '#--with-apxs2=\S+#'),
+            array(array('apxs2'),  '#--with-apxs2#'),
             array(array('sqlite'), '#--with-sqlite#'),
             array(array('mysql'),  '#--with-mysqli#'),
             array(array('pgsql'),  '#--with-pgsql#'),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,9 @@ use VCR\VCR;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-class_alias('PHPUnit\\Framework\\TestCase', 'PHPUnit_Framework_TestCase');
+if (!class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit\\Framework\\TestCase', 'PHPUnit_Framework_TestCase');
+}
 
 VCR::configure()
   ->setCassettePath('tests/fixtures/vcr_cassettes')


### PR DESCRIPTION
1. `DiffPatchRule::backup()` was mistakenly removed by #1087 and has been restored. The missing `implements PatchRule` statement has been added for clarity.
2. The logic of `InstallCommandTest::testKnownCommand()` was moved under `::testInstallCommand()` by #1079, so the dependency is no longer relevant.
3. `PathCommandTest::testPathCommand()` used to depend on `::testUseLatestPHP()`which would set the `PHPBREW_PHP` environment variable but was removed since it was not in fact used.
4. The expectation of `--with-apxs2=` is replaced with `--with-apxs2` for the same reason as in #1070.
5. The `PHPUnit_Framework_TestCase` class alias is declared conditionally since it may or may not be needed depending on the actually used PHPUnit version.