### PR TITLE
Deprecated the usage of multiple variants in one command line argument

### DIFF
--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -298,7 +298,7 @@ class InstallCommand extends Command
         // ['extra_options'] => the extra options to be passed to ./configure command
         // ['enabled_variants'] => enabeld variants
         // ['disabled_variants'] => disabled variants
-        $variantInfo = VariantParser::parseCommandArguments($args);
+        $variantInfo = VariantParser::parseCommandArguments($args, $this->logger);
         $build->loadVariantInfo($variantInfo); // load again
 
         // assume +default variant if no build config is given and warn about that


### PR DESCRIPTION
The syntax that allows specifying multiple variants in one CLI argument has the following downsides:

1. It doesn't solve any real problem. The same configuration can be expressed using one variant per argument.
2. The resulting syntax is ambiguous. What does `+openssl=/usr-mysql` mean? Is `-mysql` part of the `openssl` prefix or it disables the `mysql` variant?
   ```php
   var_dump(
       VariantParser::parseCommandArguments(array('+openssl=/usr-mysql'))
   );
   /*
   array(3) {
     'enabled_variants' =>
     array(1) {
       'openssl' =>
       string(10) "/usr-mysql"
     }
     'disabled_variants' =>
     array(0) {
     }
     'extra_options' =>
     array(0) {
     }
   }
   */
   ```
3. The parser is unnecessarily complex and doesn't handle syntax errors properly:
   ```php
   var_dump(
       VariantParser::parseCommandArguments(array('+mysql followed+ by- *garbage'))
   );
   /*
   array(3) {
     'enabled_variants' =>
     array(1) {
       'mysql' =>
       bool(true)
     }
     'disabled_variants' =>
     array(0) {
     }
     'extra_options' =>
     array(0) {
     }
   }
   */
   ```
4. The current implementation allows to specify path for a disabled variant which won't be used down the line:
   ```php
   var_dump(
       VariantParser::parseCommandArguments(array('-openssl=/blah/blah'))
   );
   /*
   array(3) {
     'enabled_variants' =>
     array(0) {
     }
     'disabled_variants' =>
     array(1) {
       'openssl' =>
       string(10) "/blah/blah"
     }
     'extra_options' =>
     array(0) {
     }
   }
   */
   ```