### PR TITLE
Fixed code coverage

### DIFF
--- a/src/PhpBrew/Patches/FreeTypePatch.php
+++ b/src/PhpBrew/Patches/FreeTypePatch.php
@@ -26,6 +26,8 @@ class FreeTypePatch extends Patch
 
     /**
      * @link https://git.archlinux.org/svntogit/packages.git/commit/?id=65fd0dc1649537b7fd1d539b769251aacec88719
+     *
+     * @codeCoverageIgnore
      */
     public function rules()
     {

--- a/src/PhpBrew/Patches/PHP53Patch.php
+++ b/src/PhpBrew/Patches/PHP53Patch.php
@@ -24,6 +24,8 @@ class PHP53Patch extends Patch
      * phpcs:disable Generic.Files.LineLength.TooLong
      *
      * @link https://gist.github.com/javian/bfcbd5bc5874ee9c539fb3d642cdce3e
+     *
+     * @codeCoverageIgnore
      */
     public function rules()
     {

--- a/src/PhpBrew/Patches/PHP56WithOpenSSL11Patch.php
+++ b/src/PhpBrew/Patches/PHP56WithOpenSSL11Patch.php
@@ -27,6 +27,8 @@ class PHP56WithOpenSSL11Patch extends Patch
      * phpcs:disable Generic.Files.LineLength.TooLong
      *
      * @link https://github.com/php/php-src/pull/2667
+     *
+     * @codeCoverageIgnore
      */
     public function rules()
     {


### PR DESCRIPTION
After #1093 was merged, the reported code coverage dropped from ~40% to 6%. This is because the PHP source patches are now part of the patch classes and they count towards the lines of code subject to coverage. They should be excluded from coverage to not distort the statistics.