### PR TITLE
Implemented the usage of the system PHP interpreter

### DIFF
--- a/bin/phpbrew
+++ b/bin/phpbrew
@@ -1,18 +1,10 @@
 #!/usr/bin/env php
 <?php
 
-if (PHP_VERSION_ID < 70200) {
-    fwrite(
-        STDERR,
-        sprintf(
-            'This version of PHPBrew is supported on PHP 7.2.0 or newer' . PHP_EOL .
-            'You are using PHP %s (%s).' . PHP_EOL,
-            PHP_VERSION,
-            PHP_BINARY
-        )
-    );
-
-    die(1);
+if (PHP_VERSION_ID < 70200 && function_exists('posix_isatty') && posix_isatty(STDOUT)) {
+    fwrite(STDOUT, "\033[33mWarning! The usage of PHP older than 7.2.0 as the interpreter is deprecated.\n");
+    fwrite(STDOUT, "Please set the system interpreter using \033[0m'phpbrew system <version>'\033[33m.\n");
+    fwrite(STDOUT, "See https://github.com/phpbrew/phpbrew/wiki/System-Interpreter for details.\033[0m\n");
 }
 
 $includeIfExists = function($file)

--- a/bin/phpbrew
+++ b/bin/phpbrew
@@ -1,6 +1,20 @@
 #!/usr/bin/env php
 <?php
 
+if (PHP_VERSION_ID < 70200) {
+    fwrite(
+        STDERR,
+        sprintf(
+            'This version of PHPBrew is supported on PHP 7.2.0 or newer' . PHP_EOL .
+            'You are using PHP %s (%s).' . PHP_EOL,
+            PHP_VERSION,
+            PHP_BINARY
+        )
+    );
+
+    die(1);
+}
+
 $includeIfExists = function($file)
 {
     return file_exists($file) ? include $file : false;

--- a/completion/bash/_phpbrew
+++ b/completion/bash/_phpbrew
@@ -6660,6 +6660,270 @@ local argument_min_length=0
         fi
     fi
 };
+___phpbrew_complete_system ()
+{
+local comp_prefix=___phpbrew
+
+        local cur words cword prev
+        _get_comp_words_by_ref -n =: cur words cword prev
+
+        local command_signature=$1
+        local command_index=$2
+
+        ((command_index++))
+
+        # Output application command alias mapping 
+        # aliases[ alias ] = command
+        declare -A subcommand_alias
+
+        # Define the command names
+        declare -A subcommands
+
+        declare -A subcommand_signs
+
+        # option names defines the available options of this command
+        declare -A options
+        # options_require_value: defines the required completion type for each
+        # option that requires a value.
+        declare -A options_require_value
+        subcommands=()
+subcommand_alias=()
+subcommand_signs=()
+options=()
+options_require_value=()
+local argument_min_length=1
+
+    # Get the command name chain of the current input, e.g.
+    # 
+    #     app asset install [arg1] [arg2] [arg3]
+    #     app commit add
+    #  
+    # The subcommand dispatch should be done in the command complete function,
+    # not in the root completion function. 
+    # We should pass the argument index to the complete function.
+
+    # command_index=1 start from the first argument, not the application name
+    # Find the command position
+    local argument_index=0
+    local i
+    local command
+    local found_options=0
+
+    # echo "[DEBUG] command_index: [$command_signature] [$command_index]"
+
+    while [ $command_index -lt $cword ]; do
+        i="${words[command_index]}"
+        case "$i" in
+            # Ignore options
+            --=*) found_options=1 ;;
+            --*) found_options=1 ;;
+            -*) found_options=1 ;;
+            *)
+                # looks like my command, that's break the loop and dispatch to the next complete function
+                if [[ -n "$i" && -n "${subcommands[$i]}" ]] ; then
+                    command="$i"
+                    break
+                elif [[ -n "$i" && -n "${subcommand_alias[$i]}" ]] ; then
+                    command="$i"
+                    break
+                elif [[ $command_index -gt 1 ]] ; then
+                    # If the command is not found, check if the previous argument is an option expecting a value
+                    # or it is an argument
+
+                    # the previous argument (might be)
+                    p="${words[command_index-1]}"
+
+                    # not an option value, push to the argument list
+                    if [[ -z "${options_require_value[$p]}" ]] ; then
+                        # echo "[DEBUG] argument_index++ because of [$i]"
+                        ((argument_index++))
+                    fi
+                fi
+            ;;
+        esac
+        ((command_index++))
+    done
+
+    # If the first command name is not found, we do complete...
+    if [[ -z "$command" ]] ; then
+        case "$cur" in
+            # If the current argument $cur looks like an option, then we should complete
+            -*)
+                __mycomp "${!options[*]}"
+                return
+            ;;
+            *)
+                # The argument here can be an option value. e.g. --output-dir /tmp
+                # The the previous one...
+                if [[ -n "$prev" && -n "${options_require_value[$prev]}" ]] ; then
+                    # TODO: local complete_type="${options_require_value[$prev]"}
+                  __complete_meta "$command_signature" "opt" "${prev##*(-)}" "valid-values"
+          return
+      fi
+      # If the command requires at least $argument_min_length to run, we check the argument
+if [[ $argument_min_length > 0 ]] ; then
+  case $argument_index in
+      0)
+      __complete_meta "$command_signature" "arg" 0 "suggestions"
+      return
+      ;;
+  esac
+  fi
+
+                # If there is no argument support, then user is supposed to give a subcommand name or an option
+                __mycomp "${!options[*]} ${!subcommands[*]} ${!subcommand_alias[*]}"
+                return
+            ;;
+        esac
+
+    else
+        # We just found the first command, we are going to dispatch the completion handler to the next level...
+        # Rewrite command alias to command name to get the correct response
+        if [[ -n "${subcommand_alias[$command]}" ]] ; then
+            command="${subcommand_alias[$command]}"
+        fi
+
+        if [[ -n "${subcommand_signs[$command]}" ]] ; then
+            local suffix="${subcommand_signs[$command]}"
+            local completion_func="${comp_prefix}_complete_${suffix//-/_}"
+
+            # Declare the completion function name and dispatch rest arguments to the complete function
+            command_signature="${command_signature}.${command}"
+            declare -f $completion_func >/dev/null && \
+                $completion_func $command_signature $command_index && return
+        else
+            echo "Command '$command' not found"
+        fi
+    fi
+};
+___phpbrew_complete_system-off ()
+{
+local comp_prefix=___phpbrew
+
+        local cur words cword prev
+        _get_comp_words_by_ref -n =: cur words cword prev
+
+        local command_signature=$1
+        local command_index=$2
+
+        ((command_index++))
+
+        # Output application command alias mapping 
+        # aliases[ alias ] = command
+        declare -A subcommand_alias
+
+        # Define the command names
+        declare -A subcommands
+
+        declare -A subcommand_signs
+
+        # option names defines the available options of this command
+        declare -A options
+        # options_require_value: defines the required completion type for each
+        # option that requires a value.
+        declare -A options_require_value
+        subcommands=()
+subcommand_alias=()
+subcommand_signs=()
+options=()
+options_require_value=()
+local argument_min_length=0
+
+    # Get the command name chain of the current input, e.g.
+    # 
+    #     app asset install [arg1] [arg2] [arg3]
+    #     app commit add
+    #  
+    # The subcommand dispatch should be done in the command complete function,
+    # not in the root completion function. 
+    # We should pass the argument index to the complete function.
+
+    # command_index=1 start from the first argument, not the application name
+    # Find the command position
+    local argument_index=0
+    local i
+    local command
+    local found_options=0
+
+    # echo "[DEBUG] command_index: [$command_signature] [$command_index]"
+
+    while [ $command_index -lt $cword ]; do
+        i="${words[command_index]}"
+        case "$i" in
+            # Ignore options
+            --=*) found_options=1 ;;
+            --*) found_options=1 ;;
+            -*) found_options=1 ;;
+            *)
+                # looks like my command, that's break the loop and dispatch to the next complete function
+                if [[ -n "$i" && -n "${subcommands[$i]}" ]] ; then
+                    command="$i"
+                    break
+                elif [[ -n "$i" && -n "${subcommand_alias[$i]}" ]] ; then
+                    command="$i"
+                    break
+                elif [[ $command_index -gt 1 ]] ; then
+                    # If the command is not found, check if the previous argument is an option expecting a value
+                    # or it is an argument
+
+                    # the previous argument (might be)
+                    p="${words[command_index-1]}"
+
+                    # not an option value, push to the argument list
+                    if [[ -z "${options_require_value[$p]}" ]] ; then
+                        # echo "[DEBUG] argument_index++ because of [$i]"
+                        ((argument_index++))
+                    fi
+                fi
+            ;;
+        esac
+        ((command_index++))
+    done
+
+    # If the first command name is not found, we do complete...
+    if [[ -z "$command" ]] ; then
+        case "$cur" in
+            # If the current argument $cur looks like an option, then we should complete
+            -*)
+                __mycomp "${!options[*]}"
+                return
+            ;;
+            *)
+                # The argument here can be an option value. e.g. --output-dir /tmp
+                # The the previous one...
+                if [[ -n "$prev" && -n "${options_require_value[$prev]}" ]] ; then
+                    # TODO: local complete_type="${options_require_value[$prev]"}
+                  __complete_meta "$command_signature" "opt" "${prev##*(-)}" "valid-values"
+          return
+      fi
+      # If the command requires at least $argument_min_length to run, we check the argument
+
+                # If there is no argument support, then user is supposed to give a subcommand name or an option
+                __mycomp "${!options[*]} ${!subcommands[*]} ${!subcommand_alias[*]}"
+                return
+            ;;
+        esac
+
+    else
+        # We just found the first command, we are going to dispatch the completion handler to the next level...
+        # Rewrite command alias to command name to get the correct response
+        if [[ -n "${subcommand_alias[$command]}" ]] ; then
+            command="${subcommand_alias[$command]}"
+        fi
+
+        if [[ -n "${subcommand_signs[$command]}" ]] ; then
+            local suffix="${subcommand_signs[$command]}"
+            local completion_func="${comp_prefix}_complete_${suffix//-/_}"
+
+            # Declare the completion function name and dispatch rest arguments to the complete function
+            command_signature="${command_signature}.${command}"
+            declare -f $completion_func >/dev/null && \
+                $completion_func $command_signature $command_index && return
+        else
+            echo "Command '$command' not found"
+        fi
+    fi
+};
 ___phpbrew_complete_phpbrew ()
 {
 local comp_prefix=___phpbrew
@@ -6686,9 +6950,9 @@ local comp_prefix=___phpbrew
         # options_require_value: defines the required completion type for each
         # option that requires a value.
         declare -A options_require_value
-        subcommands=(["help"]="Show help message of a command" ["zsh"]="This function generate a zsh-completion script automatically" ["bash"]="This command generate a bash completion script automatically" ["meta"]="Return the meta data of a commands." ["compile"]="compile current source into Phar format library file." ["archive"]="Build executable phar file from composer.json" ["github:build-topics"]="Build topic classes from the wiki of a GitHub Project." ["app"]="[deprecated] php app store" ["init"]="Initialize phpbrew config file." ["known"]="List known PHP versions" ["install"]="Install php" ["list"]="List installed PHPs" ["use"]="Use php, switch version temporarily" ["switch"]="Switch default php version." ["each"]="Iterate and run a given shell command over all php versions managed by PHPBrew." ["config"]="Edit your current php.ini in your favorite $EDITOR" ["info"]="Show current php information" ["env"]="Export environment variables" ["extension"]="List extensions or execute extension subcommands" ["variants"]="List php variants" ["path"]="Show paths of the current PHP." ["cd"]="Change to directories" ["download"]="Download php" ["clean"]="Clean up the source directory of a PHP distribution" ["update"]="Update PHP release source file" ["ctags"]="Run ctags at current php source dir for extension development." ["fpm"]="fpm commands" ["list-ini"]="List loaded ini config files." ["self-update"]="Self-update, default to master version" ["remove"]="Remove installed php build." ["purge"]="Remove installed php version and config files." ["off"]="Temporarily go back to the system php" ["switch-off"]="Definitely go back to the system php" )
+        subcommands=(["help"]="Show help message of a command" ["zsh"]="This function generate a zsh-completion script automatically" ["bash"]="This command generate a bash completion script automatically" ["meta"]="Return the meta data of a commands." ["compile"]="compile current source into Phar format library file." ["archive"]="Build executable phar file from composer.json" ["github:build-topics"]="Build topic classes from the wiki of a GitHub Project." ["app"]="[deprecated] php app store" ["init"]="Initialize phpbrew config file." ["known"]="List known PHP versions" ["install"]="Install php" ["list"]="List installed PHPs" ["use"]="Use php, switch version temporarily" ["switch"]="Switch default php version." ["each"]="Iterate and run a given shell command over all php versions managed by PHPBrew." ["config"]="Edit your current php.ini in your favorite $EDITOR" ["info"]="Show current php information" ["env"]="Export environment variables" ["extension"]="List extensions or execute extension subcommands" ["variants"]="List php variants" ["path"]="Show paths of the current PHP." ["cd"]="Change to directories" ["download"]="Download php" ["clean"]="Clean up the source directory of a PHP distribution" ["update"]="Update PHP release source file" ["ctags"]="Run ctags at current php source dir for extension development." ["fpm"]="fpm commands" ["list-ini"]="List loaded ini config files." ["self-update"]="Self-update, default to master version" ["remove"]="Remove installed php build." ["purge"]="Remove installed php version and config files." ["off"]="Temporarily go back to the system php" ["switch-off"]="Definitely go back to the system php" ["system"]="Get or set the internally used PHP binary" ["system-off"]="Use the currently effective PHP binary internally" )
 subcommand_alias=(["a"]="archive" ["ar"]="archive" ["i"]="install" ["ins"]="install" ["ext"]="extension" )
-subcommand_signs=(["help"]="help" ["zsh"]="zsh" ["bash"]="bash" ["meta"]="meta" ["compile"]="compile" ["archive"]="archive" ["github:build-topics"]="github:build-topics" ["app"]="app" ["init"]="init" ["known"]="known" ["install"]="install" ["list"]="list" ["use"]="use" ["switch"]="switch" ["each"]="each" ["config"]="config" ["info"]="info" ["env"]="env" ["extension"]="extension" ["variants"]="variants" ["path"]="path" ["cd"]="cd" ["download"]="download" ["clean"]="clean" ["update"]="update" ["ctags"]="ctags" ["fpm"]="fpm" ["list-ini"]="list-ini" ["self-update"]="self-update" ["remove"]="remove" ["purge"]="purge" ["off"]="off" ["switch-off"]="switch-off" )
+subcommand_signs=(["help"]="help" ["zsh"]="zsh" ["bash"]="bash" ["meta"]="meta" ["compile"]="compile" ["archive"]="archive" ["github:build-topics"]="github:build-topics" ["app"]="app" ["init"]="init" ["known"]="known" ["install"]="install" ["list"]="list" ["use"]="use" ["switch"]="switch" ["each"]="each" ["config"]="config" ["info"]="info" ["env"]="env" ["extension"]="extension" ["variants"]="variants" ["path"]="path" ["cd"]="cd" ["download"]="download" ["clean"]="clean" ["update"]="update" ["ctags"]="ctags" ["fpm"]="fpm" ["list-ini"]="list-ini" ["self-update"]="self-update" ["remove"]="remove" ["purge"]="purge" ["off"]="off" ["switch-off"]="switch-off" ["system"]="system" ["system-off"]="system-off" )
 options=(["-v"]="1" ["--verbose"]="1" ["-d"]="1" ["--debug"]="1" ["-q"]="1" ["--quiet"]="1" ["-h"]="1" ["--help"]="1" ["--version"]="1" ["-p"]="1" ["--profile"]="1" ["--log-path"]="1" ["--no-interact"]="1" ["--no-progress"]="1" )
 options_require_value=()
 local argument_min_length=0

--- a/completion/zsh/_phpbrew
+++ b/completion/zsh/_phpbrew
@@ -90,6 +90,8 @@ local ret=1
     purge:'Remove installed php version and config files.'
     off:'Temporarily go back to the system php'
     switch-off:'Definitely go back to the system php'
+    system:'Get or set the internally used PHP binary'
+    system-off:'Use the currently effective PHP binary internally'
   )
   _describe -t commands 'command' commands && ret=0
     ;;
@@ -505,6 +507,15 @@ local ret=1
         
         ;;
         (switch-off)
+        
+        ;;
+        (system)
+            _arguments -w -S -s \
+              ':php version:{___phpbrewmeta "php version" system arg 0 suggestions}' \
+               && ret=0
+        
+        ;;
+        (system-off)
         
         ;;
       esac

--- a/shell/bashrc
+++ b/shell/bashrc
@@ -205,8 +205,6 @@ function phpbrew ()
             else
                 local PHP_BUILD=$(__phpbrew_normalize_build $2)
 
-                __phpbrew_can_use_build $PHP_BUILD || return 1
-
                 # checking if php source exists
                 NEW_PHPBREW_PHP_PATH="$PHPBREW_ROOT/php/$PHP_BUILD"
                 if [ -d $NEW_PHPBREW_PHP_PATH ]; then
@@ -235,8 +233,6 @@ function phpbrew ()
                 echo "Please specify the php version."
             else
                 local PHP_BUILD=$(__phpbrew_normalize_build $2)
-
-                __phpbrew_can_use_build $PHP_BUILD || return 1
 
                 __phpbrew_reinit $PHP_BUILD
             fi

--- a/shell/bashrc
+++ b/shell/bashrc
@@ -10,9 +10,102 @@
 # PHPBREW_SKIP_INIT: if you need to skip loading config from the init file.
 # PHPBREW_PHP:  the current php version.
 # PHPBREW_PATH: the bin path of the current php.
+# PHPBREW_SYSTEM_PHP: the path to the system php binary.
 
 [[ -z "$PHPBREW_HOME" ]] && export PHPBREW_HOME="$HOME/.phpbrew"
 [[ -z "$PHPBREW_BIN" ]] && export PHPBREW_BIN="$PHPBREW_HOME/bin"
+[[ -z "$PHPBREW_VERSION_REGEX" ]] && export PHPBREW_VERSION_REGEX="^([[:digit:]]+\.){2}[[:digit:]]+(-dev|((alpha|beta|RC)[[:digit:]]+))?$"
+
+# The minimal PHP version that PhpBrew supports as interpreter
+MIN_PHP_VERSION="7.2.0"
+MIN_PHP_VERSION_ID=70200
+
+# Executes the given command via the PHP implementation
+function __phpbrew_php_exec()
+{
+    local cmd
+
+    # Check if we are in a PHPBrew source directory (this is only for development)
+    if [[ -e bin/phpbrew ]] ; then
+        cmd=bin/phpbrew
+    else
+        cmd=$(which phpbrew)
+    fi
+
+    # Force the usage of the system PHP interpreter if it's set
+    if [[ -n "$PHPBREW_SYSTEM_PHP" ]] ; then
+        command "$PHPBREW_SYSTEM_PHP" "$cmd" "$@"
+    else
+        command "$cmd" "$@"
+    fi
+}
+
+# Normalizes a PHP build by adding the "php-" prefix if it's missing
+function __phpbrew_normalize_build()
+{
+    if [[ ! -d "$PHPBREW_ROOT/php/$1" && "$1" =~ $PHPBREW_VERSION_REGEX ]] ; then
+        echo "php-$1"
+    else
+        echo "$1"
+    fi
+}
+
+# Returns the PHP binary path for a given version
+function __phpbrew_get_version_bin()
+{
+    if [[ ! "$1" == /* ]] ; then
+        echo "$PHPBREW_ROOT/php/$(__phpbrew_normalize_build $1)/bin/php"
+    else
+        echo "$1"
+    fi
+}
+
+# Validates the PHP binary that is to be used as interpreter
+function __phpbrew_validate_interpreter()
+{
+    if [[ -d "$1" ]] ; then
+        echo "$1 is a directory"
+        return 1
+    fi
+
+    if [[ ! -f "$1" ]] ; then
+        echo "$1 not found"
+        return 1
+    fi
+
+    if [[ ! -x "$1" ]] ; then
+        echo "$1 is not executable"
+        return 1
+    fi
+
+    local PHP_VERSION_ID=$(command "$1" -r "echo PHP_VERSION_ID;")
+
+    if [[ $? -ne 0 ]] ; then
+        return 1
+    fi
+
+    if [[ $PHP_VERSION_ID -lt $MIN_PHP_VERSION_ID ]] ; then
+        echo "Only PHP $MIN_PHP_VERSION or newer can be used as PHPBrew interpreter"
+        return 1
+    fi
+}
+
+# Checks whether the given PHP build can be currently used or switched to
+function __phpbrew_can_use_build()
+{
+    if [[ ! -z "$PHPBREW_SYSTEM_PHP" ]] ; then
+        # Can use any version since the system interpreter is set
+        return
+    fi
+
+    __phpbrew_validate_interpreter "$(__phpbrew_get_version_bin $1)"
+
+    if [[ $? -ne 0 ]] ; then
+        echo "The system interpreter is not currently set"
+        echo "Please execute 'phpbrew system' using PHP $MIN_PHP_VERSION or newer before using an older one"
+        return 1
+    fi
+}
 
 function __phpbrew_set_path()
 {
@@ -45,21 +138,9 @@ if [[ -z "$PHPBREW_SKIP_INIT" ]]; then
     __phpbrew_load_user_config
 fi
 
-[[ -z "$PHPBREW_ROOT" ]] && export PHPBREW_ROOT="$HOME/.phpbrew"
-[[ -z "$PHPBREW_BIN" ]] && export PHPBREW_BIN="$PHPBREW_HOME/bin"
-[[ -z "$PHPBREW_VERSION_REGEX" ]] && export PHPBREW_VERSION_REGEX="^([[:digit:]]+\.){2}[[:digit:]]+(-dev|((alpha|beta|RC)[[:digit:]]+))?$"
-
 [[ -e "$PHPBREW_ROOT" ]] || mkdir $PHPBREW_ROOT
 [[ -e "$PHPBREW_HOME" ]] || mkdir $PHPBREW_HOME
 [[ -e "$PHPBREW_BIN"  ]] || mkdir -p $PHPBREW_BIN
-
-function __wget_as ()
-{
-    local url=$1
-    local target=$2
-    wget --no-check-certificate -c $url -O $target
-}
-
 
 # When setting lookup prefix, the alias name will be translated into the real
 # path.
@@ -100,17 +181,8 @@ function __phpbrew_set_lookup_prefix ()
     esac
 }
 
-
 function phpbrew ()
 {
-    # Check bin/phpbrew if we are in PHPBrew source directory,
-    # This is only for development
-    if [[ -e bin/phpbrew ]] ; then
-        BIN='bin/phpbrew'
-    else
-        BIN=$(command -p which phpbrew 2> /dev/null || command which phpbrew)
-    fi
-
     local exit_status
     local short_option
     if [[ `echo $1 | awk 'BEGIN{FS=""}{print $1}'` = '-' ]]
@@ -120,7 +192,6 @@ function phpbrew ()
     else
         short_option=""
     fi
-
 
     case $1 in
         use)
@@ -132,17 +203,14 @@ function phpbrew ()
                     echo "Currently using $PHPBREW_PHP"
                 fi
             else
-                if [[ ! -d "$PHPBREW_ROOT/php/$2" && $2 =~ $PHPBREW_VERSION_REGEX ]]
-                then
-                    _PHP_VERSION="php-$2"
-                else
-                    _PHP_VERSION=$2
-                fi
+                local PHP_BUILD=$(__phpbrew_normalize_build $2)
 
-                # checking php version exists?
-                NEW_PHPBREW_PHP_PATH="$PHPBREW_ROOT/php/$_PHP_VERSION"
+                __phpbrew_can_use_build $PHP_BUILD || return 1
+
+                # checking if php source exists
+                NEW_PHPBREW_PHP_PATH="$PHPBREW_ROOT/php/$PHP_BUILD"
                 if [ -d $NEW_PHPBREW_PHP_PATH ]; then
-                    code=$(command $BIN env $_PHP_VERSION)
+                    code=$(__phpbrew_php_exec env $PHP_BUILD)
                     if [ -z "$code" ]
                     then
                         exit_status=1
@@ -151,7 +219,7 @@ function phpbrew ()
                         __phpbrew_set_path
                     fi
                 else
-                    echo "PHP version $_PHP_VERSION is not installed."
+                    echo "PHP version $PHP_BUILD is not installed."
                 fi
             fi
             ;;
@@ -166,7 +234,11 @@ function phpbrew ()
             then
                 echo "Please specify the php version."
             else
-                __phpbrew_reinit $2
+                local PHP_BUILD=$(__phpbrew_normalize_build $2)
+
+                __phpbrew_can_use_build $PHP_BUILD || return 1
+
+                __phpbrew_reinit $PHP_BUILD
             fi
             ;;
         lookup-prefix)
@@ -210,25 +282,25 @@ function phpbrew ()
             ;;
         fpm)
             if ! [[ -z $3 ]]; then
-              _PHP_VERSION=$3
+                PHP_BUILD=$3
             else
-              _PHP_VERSION=${PHPBREW_PHP}
+                PHP_BUILD=${PHPBREW_PHP}
             fi
 
-            mkdir -p ${PHPBREW_ROOT}/php/${_PHP_VERSION}/var/run
-            PHPFPM_BIN=${PHPBREW_ROOT}/php/${_PHP_VERSION}/sbin/php-fpm
-            PHPFPM_PIDFILE=${PHPBREW_ROOT}/php/${_PHP_VERSION}/var/run/php-fpm.pid
+            mkdir -p ${PHPBREW_ROOT}/php/${PHP_BUILD}/var/run
+            PHPFPM_BIN=${PHPBREW_ROOT}/php/${PHP_BUILD}/sbin/php-fpm
+            PHPFPM_PIDFILE=${PHPBREW_ROOT}/php/${PHP_BUILD}/var/run/php-fpm.pid
 
             function fpm_start()
             {
               echo "Starting php-fpm..."
               local regex="^php-5\.2.*"
 
-              if [[ ${_PHP_VERSION} =~ ${regex} ]]; then
+              if [[ ${PHP_BUILD} =~ ${regex} ]]; then
                 ${PHPFPM_BIN} start
               else
-                ${PHPFPM_BIN} --php-ini ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php.ini \
-                  --fpm-config ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php-fpm.conf \
+                ${PHPFPM_BIN} --php-ini ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php.ini \
+                  --fpm-config ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php-fpm.conf \
                   --pid ${PHPFPM_PIDFILE} \
                   "$@"
               fi
@@ -257,7 +329,7 @@ function phpbrew ()
                     fpm_stop
                     ;;
                 setup)
-                    command $PHPBREW_OVERRIDE_PHP $BIN $short_option "$@"
+                    __phpbrew_php_exec $short_option "$@"
                     exit_status=$?
                     ;;
                 restart)
@@ -270,67 +342,75 @@ function phpbrew ()
                     fi
                     ;;
                 module)
-                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php.ini \
-                            --fpm-config ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php-fpm.conf \
+                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php.ini \
+                            --fpm-config ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php-fpm.conf \
                             -m | less
                     ;;
                 info)
-                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php.ini \
-                            --fpm-config ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php-fpm.conf \
+                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php.ini \
+                            --fpm-config ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php-fpm.conf \
                             -i
                     ;;
                 config)
                     if [[ -n $EDITOR ]] ; then
-                        $EDITOR ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php-fpm.conf
+                        $EDITOR ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php-fpm.conf
                     else
                         echo "Please set EDITOR environment variable for your favor."
-                        nano ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php-fpm.conf
+                        nano ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php-fpm.conf
                     fi
                     ;;
                 which)
                     echo $PHPFPM_BIN
                     ;;
                 help)
-                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php.ini \
-                            --fpm-config ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php-fpm.conf --help
+                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php.ini \
+                            --fpm-config ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php-fpm.conf --help
                     ;;
                 test)
-                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php.ini \
-                            --fpm-config ${PHPBREW_ROOT}/php/${_PHP_VERSION}/etc/php-fpm.conf --test
+                    $PHPFPM_BIN --php-ini ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php.ini \
+                            --fpm-config ${PHPBREW_ROOT}/php/${PHP_BUILD}/etc/php-fpm.conf --test
                     ;;
                 *)
                     echo "Usage: phpbrew fpm [start|stop|restart|module|test|config|setup|info|current|which|help]"
                     ;;
             esac
             ;;
-        env)
-            # we don't check php path here, you should check path before you
-            # use env command to output the environment config.
-            if [[ -n "$2" ]]; then
-                export PHPBREW_PHP=$2
-            fi
-            echo "export PHPBREW_ROOT=$PHPBREW_ROOT";
-            echo "export PHPBREW_HOME=$PHPBREW_HOME";
-            if [[ -n $PHPBREW_LOOKUP_PREFIX ]] ; then
-                echo "export PHPBREW_LOOKUP_PREFIX=$PHPBREW_LOOKUP_PREFIX";
-            fi
-            if [[ -n $PHPBREW_PHP ]] ; then
-                echo "export PHPBREW_PHP=$PHPBREW_PHP";
-                echo "export PHPBREW_PATH=$PHPBREW_ROOT/php/$PHPBREW_PHP/bin";
-            fi
-            ;;
         off)
             unset PHPBREW_PHP
             unset PHPBREW_PATH
-            eval `$BIN env`
+            eval $(__phpbrew_php_exec env)
             __phpbrew_set_path
             ;;
         switch-off)
             unset PHPBREW_PHP
             unset PHPBREW_PATH
-            eval `$BIN env`
+            eval $(__phpbrew_php_exec env)
             __phpbrew_reinit
             echo "phpbrew is switched off."
+            ;;
+        system)
+            if [[ -z "$2" ]] ; then
+                __phpbrew_php_exec system
+            else
+                local bin="$(__phpbrew_get_version_bin $2)"
+
+                __phpbrew_validate_interpreter "$bin" || return 1
+
+                export PHPBREW_SYSTEM_PHP="$bin"
+                __phpbrew_update_config
+            fi
+            ;;
+        system-off)
+            __phpbrew_validate_interpreter "$(which php)"
+
+            if [[ $? -ne 0 ]] ; then
+                echo "The currently used PHP build $PHPBREW_PHP cannot be used as PhpBrew interpreter"
+                echo "Please execute `phpbrew switch` using PHP $MIN_PHP_VERSION or newer before switching the system interpreter off"
+                return 1
+            fi
+
+            unset PHPBREW_SYSTEM_PHP
+            __phpbrew_update_config
             ;;
         rehash)
             echo "Rehashing..."
@@ -339,7 +419,7 @@ function phpbrew ()
         purge)
             if [[ -z "$2" ]]
             then
-                command $PHPBREW_OVERRIDE_PHP $BIN help
+                __phpbrew_php_exec help
             else
                 shift
                 __phpbrew_purge "$@"
@@ -347,7 +427,7 @@ function phpbrew ()
             fi
             ;;
         *)
-            command $PHPBREW_OVERRIDE_PHP $BIN $short_option "$@"
+            __phpbrew_php_exec $short_option "$@"
             exit_status=$?
             ;;
     esac
@@ -357,17 +437,11 @@ function phpbrew ()
 
 function __phpbrew_update_config ()
 {
-    local VERSION
-    if [[ ! -d "$PHPBREW_ROOT/php/$1" && $1 =~ $PHPBREW_VERSION_REGEX ]]
-    then
-        VERSION="php-$1"
-    else
-        VERSION=$1
-    fi
+    local VERSION=$(__phpbrew_normalize_build $1)
 
     (
         echo "# DO NOT EDIT THIS FILE"
-        command $BIN env $VERSION
+        __phpbrew_php_exec env $VERSION
     ) > "$PHPBREW_HOME/init"
 
     . "$PHPBREW_HOME/init"
@@ -415,26 +489,34 @@ function __phpbrew_purge()
 
 function __phpbrew_purge_build ()
 {
-    _PHP_VERSION=$1
-    if [[ "$_PHP_VERSION" = "$PHPBREW_PHP" ]]
+    local PHP_BUILD=$(__phpbrew_normalize_build $1)
+
+    if [[ "$PHP_BUILD" = "$PHPBREW_PHP" ]]
     then
-        echo "php version: $_PHP_VERSION is already in use."
+        echo "php version: $PHP_BUILD is already in use."
         return 1
     fi
 
-    _PHP_BIN_PATH=$PHPBREW_ROOT/php/$_PHP_VERSION
+    local bin="$(__phpbrew_get_version_bin $PHP_BUILD)"
+
+    if [[ "$bin" = "$PHPBREW_SYSTEM_PHP" ]] ; then
+        echo "PHP build $PHP_BUILD is used as the system interpreter"
+        return 1
+    fi
+
+    _PHP_BIN_PATH=$PHPBREW_ROOT/php/$PHP_BUILD
 
     if [ ! -d $_PHP_BIN_PATH ]; then
-        echo "php version: $_PHP_VERSION not installed."
+        echo "php version: $PHP_BUILD not installed."
         return 1
     fi
 
-    _PHP_SOURCE_FILE=$PHPBREW_ROOT/build/$_PHP_VERSION.tar.bz2
-    _PHP_BUILD_PATH=$PHPBREW_ROOT/build/$_PHP_VERSION
+    _PHP_SOURCE_FILE=$PHPBREW_ROOT/build/$PHP_BUILD.tar.bz2
+    _PHP_BUILD_PATH=$PHPBREW_ROOT/build/$PHP_BUILD
 
     rm -fr $_PHP_SOURCE_FILE $_PHP_BUILD_PATH $_PHP_BIN_PATH
 
-    echo "php version: $_PHP_VERSION is removed and purged."
+    echo "php version: $PHP_BUILD is removed and purged."
 
     return 0
 }
@@ -455,7 +537,6 @@ function phpbrew_current_php_version() {
 if [[ -n "$PHPBREW_SET_PROMPT" && "$PHPBREW_SET_PROMPT" == "1" ]]; then
     export PS1="\w > \u@\h [\$(phpbrew_current_php_version)]\n\\$ "
 fi
-
 
 # the _phpbrewrc_load will be called after *every simple command* executed in bash,
 # this will make the start up process slower if you have many commands to be run in your .bashrc or .zshrc

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -10,6 +10,7 @@
 # PHPBREW_SKIP_INIT: if you need to skip loading config from the init file.
 # PHPBREW_PHP:  the current php version.
 # PHPBREW_PATH: the bin path of the current php.
+# PHPBREW_SYSTEM_PHP: the path to the system php binary.
 
 # export alias for bourne shell compatibility.
 # From PR https://github.com/fish-shell/fish-shell/pull/1833
@@ -55,10 +56,84 @@ end
 
 [ ! -d $PHPBREW_BIN ]; and mkdir -p $PHPBREW_BIN
 
-function __wget_as
-    set -l url $argv[1]
-    set -l target $argv[2]
-    wget --no-check-certificate -c $url -O $target
+# The minimal PHP version that PhpBrew supports as interpreter
+set MIN_PHP_VERSION    "7.2.0"
+set MIN_PHP_VERSION_ID 70200
+
+# Executes the given command via the PHP implementation
+function __phpbrew_php_exec
+    # Force the usage of the system PHP interpreter if it's set
+    if set -q PHPBREW_SYSTEM_PHP
+        set cmd $PHPBREW_SYSTEM_PHP
+    end
+
+    # Check if we are in a PHPBrew source directory (this is only for development)
+    if [ -e bin/phpbrew ]
+        set -a cmd bin/phpbrew
+    else
+        set -a cmd (which phpbrew)
+    end
+
+    command $cmd $argv
+end
+
+# Normalizes a PHP build by adding the "php-" prefix if it's missing
+function __phpbrew_normalize_build
+    if begin ; [ ! -d "$PHPBREW_ROOT/php/$argv" ]; and echo $argv | egrep -q -e $PHPBREW_VERSION_REGEX; end
+        echo "php-$argv"
+    else
+        echo $argv
+    end
+end
+
+# Returns the PHP binary path for a given version
+function __phpbrew_get_version_bin
+    if not string match -q "/*" $argv
+        set -l build (__phpbrew_normalize_build $argv)
+        echo "$PHPBREW_ROOT/php/$build/bin/php"
+    else
+        echo $argv
+    end
+end
+
+# Validates the PHP binary that is to be used as interpreter
+function __phpbrew_validate_interpreter
+    if [ -d $argv[1] ]
+        echo $argv[1] "is a directory"
+        return 1
+    end
+
+    if [ ! -f $argv[1] ]
+        echo $argv[1] "not found"
+        return 1
+    end
+
+    if [ ! -x $argv[1] ]
+        echo $argv[1] "is not executable"
+        return 1
+    end
+
+    set PHP_VERSION_ID (command $argv[1] -r "echo PHP_VERSION_ID;")
+    or return 1
+
+    if [ $PHP_VERSION_ID -lt $MIN_PHP_VERSION_ID ]
+        echo "Only PHP $MIN_PHP_VERSION or newer can be used as PHPBrew interpreter"
+        return 1
+    end
+end
+
+# Checks whether the given PHP build can be currently used or switched to
+function __phpbrew_can_use_build
+    if set -q PHPBREW_SYSTEM_PHP
+        # Can use any version since the system interpreter is set
+        return
+    end
+
+    if not __phpbrew_validate_interpreter (__phpbrew_get_version_bin $argv[1])
+        echo "The system interpreter is not currently set"
+        echo "Please execute 'phpbrew system' using PHP $MIN_PHP_VERSION or newer before using an older one"
+        return 1
+    end
 end
 
 function __phpbrew_set_lookup_prefix
@@ -87,14 +162,6 @@ function __phpbrew_set_lookup_prefix
 end
 
 function phpbrew
-    # Check bin/phpbrew if we are in PHPBrew source directory,
-    # This is only for development
-    if [ -e bin/phpbrew ]
-        set -g BIN 'bin/phpbrew'
-    else
-        set -g BIN 'phpbrew'
-    end
-
     set exit_status
     set short_option
     # export SHELL
@@ -114,20 +181,16 @@ function phpbrew
                     echo "Currently using $PHPBREW_PHP"
                 end
             else
-                if begin ; [ ! -d "$PHPBREW_ROOT/php/$argv[2]" ]; and echo $argv[2] | egrep -q -e $PHPBREW_VERSION_REGEX; end
-                    set _PHP_VERSION "php-$argv[2]"
-                else
-                    set _PHP_VERSION $argv[2]
-                end
+                set PHP_BUILD (__phpbrew_normalize_build $argv[2])
 
-                # checking php version exists?
-                set NEW_PHPBREW_PHP_PATH "$PHPBREW_ROOT/php/$_PHP_VERSION"
+                __phpbrew_can_use_build $PHP_BUILD
+                or return 1
+
+                # checking if php source exists
+                set NEW_PHPBREW_PHP_PATH "$PHPBREW_ROOT/php/$PHP_BUILD"
                 if [ -d $NEW_PHPBREW_PHP_PATH ]
-                    if [ $BIN = "phpbrew" ]
-                        set code (command phpbrew env $_PHP_VERSION | grep -v '^#' | tr '\n' ';')
-                    else
-                        set code (eval $BIN env $_PHP_VERSION | grep -v '^#' | tr '\n' ';')
-                    end
+                    set code (__phpbrew_php_exec env $PHP_BUILD | grep -v '^#' | tr '\n' ';')
+
                     if [ -z "$code" ]
                         set exit_status 1
                     else
@@ -136,7 +199,7 @@ function phpbrew
                         __phpbrew_set_path
                     end
                 else
-                    echo "PHP version $_PHP_VERSION is not installed."
+                    echo "PHP version $PHP_BUILD is not installed."
                 end
             end
         case cd-src
@@ -148,7 +211,12 @@ function phpbrew
             if [ (count $argv) -eq 1 ]
                 echo "Please specify the php version."
             else
-                __phpbrew_reinit $argv[2]
+                set -l build (__phpbrew_normalize_build $argv[2])
+
+                __phpbrew_can_use_build $build
+                or return 1
+
+                __phpbrew_reinit $build
             end
         case lookup-prefix
             if [ (count $argv) -eq 1 ]
@@ -185,14 +253,14 @@ function phpbrew
 
         case fpm
             if [ (count $argv) -ge 3 ]
-              set -g _PHP_VERSION $argv[3]
+              set -g PHP_BUILD $argv[3]
             else
-              set -g _PHP_VERSION $PHPBREW_PHP
+              set -g PHP_BUILD $PHPBREW_PHP
             end
 
-            mkdir -p $PHPBREW_ROOT/php/$_PHP_VERSION/var/run
-            set -g PHPFPM_BIN $PHPBREW_ROOT/php/$_PHP_VERSION/sbin/php-fpm
-            set -g PHPFPM_PIDFILE $PHPBREW_ROOT/php/$_PHP_VERSION/var/run/php-fpm.pid
+            mkdir -p $PHPBREW_ROOT/php/$PHP_BUILD/var/run
+            set -g PHPFPM_BIN $PHPBREW_ROOT/php/$PHP_BUILD/sbin/php-fpm
+            set -g PHPFPM_PIDFILE $PHPBREW_ROOT/php/$PHP_BUILD/var/run/php-fpm.pid
 
             function fpm_start
               echo "Starting php-fpm..."
@@ -205,10 +273,10 @@ function phpbrew
               end
 
 
-              if echo $_PHP_VERSION | egrep -q -e $regex
+              if echo $PHP_BUILD | egrep -q -e $regex
                 eval $PHPFPM_BIN start
               else
-                 eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php-fpm.conf --pid $PHPFPM_PIDFILE $_PHPFPM_APPEND
+                 eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$PHP_BUILD/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$PHP_BUILD/etc/php-fpm.conf --pid $PHPFPM_PIDFILE $_PHPFPM_APPEND
               end
 
               if [ "$status" != "0" ]
@@ -219,7 +287,7 @@ function phpbrew
             function fpm_stop
               set -l regex '^php-5\.2.*'
 
-              if echo $_PHP_VERSION | egrep -q -e $regex
+              if echo $PHP_BUILD | egrep -q -e $regex
                 eval $PHPFPM_BIN stop
               else if [ -e $PHPFPM_PIDFILE ]
                 echo "Stopping php-fpm..."
@@ -239,53 +307,58 @@ function phpbrew
                     fpm_stop
                     fpm_start $argv
               case module
-                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php-fpm.conf -m | less
+                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$PHP_BUILD/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$PHP_BUILD/etc/php-fpm.conf -m | less
               case info
-                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php-fpm.conf -i
+                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$PHP_BUILD/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$PHP_BUILD/etc/php-fpm.conf -i
               case config
                     if [ -n "$EDITOR" ]
-                        eval $EDITOR $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php-fpm.conf
+                        eval $EDITOR $PHPBREW_ROOT/php/$PHP_BUILD/etc/php-fpm.conf
                     else
                         echo "Please set EDITOR environment variable for your favor."
-                        nano $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php-fpm.conf
+                        nano $PHPBREW_ROOT/php/$PHP_BUILD/etc/php-fpm.conf
                     end
               case help
-                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php-fpm.conf --help
+                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$PHP_BUILD/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$PHP_BUILD/etc/php-fpm.conf --help
               case test
-                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$_PHP_VERSION/etc/php-fpm.conf --test
+                     eval $PHPFPM_BIN --php-ini $PHPBREW_ROOT/php/$PHP_BUILD/etc/php.ini --fpm-config $PHPBREW_ROOT/php/$PHP_BUILD/etc/php-fpm.conf --test
               case '*'
                     echo "Usage: phpbrew fpm [start|stop|restart|module|test|help|config]"
-            end
-
-        case env
-            # we don't check php path here, you should check path before you
-            # use env command to output the environment config.
-            [ (count $argv) -ge 2 ]; and set -gx PHPBREW_PHP $argv[2]
-
-            echo "export PHPBREW_ROOT=$PHPBREW_ROOT";
-            echo "export PHPBREW_HOME=$PHPBREW_HOME";
-
-            if [ -n "$PHPBREW_LOOKUP_PREFIX" ]
-                echo "export PHPBREW_LOOKUP_PREFIX=$PHPBREW_LOOKUP_PREFIX";
-            end
-
-            if [ -n "$PHPBREW_PHP" ]
-                echo "export PHPBREW_PHP=$PHPBREW_PHP";
-                echo "export PHPBREW_PATH=$PHPBREW_ROOT/php/$PHPBREW_PHP/bin";
             end
 
         case off
             set -e PHPBREW_PHP
             set -e PHPBREW_PATH
-            eval (eval $BIN env)
+            eval (__phpbrew_php_exec env)
             __phpbrew_set_path
 
         case switch-off
             set -e PHPBREW_PHP
             set -e PHPBREW_PATH
-            eval (eval $BIN env)
+            eval (__phpbrew_php_exec env)
             __phpbrew_reinit
             echo "phpbrew is switched off."
+
+        case system
+            if [ (count $argv) -lt 2 ]
+                __phpbrew_php_exec system
+            else
+                set -l bin (__phpbrew_get_version_bin $argv[2])
+                __phpbrew_validate_interpreter $bin
+                or return 1
+
+                set -gx PHPBREW_SYSTEM_PHP $bin
+                __phpbrew_update_config
+            end
+
+        case system-off
+            if not __phpbrew_validate_interpreter (which php)
+                echo "The currently used PHP build $PHPBREW_PHP cannot be used as PhpBrew interpreter"
+                echo "Please execute `phpbrew switch` using PHP $MIN_PHP_VERSION or newer before switching the system interpreter off"
+                return 1
+            end
+
+            set -e PHPBREW_SYSTEM_PHP
+            __phpbrew_update_config
 
         case rehash
             echo "Rehashing..."
@@ -293,33 +366,21 @@ function phpbrew
 
         case purge
             if [ (count $argv) -ge 2 ]
-              __phpbrew_remove_purge $argv[2] purge
+              __phpbrew_purge $argv[2] purge
             else
-                if [ $BIN = "phpbrew" ]
-                    command phpbrew BIN help
-                else
-                    eval $BIN help
-                end
+                __phpbrew_php_exec help
             end
 
         case '*'
-            if [ $BIN = "phpbrew" ]
-                if [ -z "$short_option" ]
-                  command phpbrew $argv
-                else
-                  command phpbrew $short_option $argv
-                end
+            if [ -z "$short_option" ]
+                __phpbrew_php_exec $argv
             else
-                if [ -z "$short_option" ]
-                  eval $BIN $argv
-                else
-                  eval $BIN $short_option $argv
-                end
+                __phpbrew_php_exec $short_option $argv
             end
             set exit_status $status
             ;;
     end
-    # hash -r
+
     return $exit_status
 end
 
@@ -339,19 +400,9 @@ function __phpbrew_set_path
 end
 
 function __phpbrew_update_config
-    set cmd $BIN env
-
-    if [ (count $argv) -ge 1 ]
-        if begin; [ ! -d "$PHPBREW_ROOT/php/$argv" ]; and echo $argv | egrep -q -e $PHPBREW_VERSION_REGEX ; end
-            set -a cmd "php-$argv"
-        else
-            set -a cmd $argv
-        end
-    end
-
     begin
         echo "# DO NOT EDIT THIS FILE"
-        command $cmd
+        __phpbrew_php_exec env $argv
     end > "$PHPBREW_HOME/init"
 
     source "$PHPBREW_HOME/init"
@@ -385,18 +436,24 @@ function __phpbrew_each
     return $result
 end
 
-function __phpbrew_remove_purge
-    if [ (count $argv) -ge 1 ]
-      set _PHP_VERSION $argv[1]
-    end
-    if [ "$_PHP_VERSION" = "$PHPBREW_PHP" ]
-        echo "php version: $_PHP_VERSION is already in used."
+function __phpbrew_purge
+    set -l PHP_BUILD (__phpbrew_normalize_build $argv[1])
+
+    if [ "$PHP_BUILD" = "$PHPBREW_PHP" ]
+        echo "php version: $PHP_BUILD is already in use."
         return 1
     end
 
-    set _PHP_BIN_PATH $PHPBREW_ROOT/php/$_PHP_VERSION
-    set _PHP_SOURCE_FILE $PHPBREW_ROOT/build/$_PHP_VERSION.tar.bz2
-    set _PHP_BUILD_PATH $PHPBREW_ROOT/build/$_PHP_VERSION
+    set -l bin (__phpbrew_get_version_bin $PHP_BUILD)
+
+    if [ "$bin" = "$PHPBREW_SYSTEM_PHP" ]
+        echo "PHP build $PHP_BUILD is used as the system interpreter"
+        return 1
+    end
+
+    set _PHP_BIN_PATH $PHPBREW_ROOT/php/$PHP_BUILD
+    set _PHP_SOURCE_FILE $PHPBREW_ROOT/build/$PHP_BUILD.tar.bz2
+    set _PHP_BUILD_PATH $PHPBREW_ROOT/build/$PHP_BUILD
 
     if [ -d $_PHP_BIN_PATH ]
 
@@ -404,7 +461,7 @@ function __phpbrew_remove_purge
             rm -f $_PHP_SOURCE_FILE
             rm -fr $_PHP_BUILD_PATH
             rm -fr $_PHP_BIN_PATH
-            echo "php version: $_PHP_VERSION is removed and purged."
+            echo "php version: $PHP_BUILD is removed and purged."
         else
             rm -f $_PHP_SOURCE_FILE
             rm -fr $_PHP_BUILD_PATH
@@ -415,11 +472,11 @@ function __phpbrew_remove_purge
                 end
             end
 
-            echo "php version: $_PHP_VERSION is removed."
+            echo "php version: $PHP_BUILD is removed."
         end
 
     else
-        echo "php version: $_PHP_VERSION not installed."
+        echo "php version: $PHP_BUILD not installed."
     end
 
     return 0
@@ -551,7 +608,7 @@ function __fish_phpbrew_using_command
 end
 
 function __fish_phpbrew_arg_meta
-    command phpbrew meta --flat $argv[1] arg $argv[2] $argv[3] | grep -v "^#"
+    __phpbrew_php_exec meta --flat $argv[1] arg $argv[2] $argv[3] | grep -v "^#"
 end
 
 # top level options
@@ -595,6 +652,8 @@ complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a remove -d "Remove in
 complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a self-update -d "Self-update, default to master version"
 complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a switch -d "Switch default php version"
 complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a switch-off -d "Definitely go back to the system php"
+complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a system -d "Get or set the internally used PHP binary"
+complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a system-off -d "Use the currently effective PHP binary internally"
 complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a update -d "Update PHP release source file"
 complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a use -d "Use php, switch version temporarily"
 complete -f -c phpbrew -n "__fish_phpbrew_needs_command" -a variants -d "List php variants"
@@ -803,6 +862,9 @@ complete -x -c phpbrew -n "__fish_phpbrew_using_command self-update" -l connect-
 
 # switch
 complete -x -c phpbrew -n "__fish_phpbrew_using_command switch" -a "(__fish_phpbrew_arg_meta switch 0 valid-values)"
+
+# system
+complete -x -c phpbrew -n "__fish_phpbrew_using_command system" -a "(__fish_phpbrew_arg_meta system 0 suggestions)"
 
 # update
 complete -f -c phpbrew -n "__fish_phpbrew_using_command update" -s o -l old -d "List old phps \(less than 5.3\)"

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -183,9 +183,6 @@ function phpbrew
             else
                 set PHP_BUILD (__phpbrew_normalize_build $argv[2])
 
-                __phpbrew_can_use_build $PHP_BUILD
-                or return 1
-
                 # checking if php source exists
                 set NEW_PHPBREW_PHP_PATH "$PHPBREW_ROOT/php/$PHP_BUILD"
                 if [ -d $NEW_PHPBREW_PHP_PATH ]
@@ -212,9 +209,6 @@ function phpbrew
                 echo "Please specify the php version."
             else
                 set -l build (__phpbrew_normalize_build $argv[2])
-
-                __phpbrew_can_use_build $build
-                or return 1
 
                 __phpbrew_reinit $build
             end

--- a/src/PhpBrew/Command/EnvCommand.php
+++ b/src/PhpBrew/Command/EnvCommand.php
@@ -30,24 +30,38 @@ class EnvCommand extends BaseCommand
             $buildName = getenv('PHPBREW_PHP');
         }
 
-        // $currentVersion;
-        $root = Config::getRoot();
-        $home = Config::getHome();
-        $lookup = getenv('PHPBREW_LOOKUP_PREFIX');
+        $this->export('PHPBREW_ROOT', Config::getRoot());
+        $this->export('PHPBREW_HOME', Config::getHome());
 
-        $this->logger->writeln("export PHPBREW_ROOT=$root");
-        $this->logger->writeln("export PHPBREW_HOME=$home");
-        $this->logger->writeln("export PHPBREW_LOOKUP_PREFIX=$lookup");
+        $this->replicate('PHPBREW_LOOKUP_PREFIX');
 
         if ($buildName !== false) {
-            // checking php version existence
             $targetPhpBinPath = Config::getVersionBinPath($buildName);
+
+            // checking php version existence
             if (is_dir($targetPhpBinPath)) {
-                echo 'export PHPBREW_PHP=' . $buildName . "\n";
-                echo 'export PHPBREW_PATH=' . ($buildName ? Config::getVersionBinPath($buildName) : '') . "\n";
+                $this->export('PHPBREW_PHP', $buildName);
+                $this->export('PHPBREW_PATH', $targetPhpBinPath);
             }
         }
+
+        $this->replicate('PHPBREW_SYSTEM_PHP');
+
         $this->logger->writeln('# Run this command to configure your shell:');
-        $this->logger->writeln('# # eval "$(phpbrew env)"');
+        $this->logger->writeln('# eval "$(phpbrew env)"');
+    }
+
+    private function export($varName, $value)
+    {
+        $this->logger->writeln(sprintf('export %s=%s', $varName, $value));
+    }
+
+    private function replicate($varName)
+    {
+        $value = getenv($varName);
+
+        if ($value !== false && $value !== '') {
+            $this->export($varName, $value);
+        }
     }
 }

--- a/src/PhpBrew/Command/SystemCommand.php
+++ b/src/PhpBrew/Command/SystemCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PhpBrew\Command;
+
+use CLIFramework\Command;
+use PhpBrew\BuildFinder;
+
+class SystemCommand extends Command
+{
+    public function brief()
+    {
+        return 'Get or set the internally used PHP binary';
+    }
+
+    public function arguments($args)
+    {
+        $args->add('php version')
+            ->suggestions(function () {
+                return BuildFinder::findInstalledBuilds();
+            });
+    }
+
+    final public function execute()
+    {
+        $path = getenv('PHPBREW_SYSTEM_PHP');
+
+        if ($path !== false && $path !== '') {
+            $this->logger->writeln($path);
+        }
+    }
+}

--- a/src/PhpBrew/Command/SystemOffCommand.php
+++ b/src/PhpBrew/Command/SystemOffCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PhpBrew\Command;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SystemOffCommand extends VirtualCommand
+{
+    public function brief()
+    {
+        return 'Use the currently effective PHP binary internally';
+    }
+}

--- a/src/PhpBrew/Console.php
+++ b/src/PhpBrew/Console.php
@@ -58,6 +58,9 @@ class Console extends Application
         $this->command('off');
         $this->command('switch-off', 'PhpBrew\Command\SwitchOffCommand');
 
+        $this->command('system');
+        $this->command('system-off');
+
         $this->configure();
 
         // We use '#' as the prefix to prevent issue with bash


### PR DESCRIPTION
The full new feature is implemented in the first commit and then partially reverted to the deprecation mode in the second one.

**Migration path:**
1. Once upgraded, if a user uses PHPBrew with an old PHP version, PHPBrew will display a warning suggesting to set the system interpreter. In the deprecation mode, the `use` and `switch` commands will not have the intended PHP version constraints while `system` and `system-off` will. This will motivate the users to configure their environment as expected.
2. In the next minor release, we'll revert the deprecation layer and drop the support for the older PHP version. At this point, the users will be expected to have their environment configured.

**TODO:**
- [x] Document the refactoring in this PR.
   1. A new environment variable `PHPBREW_SYSTEM_PHP` has been introduced. If set, it must contain the full path to the system PHP interpreter, e.g. `/usr/bin/php`.
   2. `__phpbrew_php_exec()` is now the key entry point from the shell PHPBrew wrapper to the PHP implementation. It uses the system PHP interpreter if it's set or falls back to the current one. Also it tries to use `bin/phpbrew` if we're currently in the PHPBrew source directory.
   3. The `env` subcommand implementations have been removed from the shell whappers since the subcommand can be properly handled by a PHP implementation.
- [x] Document the feature on [Wiki](https://github.com/phpbrew/phpbrew/wiki/System-Interpreter).
- [x] Split into deprecation and subsequent enforcement of the runtime version.
- [x] Request feedback from maintainers and active contributors.

**Behavior tested manually on Fish and Bash**:
```gherkin
Feature: System PHP interpreter

  Scenario: If the system interpreter is not set, the command displays nothing
    Given the system interpreter is not set
    When I check the system interpreter
    Then the output should have been empty

  Scenario: If the system interpreter is set, the command displays the interpreter path
    Given the system interpreter is set to:
      | build  | path         |
      | system | /usr/bin/php |
    When I check system interpreter
    Then the output should have been "/usr/bin/php"

  Scenario: The system interpreter can be set using the interpreter path
    Given the system interpreter is not set
    When I set the system interpreter using "path" to:
      | version | path         |
      | system  | /usr/bin/php |
    And I check the system interpreter
    Then the output should have been "/usr/bin/php"

  Scenario: The system interpreter can be set using the interpreter version
    Given the system interpreter is not set
    When I set the system interpreter using "version" to:
      | version | path                             |
      | 7.4.0   | ~/.phpbrew/php/php-7.4.0/bin/php |
    And I check the system interpreter
    Then the output should have been "~/.phpbrew/php/php-7.4.0/bin/php"

  Scenario: The system interpreter can be set using the interpreter build
    Given the system interpreter is not set
    When I set the system interpreter using "version" to:
      | build     | path                             |
      | php-7.4.0 | ~/.phpbrew/php/php-7.4.0/bin/php |
    And I check the system interpreter
    Then the output should have been "~/.phpbrew/php/php-7.4.0/bin/php"

  Scenario: The system interpreter cannot be set to an unsupported PHP version
    Given the system interpreter is not set
    When I set the system interpreter using "path" to:
      | path                             | PHP_VERSION_ID |
      | ~/.phpbrew/php/php-7.1.0/bin/php | 70100          |
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the system interpreter should not have been set

  Scenario: The system interpreter cannot be set to a non-existing path
    Given the system interpreter is not set
    When I set the system interpreter using "path" to:
      | path          |
      | /path/to/file |
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the system interpreter should not have been set

  Scenario: The system interpreter cannot be set to a directory path
    Given the system interpreter is not set
    When I set the system interpreter using "path" to:
      | path |
      | /    |
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the system interpreter should not have been set

  Scenario: The system interpreter cannot be set to a non-executable file path
    Given the system interpreter is not set
    When I set the system interpreter using "path" to:
      | path       |
      | /etc/fstab |
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the system interpreter should not have been set

  Scenario: The system interpreter cannot be set to a non-PHP executable
    Given the system interpreter is not set
    When I set the system interpreter using "path" to:
      | path    |
      | /bin/ls |
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the system interpreter should not have been set

  Scenario: The system interpreter version cannot be purged
    Given the system system interpreter is set to:
      | version | path                             |
      | 7.4.0   | ~/.phpbrew/php/php-7.4.0/bin/php |
    When I purge the PHP version "7.4.0"
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the system interpreter should have been remained unchanged

  Scenario: An unsupported PHP version cannot be used without a system interpreter
    Given the system interpreter is not set
    When I use the PHP version "7.1.0"
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the current PHP version should have remained unchanged

  Scenario: The system interpreter cannot be switched off when an unsupported PHP version is used
    Given the system system interpreter is set to:
      | version | path                             |
      | 7.4.0   | ~/.phpbrew/php/php-7.4.0/bin/php |
    When I switch off the system interpreter
    Then an error should have been displayed
    And the command should have exited with a non-zero exit code
    And the system interpreter should have been remained unchanged```
```
Closes #872.