### PR TITLE
Removed unnecessary top-level dependency on corneltek/class-template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "corneltek/cliframework": "dev-master#2650a53433854d43b91955e8f967c62ce07869d7",
-        "corneltek/class-template": "^2",
         "corneltek/pearx": "^1.3.4",
         "corneltek/curlkit": "^1.0.11",
         "symfony/yaml": "^2.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a95306125272774b606fa8145b00c3fe",
+    "content-hash": "61b0be8416c029a3e3aaa73e077df9e2",
     "packages": [
         {
             "name": "corneltek/cachekit",


### PR DESCRIPTION
The dependency was added in #912 probably to prevent an upgrade to an incompatible version.