### PR TITLE
Removed deprecated Config::getInstalledPhpVersions()

### DIFF
--- a/src/PhpBrew/BuildFinder.php
+++ b/src/PhpBrew/BuildFinder.php
@@ -2,21 +2,20 @@
 
 namespace PhpBrew;
 
-use Exception;
-
 class BuildFinder
 {
     /**
-     * @return string[]
+     * @return string[] PHP builds
      */
-    public static function findInstalledBuilds($stripPrefix = true)
+    public static function findInstalledBuilds()
     {
         $path = Config::getRoot() . DIRECTORY_SEPARATOR . 'php';
+
         if (!file_exists($path)) {
-            throw new Exception($path . ' does not exist.');
+            return array();
         }
-        $names = scandir($path);
-        $names = array_filter($names, function ($name) use ($path) {
+
+        $names = array_filter(scandir($path), function ($name) use ($path) {
             return $name != '.'
                 && $name != '..'
                 && file_exists(
@@ -27,15 +26,6 @@ class BuildFinder
             );
         });
 
-        if ($names == null || empty($names)) {
-            return array();
-        }
-
-        if ($stripPrefix) {
-            $names = array_map(function ($name) {
-                return preg_replace('/^php-(?=(\d+\.\d+\.\d+(-dev|((alpha|beta|RC)\d+))?)$)/', '', $name);
-            }, $names);
-        }
         uasort($names, 'version_compare'); // ordering version name ascending... 5.5.17, 5.5.12
 
         // make it descending... since there is no sort function for user-define in reverse order.
@@ -43,14 +33,12 @@ class BuildFinder
     }
 
     /**
-     * @return string[] build names
+     * @return string[] PHP versions
      */
-    public static function findMatchedBuilds($buildNameRE = '', $stripPrefix = true)
+    public static function findInstalledVersions()
     {
-        $builds = self::findInstalledBuilds($stripPrefix);
-
-        return array_filter($builds, function ($build) use ($buildNameRE) {
-            return preg_match("/^$buildNameRE/i", $build);
-        });
+        return array_map(function ($name) {
+            return preg_replace('/^php-(?=(\d+\.\d+\.\d+(-dev|((alpha|beta|RC)\d+))?)$)/', '', $name);
+        }, self::findInstalledBuilds());
     }
 }

--- a/src/PhpBrew/Command/CleanCommand.php
+++ b/src/PhpBrew/Command/CleanCommand.php
@@ -4,6 +4,7 @@ namespace PhpBrew\Command;
 
 use CLIFramework\Command;
 use PhpBrew\Build;
+use PhpBrew\BuildFinder;
 use PhpBrew\Config;
 use PhpBrew\Tasks\MakeTask;
 use PhpBrew\Utils;
@@ -27,9 +28,9 @@ class CleanCommand extends Command
 
     public function arguments($args)
     {
-        $args->add('installed php')
+        $args->add('PHP build')
             ->validValues(function () {
-                return Config::getInstalledPhpVersions();
+                return BuildFinder::findInstalledBuilds();
             })
             ;
     }

--- a/src/PhpBrew/Command/CtagsCommand.php
+++ b/src/PhpBrew/Command/CtagsCommand.php
@@ -3,6 +3,7 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command;
+use PhpBrew\BuildFinder;
 use PhpBrew\CommandBuilder;
 use PhpBrew\Config;
 
@@ -15,9 +16,9 @@ class CtagsCommand extends Command
 
     public function arguments($args)
     {
-        $args->add('installed versions')
+        $args->add('PHP build')
             ->validValues(function () {
-                return Config::getInstalledPhpVersions();
+                return BuildFinder::findInstalledBuilds();
             })
             ;
     }

--- a/src/PhpBrew/Command/EnvCommand.php
+++ b/src/PhpBrew/Command/EnvCommand.php
@@ -3,6 +3,7 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command as BaseCommand;
+use PhpBrew\BuildFinder;
 use PhpBrew\Config;
 
 class EnvCommand extends BaseCommand
@@ -14,10 +15,10 @@ class EnvCommand extends BaseCommand
 
     public function arguments($args)
     {
-        $args->add('installed php')
+        $args->add('PHP build')
             ->optional()
             ->validValues(function () {
-                return Config::getInstalledPhpVersions();
+                return BuildFinder::findInstalledBuilds();
             })
             ;
     }

--- a/src/PhpBrew/Command/ListCommand.php
+++ b/src/PhpBrew/Command/ListCommand.php
@@ -3,6 +3,7 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command;
+use PhpBrew\BuildFinder;
 use PhpBrew\Config;
 use PhpBrew\VariantParser;
 
@@ -21,27 +22,27 @@ class ListCommand extends Command
 
     public function execute()
     {
-        $versions = Config::getInstalledPhpVersions();
-        $currentVersion = Config::getCurrentPhpName();
+        $builds = BuildFinder::findInstalledBuilds();
+        $currentBuild = Config::getCurrentPhpName();
 
-        if (empty($versions)) {
-            return $this->logger->notice('Please install at least one PHP with your prefered version.');
+        if (empty($builds)) {
+            return $this->logger->notice('Please install at least one PHP with your preferred version.');
         }
 
-        if ($currentVersion === false or !in_array($currentVersion, $versions)) {
+        if ($currentBuild === false or !in_array($currentBuild, $builds)) {
             $this->logger->writeln('* (system)');
         }
 
-        foreach ($versions as $version) {
-            $versionPrefix = Config::getVersionInstallPrefix($version);
+        foreach ($builds as $build) {
+            $versionPrefix = Config::getVersionInstallPrefix($build);
 
-            if ($currentVersion == $version) {
+            if ($currentBuild === $build) {
                 $this->logger->writeln(
-                    $this->formatter->format(sprintf('* %-15s', $version), 'bold')
+                    $this->formatter->format(sprintf('* %-15s', $build), 'bold')
                 );
             } else {
                 $this->logger->writeln(
-                    $this->formatter->format(sprintf('  %-15s', $version), 'bold')
+                    $this->formatter->format(sprintf('  %-15s', $build), 'bold')
                 );
             }
 

--- a/src/PhpBrew/Command/PurgeCommand.php
+++ b/src/PhpBrew/Command/PurgeCommand.php
@@ -4,18 +4,19 @@ namespace PhpBrew\Command;
 
 use CLIFramework\Command;
 use Exception;
+use PhpBrew\BuildFinder;
 use PhpBrew\Config;
 
 /**
  * @codeCoverageIgnore
  */
-class PurgeCommand extends Command
+class PurgeCommand extends VirtualCommand
 {
     public function arguments($args)
     {
-        $args->add('installed php')
+        $args->add('PHP build')
             ->validValues(function () {
-                return Config::getInstalledPhpVersions();
+                return BuildFinder::findInstalledBuilds();
             })
             ->multiple()
             ;
@@ -24,10 +25,5 @@ class PurgeCommand extends Command
     public function brief()
     {
         return 'Remove installed php version and config files.';
-    }
-
-    public function execute($version = null)
-    {
-        throw new Exception('You should not see this, please check if phpbrew bashrc is sourced in your shell.');
     }
 }

--- a/src/PhpBrew/Command/SwitchCommand.php
+++ b/src/PhpBrew/Command/SwitchCommand.php
@@ -11,9 +11,9 @@ class SwitchCommand extends VirtualCommand
 {
     public function arguments($args)
     {
-        $args->add('installed php')
+        $args->add('PHP version')
             ->validValues(function () {
-                return BuildFinder::findMatchedBuilds();
+                return BuildFinder::findInstalledVersions();
             })
             ;
     }

--- a/src/PhpBrew/Command/UseCommand.php
+++ b/src/PhpBrew/Command/UseCommand.php
@@ -11,9 +11,9 @@ class UseCommand extends VirtualCommand
 {
     public function arguments($args)
     {
-        $args->add('php version')
+        $args->add('PHP version')
             ->validValues(function () {
-                return BuildFinder::findInstalledBuilds();
+                return BuildFinder::findInstalledVersions();
             })
             ;
     }

--- a/src/PhpBrew/Config.php
+++ b/src/PhpBrew/Config.php
@@ -161,45 +161,6 @@ class Config
         return self::getVersionInstallPrefix($buildName) . DIRECTORY_SEPARATOR . 'bin';
     }
 
-    /**
-     * XXX: This method is now deprecated. use findMatchedBuilds insteads.
-     *
-     * @deprecated
-     */
-    public static function getInstalledPhpVersions()
-    {
-        $versions = array();
-        $path = self::getRoot() . DIRECTORY_SEPARATOR . 'php';
-
-        if (!file_exists($path)) {
-            throw new Exception("$path doesn't exist.");
-        }
-        if ($fp = opendir($path)) {
-            while (($item = readdir($fp)) !== false) {
-                if ($item == '.' || $item == '..') {
-                    continue;
-                }
-
-                if (
-                    file_exists(
-                        $path
-                        . DIRECTORY_SEPARATOR . $item
-                        . DIRECTORY_SEPARATOR . 'bin'
-                        . DIRECTORY_SEPARATOR . 'php'
-                    )
-                ) {
-                    $versions[] = $item;
-                }
-            }
-            closedir($fp);
-        } else {
-            throw new Exception('opendir failed');
-        }
-        rsort($versions);
-
-        return $versions;
-    }
-
     public static function getCurrentPhpConfigBin()
     {
         return self::getCurrentPhpDir() . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'php-config';

--- a/tests/PhpBrew/Command/InstallCommandTest.php
+++ b/tests/PhpBrew/Command/InstallCommandTest.php
@@ -95,7 +95,6 @@ class InstallCommandTest extends CommandTestCase
 
     protected function assertListContains($string)
     {
-        $this->assertNotEmpty(BuildFinder::findInstalledBuilds(false), 'findInstalledBuilds');
-        $this->assertContains($string, BuildFinder::findInstalledBuilds(false));
+        $this->assertContains($string, BuildFinder::findInstalledBuilds());
     }
 }


### PR DESCRIPTION
Additionally:

1. Removed the `$stripPrefix` flag from `BuildFinder::findInstalledBuilds()`. Instead, introduced `BuildFinder::findInstalledVersions()`.
2. Removed `BuildFinder::findMatchedBuilds()`.
3. Replaced code usages: `Config::getInstalledPhpVersions()` → `BuildFinder::findInstalledBuilds()` (returns builds with the "php-" prefix); `BuildFinder::findInstalledBuilds()` or `BuildFinder::findMatchedBuilds()` → `BuildFinder::findInstalledVersions()` (returns versions without the "php-" prefix).
4. Removed the unnecessary exception from `BuildFinder::findInstalledBuilds()`. The non-existing php directory isn't a more exceptional situation than the empty directory (which doesn't result in an exception).