### PR TITLE
Fix: `composer install` fails because of required 'dev' packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,7 @@
         "psr-4": {
             "PhpBrew\\": "src/PhpBrew/"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
The minimum stability for composer packages is `stable` ([see docs](https://getcomposer.org/doc/04-schema.md#minimum-stability)). Running `composer install` on `master` fails because phpbrew is using `dev` packages.

```
$ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for corneltek/cliframework dev-master#2650a53433854d43b91955e8f967c62ce07869d7 -> satisfiable by corneltek/cliframework[dev-master].
    - corneltek/cliframework dev-master requires corneltek/codegen 4.0.x-dev -> satisfiable by corneltek/codegen[4.0.x-dev] but these conflict with your requirements or minimum-stability.
```

This change sets the minimum stability to 'dev', but with `stable` as preferred stability.