### PR TITLE
Fixed __phpbrew_normalize_build in Bash

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -42,7 +42,7 @@ function __phpbrew_php_exec()
 # Normalizes a PHP build by adding the "php-" prefix if it's missing
 function __phpbrew_normalize_build()
 {
-    if [[ ! -d "$PHPBREW_ROOT/php/$1" && "$1" =~ "^([[:digit:]]+\.){2}[[:digit:]]+(-dev|((alpha|beta|RC)[[:digit:]]+))?$" ]] ; then
+    if [[ ! -d "$PHPBREW_ROOT/php/$1" && "$1" =~ ^([[:digit:]]+\.){2}[[:digit:]]+(-dev|((alpha|beta|RC)[[:digit:]]+))?$ ]] ; then
         echo "php-$1"
     else
         echo "$1"


### PR DESCRIPTION
As of #1101, `phpbrew use` does not accept the arguments that don't start with "php-". E.g.:
```
$ phpbrew list
  php-8.0.0-dev
* php-7.4.1
  php-7.3.13
  php-7.1.33
  php-5.6.40
  php-5.3.29

$ phpbrew use 5.3.29
PHP version 5.3.29 is not installed.

$ phpbrew use php-5.3.29

$ phpbrew use
Currently using php-5.3.29
```
The reason is that the moment when the vesion regular expression pattern was converted from a variable to a literal, it should have been unquoted.