### PR TITLE
Switched from Style-CI to PrettyCI

### DIFF
--- a/.prettyci.composer.json
+++ b/.prettyci.composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.5"
+    }
+}

--- a/README.cn.md
+++ b/README.cn.md
@@ -5,7 +5,6 @@ PHPBrew
 
 [![Build Status](https://travis-ci.org/phpbrew/phpbrew.svg?branch=master)](https://travis-ci.org/phpbrew/phpbrew)
 [![Coverage Status](https://img.shields.io/coveralls/phpbrew/phpbrew.svg)](https://coveralls.io/r/phpbrew/phpbrew)
-[![StyleCI](https://styleci.io/repos/2468290/shield?style=flat)](https://styleci.io/repos/2468290)
 [![Gitter](https://badges.gitter.im/phpbrew/phpbrew.svg)](https://gitter.im/phpbrew/phpbrew?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 phpbrew 是一个构建、安装多版本 PHP 到用户根目录的工具。

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ PHPBrew
 
 [![Build Status](https://travis-ci.org/phpbrew/phpbrew.svg?branch=master)](https://travis-ci.org/phpbrew/phpbrew)
 [![Coverage Status](https://img.shields.io/coveralls/phpbrew/phpbrew.svg)](https://coveralls.io/r/phpbrew/phpbrew)
-[![StyleCI](https://styleci.io/repos/2468290/shield?style=flat)](https://styleci.io/repos/2468290)
 [![Gitter](https://badges.gitter.im/phpbrew/phpbrew.svg)](https://gitter.im/phpbrew/phpbrew?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 phpbrew builds and installs multiple version php(s) in your $HOME directory.

--- a/src/PhpBrew/BuildFinder.php
+++ b/src/PhpBrew/BuildFinder.php
@@ -19,11 +19,11 @@ class BuildFinder
             return $name != '.'
                 && $name != '..'
                 && file_exists(
-                $path
+                    $path
                     . DIRECTORY_SEPARATOR . $name
                     . DIRECTORY_SEPARATOR . 'bin'
                     . DIRECTORY_SEPARATOR . 'php'
-            );
+                );
         });
 
         uasort($names, 'version_compare'); // ordering version name ascending... 5.5.17, 5.5.12

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -554,7 +554,8 @@ class VariantBuilder
 
         $this->variants['sodium'] = function (Build $build, $prefix = null) {
             if ($build->compareVersion('7.2') < 0) {
-                echo "Sodium is available as a core extension since PHP 7.2.0. Please use 'phpbrew ext install sodium' to install it from PECL\n";
+                echo 'Sodium is available as a core extension since PHP 7.2.0.' . PHP_EOL;
+                echo "Please use 'phpbrew ext install sodium' to install it from PECL." . PHP_EOL;
             }
 
             if ($prefix === null) {

--- a/tests/PhpBrew/Patches/Apache2ModuleNamePatchTest.php
+++ b/tests/PhpBrew/Patches/Apache2ModuleNamePatchTest.php
@@ -47,7 +47,7 @@ class Apache2ModuleNamePatchTest extends PatchTestCase
         $this->assertTrue($matched, 'patch matched');
         $patchedCount = $patch->apply($build, $logger);
 
-        $sourceExpectedDirectory = getenv('PHPBREW_EXPECTED_PHP_DIR') . DIRECTORY_SEPARATOR . $version.'-apxs-patch';
+        $sourceExpectedDirectory = getenv('PHPBREW_EXPECTED_PHP_DIR') . DIRECTORY_SEPARATOR . $version . '-apxs-patch';
         $this->assertEquals($expectedPatchedCount, $patchedCount);
         $this->assertFileEquals($sourceExpectedDirectory . $makefile, $sourceDirectory . $makefile);
         $this->assertFileEquals($sourceExpectedDirectory . '/configure', $sourceDirectory . '/configure');


### PR DESCRIPTION
The reasons are:
1. Style-CI uses some non-standard engine and rules that currently don't support PSR-12.
2. Style-CI doesn't allow configuration via code stored in the repository.
3. PrettyCI supports PHP_CodeSniffer and custom standards like doctrine/coding-standards.