### PR TITLE
Removed the --official flag of the update command

### DIFF
--- a/completion/bash/_phpbrew
+++ b/completion/bash/_phpbrew
@@ -4867,7 +4867,7 @@ local comp_prefix=___phpbrew
         subcommands=()
 subcommand_alias=()
 subcommand_signs=()
-options=(["-o"]="1" ["--old"]="1" ["--official"]="1" ["--downloader"]="1" ["--continue"]="1" ["--http-proxy"]="1" ["--http-proxy-auth"]="1" ["--connect-timeout"]="1" )
+options=(["-o"]="1" ["--old"]="1" ["--downloader"]="1" ["--continue"]="1" ["--http-proxy"]="1" ["--http-proxy-auth"]="1" ["--connect-timeout"]="1" )
 options_require_value=(["--downloader"]="1" ["--http-proxy"]="1" ["--http-proxy-auth"]="1" ["--connect-timeout"]="1" )
 local argument_min_length=0
 

--- a/completion/zsh/_phpbrew
+++ b/completion/zsh/_phpbrew
@@ -421,7 +421,6 @@ local ret=1
         (update)
             _arguments -w -S -s \
               '(-o --old)'{-o,--old}'[List old phps (less than 5.3)]' \
-              '--official[Unserialize release information from official site (using `unserialize` function).]' \
               '--downloader=[Use alternative downloader.]' \
               '--continue[Continue getting a partially downloaded file.]' \
               '--http-proxy=[HTTP proxy address]' \

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -868,7 +868,6 @@ complete -x -c phpbrew -n "__fish_phpbrew_using_command system" -a "(__fish_phpb
 
 # update
 complete -f -c phpbrew -n "__fish_phpbrew_using_command update" -s o -l old -d "List old phps \(less than 5.3\)"
-complete -f -c phpbrew -n "__fish_phpbrew_using_command update" -l official -d "Unserialize release information from official site \(using `unserialize` function\)"
 complete -x -c phpbrew -n "__fish_phpbrew_using_command update" -l downloader -d "Use alternative downloader"
 complete -f -c phpbrew -n "__fish_phpbrew_using_command update" -l continue -d "Continue getting a partially downloaded file"
 complete -x -c phpbrew -n "__fish_phpbrew_using_command update" -l http-proxy -d "HTTP proxy address"

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -17,8 +17,6 @@ class UpdateCommand extends Command
     {
         $opts->add('o|old', 'List old phps (less than 5.3)');
 
-        $opts->add('official', 'Unserialize release information from official site (using `unserialize` function).');
-
         DownloadFactory::addOptionsForCommand($opts);
     }
 


### PR DESCRIPTION
The flag doesn't have any effect as of 442e7021450a69cc912a6f95119dc2320ab79cc4 but has been marked as deprecated only in the commit message.