### PR TITLE
Refactored building `./configure` command-line options and environment variables

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -204,51 +204,7 @@ PHPBrew 提供默认的 Variant ，以及一些虚拟 Variants。
 「Default Variant」包含绝大多数公共 Variants；
 「Virtual Variants」可包含多个 Variants，使用一个虚拟 Variant 即可一次性启用多个 Variants。
 
-只需执行`variants`子命令，即可列出它们：
-
-```bash
-$ phpbrew variants
-
-Variants:
-  all, apxs2, bcmath, bz2, calendar, cgi, cli, ctype, curl, dba, debug, dom,
-  dtrace, editline, embed, exif, fileinfo, filter, fpm, ftp, gcov, gd,
-  gettext, gmp, hash, iconv, icu, imap, inifile, inline, intl, ipc, ipv6,
-  json, kerberos, libgcc, mbregex, mbstring, mcrypt, mhash, mysql, opcache,
-  openssl, pcntl, pcre, pdo, pgsql, phar, phpdbg, posix, readline, session,
-  soap, sockets, sqlite, static, tidy, tokenizer, wddx, xml, xml_all, xmlrpc,
-  zip, zlib, zts
-
-
-Virtual variants:
-  dbs:        sqlite, mysql, pgsql, pdo
-
-  mb:         mbstring, mbregex
-
-  neutral:
-
-  small:      bz2, cli, dom, filter, ipc, json, mbregex, mbstring, pcre, phar,
-              posix, readline, xml, curl, openssl
-
-  default:    bcmath, bz2, calendar, cli, ctype, dom, fileinfo, filter, ipc,
-              json, mbregex, mbstring, mhash, mcrypt, pcntl, pcre, pdo, phar,
-              posix, readline, sockets, tokenizer, xml, curl, openssl, zip
-
-  everything: dba, ipv6, dom, calendar, wddx, static, inifile, inline, cli,
-              ftp, filter, gcov, zts, json, hash, exif, mbstring, mbregex,
-              libgcc, pdo, posix, embed, sockets, debug, phpdbg, zip, bcmath,
-              fileinfo, ctype, cgi, soap, pcntl, phar, session, tokenizer,
-              opcache, imap, tidy, kerberos, xmlrpc, fpm, dtrace, pcre, mhash,
-              mcrypt, zlib, curl, readline, editline, gd, intl, icu, openssl,
-              mysql, sqlite, pgsql, xml, xml_all, gettext, iconv, bz2, ipc, gmp
-
-
-Using variants to build PHP:
-
-  phpbrew install php-5.3.10 +default
-  phpbrew install php-5.3.10 +mysql +pdo
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2=/usr/bin/apxs2
-```
+只需执行`variants`子命令，即可列出它们。
 
 在 Variant 前添加`+`前缀，代表启用此 Variant，例如：
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -145,50 +145,7 @@ PHPBrewは`default`バリアントといくつかの「仮想バリアント」(
 `default`バリアントは最もよく使われているバリアントを含んでいます。
 仮想バリアントはいくつものバリアントのセットを定義するもので、ひとつの仮想バリアントを使用するだけで、一度に複数のバリアントを有効化します。
 
-これらのバリアントに何が含まれているかを調べるには、`variants`サブコマンドを実行して一覧を表示します:
-
-```bash
-$ phpbrew variants
-Variants:
-  all, apxs2, bcmath, bz2, calendar, cgi, cli, ctype, curl, dba, debug, dom,
-  dtrace, editline, embed, exif, fileinfo, filter, fpm, ftp, gcov, gd,
-  gettext, gmp, hash, iconv, icu, imap, inifile, inline, intl, ipc, ipv6,
-  json, kerberos, libgcc, mbregex, mbstring, mcrypt, mhash, mysql, opcache,
-  openssl, pcntl, pcre, pdo, pgsql, phar, phpdbg, posix, readline, session,
-  soap, sockets, sqlite, static, tidy, tokenizer, wddx, xml, xml_all, xmlrpc,
-  zip, zlib, zts
-
-
-Virtual variants:
-  dbs:        sqlite, mysql, pgsql, pdo
-
-  mb:         mbstring, mbregex
-
-  neutral:
-
-  small:      bz2, cli, dom, filter, ipc, json, mbregex, mbstring, pcre, phar,
-              posix, readline, xml, curl, openssl
-
-  default:    bcmath, bz2, calendar, cli, ctype, dom, fileinfo, filter, ipc,
-              json, mbregex, mbstring, mhash, mcrypt, pcntl, pcre, pdo, phar,
-              posix, readline, sockets, tokenizer, xml, curl, openssl, zip
-
-  everything: dba, ipv6, dom, calendar, wddx, static, inifile, inline, cli,
-              ftp, filter, gcov, zts, json, hash, exif, mbstring, mbregex,
-              libgcc, pdo, posix, embed, sockets, debug, phpdbg, zip, bcmath,
-              fileinfo, ctype, cgi, soap, pcntl, phar, session, tokenizer,
-              opcache, imap, tidy, kerberos, xmlrpc, fpm, dtrace, pcre, mhash,
-              mcrypt, zlib, curl, readline, editline, gd, intl, icu, openssl,
-              mysql, sqlite, pgsql, xml, xml_all, gettext, iconv, bz2, ipc, gmp
-
-
-Using variants to build PHP:
-
-  phpbrew install php-5.3.10 +default
-  phpbrew install php-5.3.10 +mysql +pdo
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2=/usr/bin/apxs2
-```
+これらのバリアントに何が含まれているかを調べるには、`variants`サブコマンドを実行して一覧を表示します。
 
 バリアントを有効化するには、`+`をバリアント名の前に付けます。
 例えば、

--- a/README.md
+++ b/README.md
@@ -213,58 +213,14 @@ to the default variants, which includes the most commonly used variants,
 to the virtual variants, which defines a variant set, you may use one virtual variant
 to enable multiple variants at one time.
 
-To check out what is included in these variants, simply run `variants`
-subcommand to list these variants:
+To check out what is included in these variants, run `phpbrew variants`
+to list these variants.
 
-```bash
-$ phpbrew variants
-
-Variants:
-  all, apxs2, bcmath, bz2, calendar, cgi, cli, ctype, curl, dba, debug, dom,
-  dtrace, editline, embed, exif, fileinfo, filter, fpm, ftp, gcov, gd,
-  gettext, gmp, hash, iconv, icu, imap, inifile, inline, intl, ipc, ipv6,
-  json, kerberos, libgcc, mbregex, mbstring, mcrypt, mhash, mysql, opcache,
-  openssl, pcntl, pcre, pdo, pgsql, phar, phpdbg, posix, readline, session,
-  soap, sockets, sqlite, static, tidy, tokenizer, wddx, xml, xml_all, xmlrpc,
-  zip, zlib, zts
-
-
-Virtual variants:
-  dbs:        sqlite, mysql, pgsql, pdo
-
-  mb:         mbstring, mbregex
-
-  neutral:
-
-  small:      bz2, cli, dom, filter, ipc, json, mbregex, mbstring, pcre, phar,
-              posix, readline, xml, curl, openssl
-
-  default:    bcmath, bz2, calendar, cli, ctype, dom, fileinfo, filter, ipc,
-              json, mbregex, mbstring, mhash, mcrypt, pcntl, pcre, pdo, phar,
-              posix, readline, sockets, tokenizer, xml, curl, openssl, zip
-
-  everything: dba, ipv6, dom, calendar, wddx, static, inifile, inline, cli,
-              ftp, filter, gcov, zts, json, hash, exif, mbstring, mbregex,
-              libgcc, pdo, posix, embed, sockets, debug, phpdbg, zip, bcmath,
-              fileinfo, ctype, cgi, soap, pcntl, phar, session, tokenizer,
-              opcache, imap, tidy, kerberos, xmlrpc, fpm, dtrace, pcre, mhash,
-              mcrypt, zlib, curl, readline, editline, gd, intl, icu, openssl,
-              mysql, sqlite, pgsql, xml, xml_all, gettext, iconv, bz2, ipc, gmp
-
-
-Using variants to build PHP:
-
-  phpbrew install php-5.3.10 +default
-  phpbrew install php-5.3.10 +mysql +pdo
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2=/usr/bin/apxs2
-```
-
-To enable one variant, simply add a prefix `+` before the variant name, eg
+To enable one variant, add a prefix `+` before the variant name, eg
 
     +mysql
 
-To disable one variant, simply add a prefix `-` before the variant name.
+To disable one variant, add a prefix `-` before the variant name.
 
     -debug
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -167,58 +167,14 @@ to the default variants, which includes the most commonly used variants,
 to the virtual variants, which defines a variant set, you may use one virtual variant
 to enable multiple variants at one time.
 
-To check out what is included in these variants, simply run `variants`
-subcommand to list these variants:
+To check out what is included in these variants, run `phpbrew variants`
+to list these variants.
 
-```bash
-$ phpbrew variants
-
-Variants:
-  all, apxs2, bcmath, bz2, calendar, cgi, cli, ctype, curl, dba, debug, dom,
-  dtrace, editline, embed, exif, fileinfo, filter, fpm, ftp, gcov, gd,
-  gettext, gmp, hash, iconv, icu, imap, inifile, inline, intl, ipc, ipv6,
-  json, kerberos, libgcc, mbregex, mbstring, mcrypt, mhash, mysql, opcache,
-  openssl, pcntl, pcre, pdo, pgsql, phar, phpdbg, posix, readline, session,
-  soap, sockets, sqlite, static, tidy, tokenizer, wddx, xml, xml_all, xmlrpc,
-  zip, zlib, zts
-
-
-Virtual variants:
-  dbs:        sqlite, mysql, pgsql, pdo
-
-  mb:         mbstring, mbregex
-
-  neutral:
-
-  small:      bz2, cli, dom, filter, ipc, json, mbregex, mbstring, pcre, phar,
-              posix, readline, xml, curl, openssl
-
-  default:    bcmath, bz2, calendar, cli, ctype, dom, fileinfo, filter, ipc,
-              json, mbregex, mbstring, mhash, mcrypt, pcntl, pcre, pdo, phar,
-              posix, readline, sockets, tokenizer, xml, curl, openssl, zip
-
-  everything: dba, ipv6, dom, calendar, wddx, static, inifile, inline, cli,
-              ftp, filter, gcov, zts, json, hash, exif, mbstring, mbregex,
-              libgcc, pdo, posix, embed, sockets, debug, phpdbg, zip, bcmath,
-              fileinfo, ctype, cgi, soap, pcntl, phar, session, tokenizer,
-              opcache, imap, tidy, kerberos, xmlrpc, fpm, dtrace, pcre, mhash,
-              mcrypt, zlib, curl, readline, editline, gd, intl, icu, openssl,
-              mysql, sqlite, pgsql, xml, xml_all, gettext, iconv, bz2, ipc, gmp
-
-
-Using variants to build PHP:
-
-  phpbrew install php-5.3.10 +default
-  phpbrew install php-5.3.10 +mysql +pdo
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2
-  phpbrew install php-5.3.10 +mysql +pdo +apxs2=/usr/bin/apxs2
-```
-
-To enable one variant, simply add a prefix `+` before the variant name, eg
+To enable one variant, add a prefix `+` before the variant name, eg
 
     +mysql
 
-To disable one variant, simply add a prefix `-` before the variant name.
+To disable one variant, add a prefix `-` before the variant name.
 
     -debug
 

--- a/src/PhpBrew/ConfigureParameters.php
+++ b/src/PhpBrew/ConfigureParameters.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PhpBrew;
+
+/**
+ * An immutable object representing the parameters used to call `./configure'
+ */
+final class ConfigureParameters
+{
+    /**
+     * Command line options and their values
+     *
+     * @var array<string,string|null>
+     */
+    private $options = array();
+
+    /**
+     * Paths passed to the command via the PKG_CONFIG_PATH environment variable
+     *
+     * @var array<string,null>
+     */
+    private $pkgConfigPaths = array();
+
+    /**
+     * Creates a new object with the given option and the value.
+     *
+     * If the given option is already set with the same value, the same object is returned.
+     *
+     * @param string      $option
+     * @param string|null $value
+     *
+     * @return static
+     */
+    public function withOption($option, $value = null)
+    {
+        if (array_key_exists($option, $this->options) && $this->options[$option] === $value) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->options[$option] = $value;
+
+        return $new;
+    }
+
+    /**
+     * Creates a new object with added value of PKG_CONFIG_PATH.
+     *
+     * If the given path is already added, the same object is returned.
+     *
+     * @param string $path
+     *
+     * @return static
+     */
+    public function withPkgConfigPath($path)
+    {
+        if (array_key_exists($path, $this->pkgConfigPaths)) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->pkgConfigPaths[$path] = null;
+
+        return $new;
+    }
+
+    /**
+     * @return array<string,string|null>
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getPkgConfigPaths()
+    {
+        return array_keys($this->pkgConfigPaths);
+    }
+}

--- a/src/PhpBrew/PrefixFinder/UserProvidedPrefix.php
+++ b/src/PhpBrew/PrefixFinder/UserProvidedPrefix.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PhpBrew\PrefixFinder;
+
+use PhpBrew\PrefixFinder;
+
+/**
+ * The strategy of using the user-provided prefix.
+ */
+final class UserProvidedPrefix implements PrefixFinder
+{
+    /**
+     * @var string|null
+     */
+    private $prefix;
+
+    /**
+     * @param string|null $prefix User-provided prefix
+     */
+    public function __construct($prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findPrefix()
+    {
+        return $this->prefix;
+    }
+}

--- a/src/PhpBrew/Tasks/Apxs2CheckTask.php
+++ b/src/PhpBrew/Tasks/Apxs2CheckTask.php
@@ -3,17 +3,19 @@
 namespace PhpBrew\Tasks;
 
 use Exception;
-use PhpBrew\Build;
+use PhpBrew\ConfigureParameters;
 use PhpBrew\Utils;
 
 class Apxs2CheckTask extends BaseTask
 {
-    public function check(Build $build)
+    public function check(ConfigureParameters $parameters)
     {
-        $apxs = $build->getVariant('apxs2');
+        $options = $parameters->getOptions();
 
-        // trying to find apxs binary in case it wasn't explicitly specified (+apxs variant without path)
-        if ($apxs === true) {
+        if (isset($options['--with-apxs2'])) {
+            $apxs = $options['--with-apxs2'];
+        } else {
+            // trying to find apxs binary in case it wasn't explicitly specified (+apxs variant without path)
             $apxs = Utils::findbin('apxs');
             $this->logger->debug("Found apxs2 binary: $apxs");
         }
@@ -23,7 +25,7 @@ class Apxs2CheckTask extends BaseTask
         }
 
         // use apxs to check module dir permission
-        if ($apxs && $libdir = exec("$apxs -q LIBEXECDIR")) {
+        if ($libdir = exec("$apxs -q LIBEXECDIR")) {
             if (false === is_writable($libdir)) {
                 $this->logger->error(
                     <<<EOF
@@ -38,7 +40,7 @@ EOF
             }
         }
 
-        if ($apxs && $confdir = exec("$apxs -q SYSCONFDIR")) {
+        if ($confdir = exec("$apxs -q SYSCONFDIR")) {
             if (false === is_writable($confdir)) {
                 $this->logger->error(
                     <<<EOF

--- a/src/PhpBrew/Tasks/BeforeConfigureTask.php
+++ b/src/PhpBrew/Tasks/BeforeConfigureTask.php
@@ -3,6 +3,7 @@
 namespace PhpBrew\Tasks;
 
 use PhpBrew\Build;
+use PhpBrew\ConfigureParameters;
 use PhpBrew\Patches\Apache2ModuleNamePatch;
 use PhpBrew\Patches\FreeTypePatch;
 use PhpBrew\PatchKit\Patch;
@@ -12,7 +13,7 @@ use PhpBrew\PatchKit\Patch;
  */
 class BeforeConfigureTask extends BaseTask
 {
-    public function run(Build $build)
+    public function run(Build $build, ConfigureParameters $parameters)
     {
         if (!file_exists($build->getSourceDirectory() . DIRECTORY_SEPARATOR . 'configure')) {
             $this->debug("configure file not found, running './buildconf --force'...");
@@ -41,7 +42,7 @@ class BeforeConfigureTask extends BaseTask
         // let's apply patch for libphp{php version}.so (apxs)
         if ($build->isEnabledVariant('apxs2')) {
             $apxs2Checker = new Apxs2CheckTask($this->logger);
-            $apxs2Checker->check($build, $this->options);
+            $apxs2Checker->check($parameters);
         }
 
         if (!$this->options->{'no-patch'}) {

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -5,6 +5,7 @@ namespace PhpBrew\Tasks;
 use PhpBrew\Build;
 use PhpBrew\CommandBuilder;
 use PhpBrew\Config;
+use PhpBrew\ConfigureParameters;
 use PhpBrew\Exception\SystemCommandException;
 
 /**
@@ -12,50 +13,13 @@ use PhpBrew\Exception\SystemCommandException;
  */
 class ConfigureTask extends BaseTask
 {
-    public function run(Build $build, $variantOptions)
+    public function run(Build $build, ConfigureParameters $parameters)
     {
-        $extra = $build->getExtraOptions();
-        $prefix = $build->getInstallPrefix();
-
-        $args = array();
-
-        if (!$this->options->{'no-config-cache'}) {
-            // $args[] = "-C"; // project wise cache (--config-cache)
-            $args[] = '--cache-file=' . Config::getCacheDir() . DIRECTORY_SEPARATOR . 'config.cache';
-        }
-
-        $args[] = '--prefix=' . $prefix;
-        if ($this->options->{'user-config'}) {
-            $args[] = "--with-config-file-path={$prefix}/etc";
-            $args[] = "--with-config-file-scan-dir={$prefix}/var/db";
-        } else {
-            $args[] = "--with-config-file-path={$prefix}/etc";
-            $args[] = "--with-config-file-scan-dir={$prefix}/var/db";
-        }
-
-        if ($variantOptions) {
-            $args = array_merge($args, $variantOptions);
-        }
-
-        $this->debug('Enabled variants: [' . implode(', ', array_keys($build->getVariants())) . ']');
+        $this->debug('Enabled variants: [' . implode(', ', array_keys($build->getEnabledVariants())) . ']');
         $this->debug('Disabled variants: [' . implode(', ', array_keys($build->getDisabledVariants())) . ']');
 
-        // Options for specific versions
-        // todo: extract to BuildPlan class: PHP53 BuildPlan, PHP54 BuildPlan, PHP55 BuildPlan ?
-        if ($build->compareVersion('5.4') == -1) {
-            // copied from https://github.com/Homebrew/homebrew-php/blob/master/Formula/php53.rb
-            $args[] = '--enable-sqlite-utf8';
-            $args[] = '--enable-zend-multibyte';
-        } elseif ($build->compareVersion('5.6') == -1) {
-            $args[] = '--enable-zend-signals';
-        }
-
-        foreach ($extra as $a) {
-            $args[] = $a;
-        }
-
         $cmd = new CommandBuilder('./configure');
-        $cmd->args($args);
+        $cmd->args($this->renderOptions($parameters));
 
         $buildLogPath = $build->getBuildLogPath();
         if (file_exists($buildLogPath)) {
@@ -82,11 +46,34 @@ class ConfigureTask extends BaseTask
         }
 
         if (!$this->options->dryrun) {
+            $pkgConfigPaths = $parameters->getPkgConfigPaths();
+
+            if (count($pkgConfigPaths) > 0) {
+                putenv('PKG_CONFIG_PATH=' . implode(PATH_SEPARATOR, $pkgConfigPaths));
+            }
+
             $code = $cmd->execute($lastline);
             if ($code !== 0) {
                 throw new SystemCommandException("Configure failed: $lastline", $build, $buildLogPath);
             }
         }
         $build->setState(Build::STATE_CONFIGURE);
+    }
+
+    private function renderOptions(ConfigureParameters $parameters)
+    {
+        $args = array();
+
+        foreach ($parameters->getOptions() as $option => $value) {
+            $arg = $option;
+
+            if ($value !== null) {
+                $arg .= '=' . $value;
+            }
+
+            $args[] = $arg;
+        }
+
+        return $args;
     }
 }

--- a/src/PhpBrew/VariantParser.php
+++ b/src/PhpBrew/VariantParser.php
@@ -9,12 +9,12 @@ class VariantParser
     public static function splitVariantValue($str)
     {
         if (strpos($str, '=') !== false) {
-            list($name, $val) = explode('=', $str);
+            list($name, $val) = explode('=', $str, 2);
 
             return array($name => $val);
         }
 
-        return array($str => true);
+        return array($str => null);
     }
 
     /**

--- a/tests/PhpBrew/BuildTest.php
+++ b/tests/PhpBrew/BuildTest.php
@@ -14,20 +14,10 @@ class BuildTest extends TestCase
     {
         $build = new Build('5.3.1');
 
-        $build->setVersion('5.3.1');
-        $build->enableVariant('debug');
-        $build->enableVariant('icu');
-        $build->enableVariant('sqlite');
-
-        $build->disableVariant('sqlite');
-        $build->disableVariant('mysql');
-        $build->resolveVariants();
-
         $this->assertSame(1, $build->compareVersion('5.3.0'));
         $this->assertSame(1, $build->compareVersion('5.3'));
         $this->assertSame(-1, $build->compareVersion('5.4.0'));
         $this->assertSame(-1, $build->compareVersion('5.4'));
-        $this->assertSame('php-5.3.1-debug-icu-dev', $build->getIdentifier());
     }
 
     public function testNeutralVirtualVariant()
@@ -37,6 +27,6 @@ class BuildTest extends TestCase
         $build->enableVariant('neutral');
         $build->resolveVariants();
 
-        $this->assertTrue($build->hasVariant('neutral'));
+        $this->assertTrue($build->isEnabledVariant('neutral'));
     }
 }

--- a/tests/PhpBrew/ConfigureParametersTest.php
+++ b/tests/PhpBrew/ConfigureParametersTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace PhpBrew\Tests;
+
+use PhpBrew\ConfigureParameters;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigureParametersTest extends TestCase
+{
+    private $configureParameters;
+
+    protected function setUp()
+    {
+        $this->configureParameters = new ConfigureParameters();
+    }
+
+    public function testDefaults()
+    {
+        $this->assertSame(array(), $this->configureParameters->getOptions());
+        $this->assertSame(array(), $this->configureParameters->getPkgConfigPaths());
+    }
+
+    public function testWithOptionAndValue()
+    {
+        $this->assertSame(array(
+            '--with-foo' => 'bar',
+        ), $this->configureParameters
+            ->withOption('--with-foo', 'bar')
+            ->getOptions());
+    }
+
+    public function testWithOptionAndNoValue()
+    {
+        $this->assertSame(array(
+            '--with-foo' => null,
+        ), $this->configureParameters
+            ->withOption('--with-foo')
+            ->getOptions());
+    }
+
+    public function testWithSameOptionAndValue()
+    {
+        $this->assertSame(array(
+            '--with-foo' => 'bar',
+        ), $this->configureParameters
+            ->withOption('--with-foo', 'bar')
+            ->withOption('--with-foo', 'bar')
+            ->getOptions());
+    }
+
+    public function testWithPkgConfigPath()
+    {
+        $this->assertSame(array(
+            '/usr/lib/pkgconfig',
+        ), $this->configureParameters
+            ->withPkgConfigPath('/usr/lib/pkgconfig')
+            ->getPkgConfigPaths());
+    }
+
+    public function testWithSamePkgConfigPath()
+    {
+        $this->assertSame(array(
+            '/usr/lib/pkgconfig',
+        ), $this->configureParameters
+            ->withPkgConfigPath('/usr/lib/pkgconfig')
+            ->withPkgConfigPath('/usr/lib/pkgconfig')
+            ->getPkgConfigPaths());
+    }
+}

--- a/tests/PhpBrew/Patches/Apache2ModuleNamePatchTest.php
+++ b/tests/PhpBrew/Patches/Apache2ModuleNamePatchTest.php
@@ -40,7 +40,7 @@ class Apache2ModuleNamePatchTest extends PatchTestCase
         $build = new Build($version);
         $build->setSourceDirectory($sourceDirectory);
         $build->enableVariant('apxs2');
-        $this->assertTrue($build->hasVariant('apxs2'), 'apxs2 enabled');
+        $this->assertTrue($build->isEnabledVariant('apxs2'));
 
         $patch = new Apache2ModuleNamePatch($version);
         $matched = $patch->match($build, $logger);

--- a/tests/PhpBrew/Patches/IntlWith64bitPatchTest.php
+++ b/tests/PhpBrew/Patches/IntlWith64bitPatchTest.php
@@ -29,7 +29,7 @@ class IntlWith64bitPatchTest extends PatchTestCase
         $build = new Build($fromVersion);
         $build->setSourceDirectory($sourceDirectory);
         $build->enableVariant('intl');
-        $this->assertTrue($build->hasVariant('intl'), 'intl enabled');
+        $this->assertTrue($build->isEnabledVariant('intl'));
 
         $patch = new IntlWith64bitPatch();
         $matched = $patch->match($build, $logger);

--- a/tests/PhpBrew/Patches/OpenSSLDSOPatchTest.php
+++ b/tests/PhpBrew/Patches/OpenSSLDSOPatchTest.php
@@ -22,7 +22,6 @@ class OpenSSLDSOPatchTest extends PatchTestCase
         $logger->setQuiet();
 
         $fromVersion = '5.5.17';
-        $sourceFixtureDirectory = getenv('PHPBREW_FIXTURES_PHP_DIR') . DIRECTORY_SEPARATOR . $fromVersion;
         $sourceDirectory = getenv('PHPBREW_BUILD_PHP_DIR');
 
         $this->setupBuildDirectory($fromVersion);
@@ -30,8 +29,7 @@ class OpenSSLDSOPatchTest extends PatchTestCase
         $build = new Build($fromVersion);
         $build->setSourceDirectory($sourceDirectory);
         $build->enableVariant('openssl');
-        $this->assertTrue($build->hasVariant('openssl'), 'openssl enabled');
-
+        $this->assertTrue($build->isEnabledVariant('openssl'));
 
         $patch = new OpenSSLDSOPatch();
         $matched = $patch->match($build, $logger);

--- a/tests/PhpBrew/VariantParserTest.php
+++ b/tests/PhpBrew/VariantParserTest.php
@@ -12,14 +12,14 @@ class VariantParserTest extends TestCase
     {
         $this->assertEquals(array(
             'enabled_variants' => array(
-                'pdo' => true,
-                'sqlite' => true,
-                'debug' => true,
+                'pdo' => null,
+                'sqlite' => null,
+                'debug' => null,
                 'apxs' => '/opt/local/apache2/bin/apxs',
-                'calendar' => true,
+                'calendar' => null,
             ),
             'disabled_variants' => array(
-                'mysql' => true,
+                'mysql' => null,
             ),
             'extra_options' => array(
                 '--with-icu-dir',
@@ -37,11 +37,11 @@ class VariantParserTest extends TestCase
     {
         $this->assertEquals(array(
             'enabled_variants' => array(
-                'all' => true,
+                'all' => null,
             ),
             'disabled_variants' => array(
-                'apxs2' => true,
-                'mysql' => true,
+                'apxs2' => null,
+                'mysql' => null,
             ),
             'extra_options' => array(),
         ), $this->parse(array(
@@ -66,7 +66,7 @@ class VariantParserTest extends TestCase
             'overrides default variant value' => array(
                 array('+default', '+openssl=/usr'),
                 array(
-                    'default' => true,
+                    'default' => null,
                     'openssl' => '/usr',
                 ),
             ),
@@ -74,25 +74,25 @@ class VariantParserTest extends TestCase
                 array('+openssl=/usr', '+default'),
                 array(
                     'openssl' => '/usr',
-                    'default' => true,
+                    'default' => null,
                 ),
             ),
             'negative variant' => array(
                 array('+default', '-openssl'),
                 array(
-                    'default' => true,
+                    'default' => null,
                 ),
             ),
             'negative variant precedence' => array(
                 array('-openssl', '+default'),
                 array(
-                    'default' => true,
+                    'default' => null,
                 ),
             ),
             'negative variant with an overridden value' => array(
                 array('+default', '-openssl=/usr'),
                 array(
-                    'default' => true,
+                    'default' => null,
                 ),
             ),
         );
@@ -108,8 +108,8 @@ class VariantParserTest extends TestCase
                 'gmp' => '/path/x86_64-linux-gnu'
             ),
             'disabled_variants' => array(
-                'openssl' => true,
-                'xdebug' => true,
+                'openssl' => null,
+                'xdebug' => null,
             ),
             'extra_options' => array(),
         ), $this->parse(array(


### PR DESCRIPTION
In order to be able to build PHP 7.4 using Homebrew-managed dependencies (\#1085), the variant builder should not only be able to build command-line options for the `./configure` command but also generate the `PKG_CONFIG_PATH` environment variable. Currently, it's implemented via storing the `PKG_CONFIG_PATH` components in the build object which then gets passed to the `ConfigureTask`.

This pull request refactors this implementation by introducing the `ConfigureParameters` immutable value object that can be used for building command-line options and environment variables for the `./configure` command without storing anything in the `Build` object state or global state.

All variant closures now take the a value of `ConfigurationParameters` and return a new version augmented with the parameters representing the variant.

In addition to refactoring, the following cleanup and improvements have been done:

1. Changes in the `BuildSettings` class:
   - All properties have been made `private`.
   - The absence of a user-provided value for the variant is stored as `null`, not as `true`. This is more semantically correct, corresponds to the API of the variant builder closures and makes their code more straightforward.
   - The `#hasVariant()` method has been removed since it duplicates `#isEnabledVariant()`.
   - The `#isDisabledVariant()` method has been removed because it's not used anywhere.
   - The `#getVariants()` method has been renamed to `#getEnabledVariants()` for consistency with `#getDisabledVariants()`.
   - The `#getVariant()` method has been removed since it was needed for an edge case that has been reworked to not rely on it.
   - The `#grepExtraOptionsByPattern()` method has been removed. It violates the SRP: the callers should filter using whatever suitable implementation if needed.
   - The `#resolveVariants()` no longer returns a value since it's an implementation detail. The method may be removed later as unnecessary from the API perspective.
2. A new implementation of `PrefixFinder`, the `UserProvidedPrefix` class has been added. It helps avoid the repetitive `if ($prefix === null)` conditions in the variant builder closures.
3. The default `./configure` options like `--with-config-file-path` have been moved from `ConfigureTask` to `InstallCommand` in order for the user-provided options to have higher precedence.
4. The `ENV_*` constants, the `$phpEnvironment` property and the `#getIdentifier()` method of the `Build` class have been removed as unused.
5. Changes in the `VariantBuilder` class:
   - Most of the `public` properties have been made `private`.
   - The `#checkConflicts()` method has been made `private`.
   - The `#checkPkgPrefix()` method has been removed as unused.
6. The deprecated `icu` variant has been removed. The `intl` variant will detect the needed build prefix or, otherwise, it can be passed as an extra `--with-icu-dir` option.
7. The recently added warnings in the `sodium` variant have been removed since they create unnecessary [noise](https://travis-ci.org/phpbrew/phpbrew/jobs/628398350#L457) in the test output. Additionally, the `mcrypt`, `opcache` and `phpdbg` version-specific variants don't emit such warnings. If needed, the version awareness should be introduced on the framework level.
8. The `xml` variant no longer ignores the user-provided value.
9. The `xml_all` has been removed since it duplicates `xml`.
10. The `$prefix` / `$val` arguments of the variant builder closures have been consistently renamed to `$value` since they represent the user-provided value for the variant which is not always a prefix. The argument has been made required since it's part of the API and is always passed by the calling code.
11. The `phpbrew variants` example output is removed from README since it's prone to getting stale and requires additional maintenance.