### PR TITLE
Replaced the GZ PHAR compression algorithm with BZ2

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -1,6 +1,6 @@
 {
     "output": "phpbrew",
-    "compression": "GZ",
+    "compression": "BZ2",
     "compactors": [
         "KevinGH\\Box\\Compactor\\Json",
         "KevinGH\\Box\\Compactor\\Php"


### PR DESCRIPTION
The `bz2` variant is part of the `default` variant and is less likely to be missing in the environment.