### PR TITLE
Fix the patch corrupted after inlining

### DIFF
--- a/tests/PhpBrew/Patches/PHP56WithOpenSSL11PatchTest.php
+++ b/tests/PhpBrew/Patches/PHP56WithOpenSSL11PatchTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PhpBrew\Tests\Patches;
+
+use CLIFramework\Logger;
+use PhpBrew\Build;
+use PhpBrew\Patches\PHP56WithOpenSSL11Patch;
+use PhpBrew\Testing\PatchTestCase;
+
+class PHP56WithOpenSSL11PatchTest extends PatchTestCase
+{
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testPatchVersion($version)
+    {
+        $logger = new Logger();
+        $logger->setQuiet();
+
+        $sourceDirectory = getenv('PHPBREW_BUILD_PHP_DIR');
+
+        $this->setupBuildDirectory($version);
+
+        $build = new Build($version);
+        $build->setSourceDirectory($sourceDirectory);
+        $build->enableVariant('openssl');
+        $this->assertTrue($build->isEnabledVariant('openssl'));
+
+        $patch = new PHP56WithOpenSSL11Patch();
+        $this->assertTrue($patch->match($build, $logger));
+
+        $this->assertGreaterThan(0, $patch->apply($build, $logger));
+
+        $expectedDirectory = getenv('PHPBREW_EXPECTED_PHP_DIR') . '/' . $version . '-php56-openssl11-patch';
+
+        foreach (
+            array(
+            'ext/openssl/openssl.c',
+            'ext/openssl/xp_ssl.c',
+            'ext/phar/util.c',
+                 ) as $path
+        ) {
+            $this->assertFileEquals(
+                $expectedDirectory . '/' .  $path,
+                $sourceDirectory . '/' . $path
+            );
+        }
+    }
+
+    public static function versionProvider()
+    {
+        return array(
+            array('5.6.40'),
+        );
+    }
+}

--- a/tests/expected/php/5.6.40-php56-openssl11-patch/ext/openssl/openssl.c
+++ b/tests/expected/php/5.6.40-php56-openssl11-patch/ext/openssl/openssl.c
@@ -1,0 +1,5842 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 5                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2016 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Stig Venaas <venaas@php.net>                                |
+   |          Wez Furlong <wez@thebrainroom.com>                          |
+   |          Sascha Kettler <kettler@gmx.net>                            |
+   |          Pierre-Alain Joye <pierre@php.net>                          |
+   |          Marc Delling <delling@silpion.de> (PKCS12 functions)        |		
+   +----------------------------------------------------------------------+
+ */
+
+/* $Id$ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_ini.h"
+#include "php_openssl.h"
+
+/* PHP Includes */
+#include "ext/standard/file.h"
+#include "ext/standard/info.h"
+#include "ext/standard/php_fopen_wrappers.h"
+#include "ext/standard/md5.h"
+#include "ext/standard/base64.h"
+#ifdef PHP_WIN32
+# include "win32/winutil.h"
+#endif
+
+/* OpenSSL includes */
+#include <openssl/evp.h>
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
+#include <openssl/dh.h>
+#endif
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/crypto.h>
+#include <openssl/pem.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+#include <openssl/pkcs12.h>
+
+/* Common */
+#include <time.h>
+
+#ifdef NETWARE
+#define timezone _timezone	/* timezone is called _timezone in LibC */
+#endif
+
+#define DEFAULT_KEY_LENGTH	512
+#define MIN_KEY_LENGTH		384
+
+#define OPENSSL_ALGO_SHA1 	1
+#define OPENSSL_ALGO_MD5	2
+#define OPENSSL_ALGO_MD4	3
+#ifdef HAVE_OPENSSL_MD2_H
+#define OPENSSL_ALGO_MD2	4
+#endif
+#define OPENSSL_ALGO_DSS1	5
+#if OPENSSL_VERSION_NUMBER >= 0x0090708fL
+#define OPENSSL_ALGO_SHA224 6
+#define OPENSSL_ALGO_SHA256 7
+#define OPENSSL_ALGO_SHA384 8
+#define OPENSSL_ALGO_SHA512 9
+#define OPENSSL_ALGO_RMD160 10
+#endif
+#define DEBUG_SMIME	0
+
+#if !defined(OPENSSL_NO_EC) && defined(EVP_PKEY_EC)
+#define HAVE_EVP_PKEY_EC 1
+#endif
+
+/* FIXME: Use the openssl constants instead of
+ * enum. It is now impossible to match real values
+ * against php constants. Also sorry to break the
+ * enum principles here, BC...
+ */
+enum php_openssl_key_type {
+	OPENSSL_KEYTYPE_RSA,
+	OPENSSL_KEYTYPE_DSA,
+	OPENSSL_KEYTYPE_DH,
+	OPENSSL_KEYTYPE_DEFAULT = OPENSSL_KEYTYPE_RSA,
+#ifdef HAVE_EVP_PKEY_EC
+	OPENSSL_KEYTYPE_EC = OPENSSL_KEYTYPE_DH +1
+#endif
+};
+
+enum php_openssl_cipher_type {
+	PHP_OPENSSL_CIPHER_RC2_40,
+	PHP_OPENSSL_CIPHER_RC2_128,
+	PHP_OPENSSL_CIPHER_RC2_64,
+	PHP_OPENSSL_CIPHER_DES,
+	PHP_OPENSSL_CIPHER_3DES,
+	PHP_OPENSSL_CIPHER_AES_128_CBC,
+	PHP_OPENSSL_CIPHER_AES_192_CBC,
+	PHP_OPENSSL_CIPHER_AES_256_CBC,
+
+	PHP_OPENSSL_CIPHER_DEFAULT = PHP_OPENSSL_CIPHER_RC2_40
+};
+
+PHP_FUNCTION(openssl_get_md_methods);
+PHP_FUNCTION(openssl_get_cipher_methods);
+
+PHP_FUNCTION(openssl_digest);
+PHP_FUNCTION(openssl_encrypt);
+PHP_FUNCTION(openssl_decrypt);
+PHP_FUNCTION(openssl_cipher_iv_length);
+
+PHP_FUNCTION(openssl_dh_compute_key);
+PHP_FUNCTION(openssl_random_pseudo_bytes);
+
+/* {{{ arginfo */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 0, 2)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_export, 0, 0, 2)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_fingerprint, 0, 0, 1)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, raw_output)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_check_private_key, 0)
+	ZEND_ARG_INFO(0, cert)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_parse, 0)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, shortname)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_checkpurpose, 0, 0, 3)
+	ZEND_ARG_INFO(0, x509cert)
+	ZEND_ARG_INFO(0, purpose)
+	ZEND_ARG_INFO(0, cainfo) /* array */
+	ZEND_ARG_INFO(0, untrustedfile)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_read, 0)
+	ZEND_ARG_INFO(0, cert)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_free, 0)
+	ZEND_ARG_INFO(0, x509)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs12_export_to_file, 0, 0, 4)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, filename)
+	ZEND_ARG_INFO(0, priv_key)
+	ZEND_ARG_INFO(0, pass)
+	ZEND_ARG_INFO(0, args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkcs12_export, 0)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, priv_key)
+	ZEND_ARG_INFO(0, pass)
+	ZEND_ARG_INFO(0, args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkcs12_read, 0)
+	ZEND_ARG_INFO(0, PKCS12)
+	ZEND_ARG_INFO(1, certs) /* array */
+	ZEND_ARG_INFO(0, pass)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_export_to_file, 0, 0, 2)
+	ZEND_ARG_INFO(0, csr)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_export, 0, 0, 2)
+	ZEND_ARG_INFO(0, csr)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_sign, 0, 0, 4)
+	ZEND_ARG_INFO(0, csr)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, priv_key)
+	ZEND_ARG_INFO(0, days)
+	ZEND_ARG_INFO(0, config_args) /* array */
+	ZEND_ARG_INFO(0, serial)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_new, 0, 0, 2)
+	ZEND_ARG_INFO(0, dn) /* array */
+	ZEND_ARG_INFO(1, privkey)
+	ZEND_ARG_INFO(0, configargs)
+	ZEND_ARG_INFO(0, extraattribs)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_csr_get_subject, 0)
+	ZEND_ARG_INFO(0, csr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_csr_get_public_key, 0)
+	ZEND_ARG_INFO(0, csr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_new, 0, 0, 0)
+	ZEND_ARG_INFO(0, configargs) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_export_to_file, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, passphrase)
+	ZEND_ARG_INFO(0, config_args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_export, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, passphrase)
+	ZEND_ARG_INFO(0, config_args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkey_get_public, 0)
+	ZEND_ARG_INFO(0, cert)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkey_free, 0)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_get_private, 0, 0, 1)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, passphrase)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkey_get_details, 0)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pbkdf2, 0, 0, 4)
+	ZEND_ARG_INFO(0, password)
+	ZEND_ARG_INFO(0, salt)
+	ZEND_ARG_INFO(0, key_length)
+	ZEND_ARG_INFO(0, iterations)
+	ZEND_ARG_INFO(0, digest_algorithm)
+ZEND_END_ARG_INFO()
+#endif
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_verify, 0, 0, 2)
+	ZEND_ARG_INFO(0, filename)
+	ZEND_ARG_INFO(0, flags)
+	ZEND_ARG_INFO(0, signerscerts)
+	ZEND_ARG_INFO(0, cainfo) /* array */
+	ZEND_ARG_INFO(0, extracerts)
+	ZEND_ARG_INFO(0, content)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_encrypt, 0, 0, 4)
+	ZEND_ARG_INFO(0, infile)
+	ZEND_ARG_INFO(0, outfile)
+	ZEND_ARG_INFO(0, recipcerts)
+	ZEND_ARG_INFO(0, headers) /* array */
+	ZEND_ARG_INFO(0, flags)
+	ZEND_ARG_INFO(0, cipher)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_sign, 0, 0, 5)
+	ZEND_ARG_INFO(0, infile)
+	ZEND_ARG_INFO(0, outfile)
+	ZEND_ARG_INFO(0, signcert)
+	ZEND_ARG_INFO(0, signkey)
+	ZEND_ARG_INFO(0, headers) /* array */
+	ZEND_ARG_INFO(0, flags)
+	ZEND_ARG_INFO(0, extracertsfilename)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, infilename)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, recipcert)
+	ZEND_ARG_INFO(0, recipkey)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_private_encrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_private_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_public_encrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_public_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_error_string, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_sign, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, signature)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_verify, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, signature)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_seal, 0, 0, 4)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, sealdata)
+	ZEND_ARG_INFO(1, ekeys) /* arary */
+	ZEND_ARG_INFO(0, pubkeys) /* array */
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_open, 0)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, opendata)
+	ZEND_ARG_INFO(0, ekey)
+	ZEND_ARG_INFO(0, privkey)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_get_md_methods, 0, 0, 0)
+	ZEND_ARG_INFO(0, aliases)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_get_cipher_methods, 0, 0, 0)
+	ZEND_ARG_INFO(0, aliases)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_digest, 0, 0, 2)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, raw_output)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_encrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, password)
+	ZEND_ARG_INFO(0, options)
+	ZEND_ARG_INFO(0, iv)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, password)
+	ZEND_ARG_INFO(0, options)
+	ZEND_ARG_INFO(0, iv)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_cipher_iv_length, 0)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_dh_compute_key, 0)
+	ZEND_ARG_INFO(0, pub_key)
+	ZEND_ARG_INFO(0, dh_key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_random_pseudo_bytes, 0, 0, 1)
+	ZEND_ARG_INFO(0, length)
+	ZEND_ARG_INFO(1, result_is_strong)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_spki_new, 0, 0, 2)
+	ZEND_ARG_INFO(0, privkey)
+	ZEND_ARG_INFO(0, challenge)
+	ZEND_ARG_INFO(0, algo)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_spki_verify, 0)
+	ZEND_ARG_INFO(0, spki)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_spki_export, 0)
+	ZEND_ARG_INFO(0, spki)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_spki_export_challenge, 0)
+	ZEND_ARG_INFO(0, spki)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_get_cert_locations, 0)
+ZEND_END_ARG_INFO()
+/* }}} */
+
+/* {{{ openssl_functions[]
+ */
+const zend_function_entry openssl_functions[] = {
+	PHP_FE(openssl_get_cert_locations, arginfo_openssl_get_cert_locations)
+
+/* spki functions */
+	PHP_FE(openssl_spki_new, arginfo_openssl_spki_new)
+	PHP_FE(openssl_spki_verify, arginfo_openssl_spki_verify)
+	PHP_FE(openssl_spki_export, arginfo_openssl_spki_export)
+	PHP_FE(openssl_spki_export_challenge, arginfo_openssl_spki_export_challenge)
+
+/* public/private key functions */
+	PHP_FE(openssl_pkey_free,			arginfo_openssl_pkey_free)
+	PHP_FE(openssl_pkey_new,			arginfo_openssl_pkey_new)
+	PHP_FE(openssl_pkey_export,			arginfo_openssl_pkey_export)
+	PHP_FE(openssl_pkey_export_to_file,	arginfo_openssl_pkey_export_to_file)
+	PHP_FE(openssl_pkey_get_private,	arginfo_openssl_pkey_get_private)
+	PHP_FE(openssl_pkey_get_public,		arginfo_openssl_pkey_get_public)
+	PHP_FE(openssl_pkey_get_details,	arginfo_openssl_pkey_get_details)
+
+	PHP_FALIAS(openssl_free_key,		openssl_pkey_free, 			arginfo_openssl_pkey_free)
+	PHP_FALIAS(openssl_get_privatekey,	openssl_pkey_get_private,	arginfo_openssl_pkey_get_private)
+	PHP_FALIAS(openssl_get_publickey,	openssl_pkey_get_public,	arginfo_openssl_pkey_get_public)
+
+/* x.509 cert funcs */
+	PHP_FE(openssl_x509_read,				arginfo_openssl_x509_read)
+	PHP_FE(openssl_x509_free,          		arginfo_openssl_x509_free)
+	PHP_FE(openssl_x509_parse,			 	arginfo_openssl_x509_parse)
+	PHP_FE(openssl_x509_checkpurpose,		arginfo_openssl_x509_checkpurpose)
+	PHP_FE(openssl_x509_check_private_key,	arginfo_openssl_x509_check_private_key)
+	PHP_FE(openssl_x509_export,				arginfo_openssl_x509_export)
+	PHP_FE(openssl_x509_fingerprint,			arginfo_openssl_x509_fingerprint)
+	PHP_FE(openssl_x509_export_to_file,		arginfo_openssl_x509_export_to_file)
+
+/* PKCS12 funcs */
+	PHP_FE(openssl_pkcs12_export,			arginfo_openssl_pkcs12_export)
+	PHP_FE(openssl_pkcs12_export_to_file,	arginfo_openssl_pkcs12_export_to_file)
+	PHP_FE(openssl_pkcs12_read,				arginfo_openssl_pkcs12_read)
+
+/* CSR funcs */
+	PHP_FE(openssl_csr_new,				arginfo_openssl_csr_new)
+	PHP_FE(openssl_csr_export,			arginfo_openssl_csr_export)
+	PHP_FE(openssl_csr_export_to_file,	arginfo_openssl_csr_export_to_file)
+	PHP_FE(openssl_csr_sign,			arginfo_openssl_csr_sign)
+	PHP_FE(openssl_csr_get_subject,		arginfo_openssl_csr_get_subject)
+	PHP_FE(openssl_csr_get_public_key,	arginfo_openssl_csr_get_public_key)
+
+	PHP_FE(openssl_digest,				arginfo_openssl_digest)
+	PHP_FE(openssl_encrypt,				arginfo_openssl_encrypt)
+	PHP_FE(openssl_decrypt,				arginfo_openssl_decrypt)
+	PHP_FE(openssl_cipher_iv_length,	arginfo_openssl_cipher_iv_length)
+	PHP_FE(openssl_sign,				arginfo_openssl_sign)
+	PHP_FE(openssl_verify,				arginfo_openssl_verify)
+	PHP_FE(openssl_seal,				arginfo_openssl_seal)
+	PHP_FE(openssl_open,				arginfo_openssl_open)
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	PHP_FE(openssl_pbkdf2,	arginfo_openssl_pbkdf2)
+#endif
+
+/* for S/MIME handling */
+	PHP_FE(openssl_pkcs7_verify,		arginfo_openssl_pkcs7_verify)
+	PHP_FE(openssl_pkcs7_decrypt,		arginfo_openssl_pkcs7_decrypt)
+	PHP_FE(openssl_pkcs7_sign,			arginfo_openssl_pkcs7_sign)
+	PHP_FE(openssl_pkcs7_encrypt,		arginfo_openssl_pkcs7_encrypt)
+
+	PHP_FE(openssl_private_encrypt,		arginfo_openssl_private_encrypt)
+	PHP_FE(openssl_private_decrypt,		arginfo_openssl_private_decrypt)
+	PHP_FE(openssl_public_encrypt,		arginfo_openssl_public_encrypt)
+	PHP_FE(openssl_public_decrypt,		arginfo_openssl_public_decrypt)
+
+	PHP_FE(openssl_get_md_methods,		arginfo_openssl_get_md_methods)
+	PHP_FE(openssl_get_cipher_methods,	arginfo_openssl_get_cipher_methods)
+
+	PHP_FE(openssl_dh_compute_key,      arginfo_openssl_dh_compute_key)
+
+	PHP_FE(openssl_random_pseudo_bytes,    arginfo_openssl_random_pseudo_bytes)
+	PHP_FE(openssl_error_string, arginfo_openssl_error_string)
+	PHP_FE_END
+};
+/* }}} */
+
+/* {{{ openssl_module_entry
+ */
+zend_module_entry openssl_module_entry = {
+	STANDARD_MODULE_HEADER,
+	"openssl",
+	openssl_functions,
+	PHP_MINIT(openssl),
+	PHP_MSHUTDOWN(openssl),
+	NULL,
+	NULL,
+	PHP_MINFO(openssl),
+	NO_VERSION_YET,
+	STANDARD_MODULE_PROPERTIES
+};
+/* }}} */
+
+#ifdef COMPILE_DL_OPENSSL
+ZEND_GET_MODULE(openssl)
+#endif
+
+/* {{{ OpenSSL compatibility functions and macros */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
+#define EVP_PKEY_get0_RSA(_pkey) _pkey->pkey.rsa
+#define EVP_PKEY_get0_DH(_pkey) _pkey->pkey.dh
+#define EVP_PKEY_get0_DSA(_pkey) _pkey->pkey.dsa
+#define EVP_PKEY_get0_EC_KEY(_pkey) _pkey->pkey.ec
+
+static int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
+{
+	r->n = n;
+	r->e = e;
+	r->d = d;
+
+	return 1;
+}
+
+static int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q)
+{
+	r->p = p;
+	r->q = q;
+
+	return 1;
+}
+
+static int RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp)
+{
+	r->dmp1 = dmp1;
+	r->dmq1 = dmq1;
+	r->iqmp = iqmp;
+
+	return 1;
+}
+
+static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+{
+	*n = r->n;
+	*e = r->e;
+	*d = r->d;
+}
+
+static void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
+{
+	*p = r->p;
+	*q = r->q;
+}
+
+static void RSA_get0_crt_params(const RSA *r, const BIGNUM **dmp1, const BIGNUM **dmq1, const BIGNUM **iqmp)
+{
+	*dmp1 = r->dmp1;
+	*dmq1 = r->dmq1;
+	*iqmp = r->iqmp;
+}
+
+static void DH_get0_pqg(const DH *dh, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
+{
+	*p = dh->p;
+	*q = dh->q;
+	*g = dh->g;
+}
+
+static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+	dh->p = p;
+	dh->q = q;
+	dh->g = g;
+
+	return 1;
+}
+
+static void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key)
+{
+	*pub_key = dh->pub_key;
+	*priv_key = dh->priv_key;
+}
+
+static int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
+{
+	dh->pub_key = pub_key;
+	dh->priv_key = priv_key;
+
+	return 1;
+}
+
+static void DSA_get0_pqg(const DSA *d, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
+{
+	*p = d->p;
+	*q = d->q;
+	*g = d->g;
+}
+
+int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+	d->p = p;
+	d->q = q;
+	d->g = g;
+
+	return 1;
+}
+
+static void DSA_get0_key(const DSA *d, const BIGNUM **pub_key, const BIGNUM **priv_key)
+{
+	*pub_key = d->pub_key;
+	*priv_key = d->priv_key;
+}
+
+int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key)
+{
+	d->pub_key = pub_key;
+	d->priv_key = priv_key;
+
+	return 1;
+}
+
+#if OPENSSL_VERSION_NUMBER < 0x10002000L || defined (LIBRESSL_VERSION_NUMBER)
+#define EVP_PKEY_id(_pkey) _pkey->type
+#define EVP_PKEY_base_id(_key) EVP_PKEY_type(_key->type)
+
+static int X509_get_signature_nid(const X509 *x)
+{
+	return OBJ_obj2nid(x->sig_alg->algorithm);
+}
+
+#endif
+
+#endif
+/* }}} */
+
+static int le_key;
+static int le_x509;
+static int le_csr;
+static int ssl_stream_data_index;
+
+int php_openssl_get_x509_list_id(void) /* {{{ */
+{
+	return le_x509;
+}
+/* }}} */
+
+/* {{{ resource destructors */
+static void php_pkey_free(zend_rsrc_list_entry *rsrc TSRMLS_DC)
+{
+	EVP_PKEY *pkey = (EVP_PKEY *)rsrc->ptr;
+
+	assert(pkey != NULL);
+
+	EVP_PKEY_free(pkey);
+}
+
+static void php_x509_free(zend_rsrc_list_entry *rsrc TSRMLS_DC)
+{
+	X509 *x509 = (X509 *)rsrc->ptr;
+	X509_free(x509);
+}
+
+static void php_csr_free(zend_rsrc_list_entry *rsrc TSRMLS_DC)
+{
+	X509_REQ * csr = (X509_REQ*)rsrc->ptr;
+	X509_REQ_free(csr);
+}
+/* }}} */
+
+/* {{{ openssl open_basedir check */
+inline static int php_openssl_open_base_dir_chk(char *filename TSRMLS_DC)
+{
+	if (php_check_open_basedir(filename TSRMLS_CC)) {
+		return -1;
+	}
+	
+	return 0;
+}
+/* }}} */
+
+php_stream* php_openssl_get_stream_from_ssl_handle(const SSL *ssl)
+{
+	return (php_stream*)SSL_get_ex_data(ssl, ssl_stream_data_index);
+}
+
+int php_openssl_get_ssl_stream_data_index()
+{
+	return ssl_stream_data_index;
+}
+
+/* openssl -> PHP "bridging" */
+/* true global; readonly after module startup */
+static char default_ssl_conf_filename[MAXPATHLEN];
+
+struct php_x509_request { /* {{{ */
+#if OPENSSL_VERSION_NUMBER >= 0x10000002L
+	LHASH_OF(CONF_VALUE) * global_config;	/* Global SSL config */
+	LHASH_OF(CONF_VALUE) * req_config;		/* SSL config for this request */
+#else
+	LHASH * global_config;  /* Global SSL config */
+	LHASH * req_config;             /* SSL config for this request */
+#endif
+	const EVP_MD * md_alg;
+	const EVP_MD * digest;
+	char	* section_name,
+			* config_filename,
+			* digest_name,
+			* extensions_section,
+			* request_extensions_section;
+	int priv_key_bits;
+	int priv_key_type;
+
+	int priv_key_encrypt;
+
+	EVP_PKEY * priv_key;
+
+    const EVP_CIPHER * priv_key_encrypt_cipher;
+};
+/* }}} */
+
+static X509 * php_openssl_x509_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC);
+static EVP_PKEY * php_openssl_evp_from_zval(zval ** val, int public_key, char * passphrase, int makeresource, long * resourceval TSRMLS_DC);
+static int php_openssl_is_private_key(EVP_PKEY* pkey TSRMLS_DC);
+static X509_STORE * setup_verify(zval * calist TSRMLS_DC);
+static STACK_OF(X509) * load_all_certs_from_file(char *certfile);
+static X509_REQ * php_openssl_csr_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC);
+static EVP_PKEY * php_openssl_generate_private_key(struct php_x509_request * req TSRMLS_DC);
+
+static void add_assoc_name_entry(zval * val, char * key, X509_NAME * name, int shortname TSRMLS_DC) /* {{{ */
+{
+	zval **data;
+	zval *subitem, *subentries;
+	int i;
+	char *sname;
+	int nid;
+	X509_NAME_ENTRY * ne;
+	ASN1_STRING * str = NULL;
+	ASN1_OBJECT * obj;
+
+	if (key != NULL) {
+		MAKE_STD_ZVAL(subitem);
+		array_init(subitem);
+	} else {
+		subitem = val;
+	}
+	
+	for (i = 0; i < X509_NAME_entry_count(name); i++) {
+		unsigned char *to_add;
+		int to_add_len = 0;
+
+
+		ne  = X509_NAME_get_entry(name, i);
+		obj = X509_NAME_ENTRY_get_object(ne);
+		nid = OBJ_obj2nid(obj);
+
+		if (shortname) {
+			sname = (char *) OBJ_nid2sn(nid);
+		} else {
+			sname = (char *) OBJ_nid2ln(nid);
+		}
+
+		str = X509_NAME_ENTRY_get_data(ne);
+		if (ASN1_STRING_type(str) != V_ASN1_UTF8STRING) {
+			to_add_len = ASN1_STRING_to_UTF8(&to_add, str);
+		} else {
+			to_add = ASN1_STRING_data(str);
+			to_add_len = ASN1_STRING_length(str);
+		}
+
+		if (to_add_len != -1) {
+			if (zend_hash_find(Z_ARRVAL_P(subitem), sname, strlen(sname)+1, (void**)&data) == SUCCESS) {
+				if (Z_TYPE_PP(data) == IS_ARRAY) {
+					subentries = *data;
+					add_next_index_stringl(subentries, (char *)to_add, to_add_len, 1);
+				} else if (Z_TYPE_PP(data) == IS_STRING) {
+					MAKE_STD_ZVAL(subentries);
+					array_init(subentries);
+					add_next_index_stringl(subentries, Z_STRVAL_PP(data), Z_STRLEN_PP(data), 1);
+					add_next_index_stringl(subentries, (char *)to_add, to_add_len, 1);
+					zend_hash_update(Z_ARRVAL_P(subitem), sname, strlen(sname)+1, &subentries, sizeof(zval*), NULL);
+				}
+			} else {
+				add_assoc_stringl(subitem, sname, (char *)to_add, to_add_len, 1);
+			}
+		}
+	}
+	if (key != NULL) {
+		zend_hash_update(HASH_OF(val), key, strlen(key) + 1, (void *)&subitem, sizeof(subitem), NULL);
+	}
+}
+/* }}} */
+
+static void add_assoc_asn1_string(zval * val, char * key, ASN1_STRING * str) /* {{{ */
+{
+	add_assoc_stringl(val, key, (char *)str->data, str->length, 1);
+}
+/* }}} */
+
+static time_t asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC) /* {{{ */
+{
+/*
+	This is how the time string is formatted:
+
+   snprintf(p, sizeof(p), "%02d%02d%02d%02d%02d%02dZ",ts->tm_year%100,
+      ts->tm_mon+1,ts->tm_mday,ts->tm_hour,ts->tm_min,ts->tm_sec);
+*/
+
+	time_t ret;
+	struct tm thetime;
+	char * strbuf;
+	char * thestr;
+	long gmadjust = 0;
+
+	if (ASN1_STRING_type(timestr) != V_ASN1_UTCTIME && ASN1_STRING_type(timestr) != V_ASN1_GENERALIZEDTIME) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "illegal ASN1 data type for timestamp");
+		return (time_t)-1;
+	}
+
+	if (ASN1_STRING_length(timestr) != strlen((const char*)ASN1_STRING_data(timestr))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "illegal length in timestamp");
+		return (time_t)-1;
+	}
+
+	if (ASN1_STRING_length(timestr) < 13) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to parse time string %s correctly", timestr->data);
+		return (time_t)-1;
+	}
+
+	if (ASN1_STRING_type(timestr) == V_ASN1_GENERALIZEDTIME && ASN1_STRING_length(timestr) < 15) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to parse time string %s correctly", timestr->data);
+		return (time_t)-1;
+	}
+
+	strbuf = estrdup((char *)ASN1_STRING_data(timestr));
+
+	memset(&thetime, 0, sizeof(thetime));
+
+	/* we work backwards so that we can use atoi more easily */
+
+	thestr = strbuf + ASN1_STRING_length(timestr) - 3;
+
+	thetime.tm_sec = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_min = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_hour = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_mday = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_mon = atoi(thestr)-1;
+
+	*thestr = '\0';
+	if( ASN1_STRING_type(timestr) == V_ASN1_UTCTIME ) {
+		thestr -= 2;
+		thetime.tm_year = atoi(thestr);
+
+		if (thetime.tm_year < 68) {
+			thetime.tm_year += 100;
+		}
+	} else if( ASN1_STRING_type(timestr) == V_ASN1_GENERALIZEDTIME ) {
+		thestr -= 4;
+		thetime.tm_year = atoi(thestr) - 1900;
+	}
+
+
+	thetime.tm_isdst = -1;
+	ret = mktime(&thetime);
+
+#if HAVE_TM_GMTOFF
+	gmadjust = thetime.tm_gmtoff;
+#else
+	/*
+	** If correcting for daylight savings time, we set the adjustment to
+	** the value of timezone - 3600 seconds. Otherwise, we need to overcorrect and
+	** set the adjustment to the main timezone + 3600 seconds.
+	*/
+	gmadjust = -(thetime.tm_isdst ? (long)timezone - 3600 : (long)timezone + 3600);
+#endif
+	ret += gmadjust;
+
+	efree(strbuf);
+
+	return ret;
+}
+/* }}} */
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000002L
+static inline int php_openssl_config_check_syntax(const char * section_label, const char * config_filename, const char * section, LHASH_OF(CONF_VALUE) * config TSRMLS_DC) /* {{{ */
+#else
+static inline int php_openssl_config_check_syntax(const char * section_label, const char * config_filename, const char * section, LHASH * config TSRMLS_DC)
+#endif
+{
+	X509V3_CTX ctx;
+	
+	X509V3_set_ctx_test(&ctx);
+	X509V3_set_conf_lhash(&ctx, config);
+	if (!X509V3_EXT_add_conf(config, &ctx, (char *)section, NULL)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error loading %s section %s of %s",
+				section_label,
+				section,
+				config_filename);
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+static int add_oid_section(struct php_x509_request * req TSRMLS_DC) /* {{{ */
+{
+	char * str;
+	STACK_OF(CONF_VALUE) * sktmp;
+	CONF_VALUE * cnf;
+	int i;
+
+	str = CONF_get_string(req->req_config, NULL, "oid_section");
+	if (str == NULL) {
+		return SUCCESS;
+	}
+	sktmp = CONF_get_section(req->req_config, str);
+	if (sktmp == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "problem loading oid section %s", str);
+		return FAILURE;
+	}
+	for (i = 0; i < sk_CONF_VALUE_num(sktmp); i++) {
+		cnf = sk_CONF_VALUE_value(sktmp, i);
+		if (OBJ_sn2nid(cnf->name) == NID_undef && OBJ_ln2nid(cnf->name) == NID_undef && OBJ_create(cnf->value, cnf->name, cnf->name) == NID_undef) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "problem creating object %s=%s", cnf->name, cnf->value);
+			return FAILURE;
+		}
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+#define PHP_SSL_REQ_INIT(req)		memset(req, 0, sizeof(*req))
+#define PHP_SSL_REQ_DISPOSE(req)	php_openssl_dispose_config(req TSRMLS_CC)
+#define PHP_SSL_REQ_PARSE(req, zval)	php_openssl_parse_config(req, zval TSRMLS_CC)
+
+#define PHP_SSL_CONFIG_SYNTAX_CHECK(var) if (req->var && php_openssl_config_check_syntax(#var, \
+			req->config_filename, req->var, req->req_config TSRMLS_CC) == FAILURE) return FAILURE
+
+#define SET_OPTIONAL_STRING_ARG(key, varname, defval)	\
+	if (optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), key, sizeof(key), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_STRING) \
+		varname = Z_STRVAL_PP(item); \
+	else \
+		varname = defval
+
+#define SET_OPTIONAL_LONG_ARG(key, varname, defval)	\
+	if (optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), key, sizeof(key), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_LONG) \
+		varname = Z_LVAL_PP(item); \
+	else \
+		varname = defval
+
+static const EVP_CIPHER * php_openssl_get_evp_cipher_from_algo(long algo);
+
+int openssl_spki_cleanup(const char *src, char *dest);
+
+static int php_openssl_parse_config(struct php_x509_request * req, zval * optional_args TSRMLS_DC) /* {{{ */
+{
+	char * str;
+	zval ** item;
+
+	SET_OPTIONAL_STRING_ARG("config", req->config_filename, default_ssl_conf_filename);
+	SET_OPTIONAL_STRING_ARG("config_section_name", req->section_name, "req");
+	req->global_config = CONF_load(NULL, default_ssl_conf_filename, NULL);
+	req->req_config = CONF_load(NULL, req->config_filename, NULL);
+
+	if (req->req_config == NULL) {
+		return FAILURE;
+	}
+
+	/* read in the oids */
+	str = CONF_get_string(req->req_config, NULL, "oid_file");
+	if (str && !php_openssl_open_base_dir_chk(str TSRMLS_CC)) {
+		BIO *oid_bio = BIO_new_file(str, "r");
+		if (oid_bio) {
+			OBJ_create_objects(oid_bio);
+			BIO_free(oid_bio);
+		}
+	}
+	if (add_oid_section(req TSRMLS_CC) == FAILURE) {
+		return FAILURE;
+	}
+	SET_OPTIONAL_STRING_ARG("digest_alg", req->digest_name,
+		CONF_get_string(req->req_config, req->section_name, "default_md"));
+	SET_OPTIONAL_STRING_ARG("x509_extensions", req->extensions_section,
+		CONF_get_string(req->req_config, req->section_name, "x509_extensions"));
+	SET_OPTIONAL_STRING_ARG("req_extensions", req->request_extensions_section,
+		CONF_get_string(req->req_config, req->section_name, "req_extensions"));
+	SET_OPTIONAL_LONG_ARG("private_key_bits", req->priv_key_bits,
+		CONF_get_number(req->req_config, req->section_name, "default_bits"));
+
+	SET_OPTIONAL_LONG_ARG("private_key_type", req->priv_key_type, OPENSSL_KEYTYPE_DEFAULT);
+
+	if (optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), "encrypt_key", sizeof("encrypt_key"), (void**)&item) == SUCCESS) {
+		req->priv_key_encrypt = Z_BVAL_PP(item);
+	} else {
+		str = CONF_get_string(req->req_config, req->section_name, "encrypt_rsa_key");
+		if (str == NULL) {
+			str = CONF_get_string(req->req_config, req->section_name, "encrypt_key");
+		}
+		if (str && strcmp(str, "no") == 0) {
+			req->priv_key_encrypt = 0;
+		} else {
+			req->priv_key_encrypt = 1;
+		}
+	}
+
+	if (req->priv_key_encrypt && optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), "encrypt_key_cipher", sizeof("encrypt_key_cipher"), (void**)&item) == SUCCESS 
+		&& Z_TYPE_PP(item) == IS_LONG) {
+		long cipher_algo = Z_LVAL_PP(item);
+		const EVP_CIPHER* cipher = php_openssl_get_evp_cipher_from_algo(cipher_algo);
+		if (cipher == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm for private key.");
+			return FAILURE;
+		} else  {
+			req->priv_key_encrypt_cipher = cipher;
+		}
+	} else {
+		req->priv_key_encrypt_cipher = NULL;
+	}
+
+
+	
+	/* digest alg */
+	if (req->digest_name == NULL) {
+		req->digest_name = CONF_get_string(req->req_config, req->section_name, "default_md");
+	}
+	if (req->digest_name) {
+		req->digest = req->md_alg = EVP_get_digestbyname(req->digest_name);
+	}
+	if (req->md_alg == NULL) {
+		req->md_alg = req->digest = EVP_sha1();
+	}
+
+	PHP_SSL_CONFIG_SYNTAX_CHECK(extensions_section);
+
+	/* set the string mask */
+	str = CONF_get_string(req->req_config, req->section_name, "string_mask");
+	if (str && !ASN1_STRING_set_default_mask_asc(str)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid global string mask setting %s", str);
+		return FAILURE;
+	}
+
+	PHP_SSL_CONFIG_SYNTAX_CHECK(request_extensions_section);
+	
+	return SUCCESS;
+}
+/* }}} */
+
+static void php_openssl_dispose_config(struct php_x509_request * req TSRMLS_DC) /* {{{ */
+{
+	if (req->priv_key) {
+		EVP_PKEY_free(req->priv_key);
+		req->priv_key = NULL;
+	}
+	if (req->global_config) {
+		CONF_free(req->global_config);
+		req->global_config = NULL;
+	}
+	if (req->req_config) {
+		CONF_free(req->req_config);
+		req->req_config = NULL;
+	}
+}
+/* }}} */
+
+#if defined(PHP_WIN32) || (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER))
+#define PHP_OPENSSL_RAND_ADD_TIME() ((void) 0)
+#else
+#define PHP_OPENSSL_RAND_ADD_TIME() php_openssl_rand_add_timeval()
+
+static inline void php_openssl_rand_add_timeval()  /* {{{ */
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	RAND_add(&tv, sizeof(tv), 0.0);
+}
+/* }}} */
+
+#endif
+
+static int php_openssl_load_rand_file(const char * file, int *egdsocket, int *seeded TSRMLS_DC) /* {{{ */
+{
+	char buffer[MAXPATHLEN];
+
+	*egdsocket = 0;
+	*seeded = 0;
+
+	if (file == NULL) {
+		file = RAND_file_name(buffer, sizeof(buffer));
+#ifdef HAVE_RAND_EGD
+	} else if (RAND_egd(file) > 0) {
+		/* if the given filename is an EGD socket, don't
+		 * write anything back to it */
+		*egdsocket = 1;
+		return SUCCESS;
+#endif
+	}
+	if (file == NULL || !RAND_load_file(file, -1)) {
+		if (RAND_status() == 0) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to load random state; not enough random data!");
+			return FAILURE;
+		}
+		return FAILURE;
+	}
+	*seeded = 1;
+	return SUCCESS;
+}
+/* }}} */
+
+static int php_openssl_write_rand_file(const char * file, int egdsocket, int seeded) /* {{{ */
+{
+	char buffer[MAXPATHLEN];
+
+	TSRMLS_FETCH();
+
+	if (egdsocket || !seeded) {
+		/* if we did not manage to read the seed file, we should not write
+		 * a low-entropy seed file back */
+		return FAILURE;
+	}
+	if (file == NULL) {
+		file = RAND_file_name(buffer, sizeof(buffer));
+	}
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (file == NULL || !RAND_write_file(file)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to write random state");
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+static EVP_MD * php_openssl_get_evp_md_from_algo(long algo) { /* {{{ */
+	EVP_MD *mdtype;
+
+	switch (algo) {
+		case OPENSSL_ALGO_SHA1:
+			mdtype = (EVP_MD *) EVP_sha1();
+			break;
+		case OPENSSL_ALGO_MD5:
+			mdtype = (EVP_MD *) EVP_md5();
+			break;
+		case OPENSSL_ALGO_MD4:
+			mdtype = (EVP_MD *) EVP_md4();
+			break;
+#ifdef HAVE_OPENSSL_MD2_H
+		case OPENSSL_ALGO_MD2:
+			mdtype = (EVP_MD *) EVP_md2();
+			break;
+#endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
+		case OPENSSL_ALGO_DSS1:
+			mdtype = (EVP_MD *) EVP_dss1();
+			break;
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x0090708fL
+		case OPENSSL_ALGO_SHA224:
+			mdtype = (EVP_MD *) EVP_sha224();
+			break;
+		case OPENSSL_ALGO_SHA256:
+			mdtype = (EVP_MD *) EVP_sha256();
+			break;
+		case OPENSSL_ALGO_SHA384:
+			mdtype = (EVP_MD *) EVP_sha384();
+			break;
+		case OPENSSL_ALGO_SHA512:
+			mdtype = (EVP_MD *) EVP_sha512();
+			break;
+		case OPENSSL_ALGO_RMD160:
+			mdtype = (EVP_MD *) EVP_ripemd160();
+			break;
+#endif
+		default:
+			return NULL;
+			break;
+	}
+	return mdtype;
+}
+/* }}} */
+
+static const EVP_CIPHER * php_openssl_get_evp_cipher_from_algo(long algo) { /* {{{ */
+	switch (algo) {
+#ifndef OPENSSL_NO_RC2
+		case PHP_OPENSSL_CIPHER_RC2_40:
+			return EVP_rc2_40_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_RC2_64:
+			return EVP_rc2_64_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_RC2_128:
+			return EVP_rc2_cbc();
+			break;
+#endif
+
+#ifndef OPENSSL_NO_DES
+		case PHP_OPENSSL_CIPHER_DES:
+			return EVP_des_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_3DES:
+			return EVP_des_ede3_cbc();
+			break;
+#endif
+
+#ifndef OPENSSL_NO_AES
+		case PHP_OPENSSL_CIPHER_AES_128_CBC:
+			return EVP_aes_128_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_AES_192_CBC:
+			return EVP_aes_192_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_AES_256_CBC:
+			return EVP_aes_256_cbc();
+			break;
+#endif
+
+
+		default:
+			return NULL;
+			break;
+	}
+}
+/* }}} */
+
+/* {{{ INI Settings */
+PHP_INI_BEGIN()
+	PHP_INI_ENTRY("openssl.cafile", NULL, PHP_INI_PERDIR, NULL)
+	PHP_INI_ENTRY("openssl.capath", NULL, PHP_INI_PERDIR, NULL)
+PHP_INI_END()
+/* }}} */
+ 
+/* {{{ PHP_MINIT_FUNCTION
+ */
+PHP_MINIT_FUNCTION(openssl)
+{
+	char * config_filename;
+
+	le_key = zend_register_list_destructors_ex(php_pkey_free, NULL, "OpenSSL key", module_number);
+	le_x509 = zend_register_list_destructors_ex(php_x509_free, NULL, "OpenSSL X.509", module_number);
+	le_csr = zend_register_list_destructors_ex(php_csr_free, NULL, "OpenSSL X.509 CSR", module_number);
+
+	SSL_library_init();
+	OpenSSL_add_all_ciphers();
+	OpenSSL_add_all_digests();
+	OpenSSL_add_all_algorithms();
+
+#if !defined(OPENSSL_NO_AES) && defined(EVP_CIPH_CCM_MODE) && OPENSSL_VERSION_NUMBER < 0x100020000
+	EVP_add_cipher(EVP_aes_128_ccm());
+	EVP_add_cipher(EVP_aes_192_ccm());
+	EVP_add_cipher(EVP_aes_256_ccm());
+#endif
+
+	SSL_load_error_strings();
+
+	/* register a resource id number with OpenSSL so that we can map SSL -> stream structures in
+	 * OpenSSL callbacks */
+	ssl_stream_data_index = SSL_get_ex_new_index(0, "PHP stream index", NULL, NULL, NULL);
+	
+	REGISTER_STRING_CONSTANT("OPENSSL_VERSION_TEXT", OPENSSL_VERSION_TEXT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_VERSION_NUMBER", OPENSSL_VERSION_NUMBER, CONST_CS|CONST_PERSISTENT);
+	
+	/* purposes for cert purpose checking */
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SSL_CLIENT", X509_PURPOSE_SSL_CLIENT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SSL_SERVER", X509_PURPOSE_SSL_SERVER, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_NS_SSL_SERVER", X509_PURPOSE_NS_SSL_SERVER, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SMIME_SIGN", X509_PURPOSE_SMIME_SIGN, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SMIME_ENCRYPT", X509_PURPOSE_SMIME_ENCRYPT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_CRL_SIGN", X509_PURPOSE_CRL_SIGN, CONST_CS|CONST_PERSISTENT);
+#ifdef X509_PURPOSE_ANY
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_ANY", X509_PURPOSE_ANY, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	/* signature algorithm constants */
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA1", OPENSSL_ALGO_SHA1, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_MD5", OPENSSL_ALGO_MD5, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_MD4", OPENSSL_ALGO_MD4, CONST_CS|CONST_PERSISTENT);
+#ifdef HAVE_OPENSSL_MD2_H
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_MD2", OPENSSL_ALGO_MD2, CONST_CS|CONST_PERSISTENT);
+#endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_DSS1", OPENSSL_ALGO_DSS1, CONST_CS|CONST_PERSISTENT);
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x0090708fL
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA224", OPENSSL_ALGO_SHA224, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA256", OPENSSL_ALGO_SHA256, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA384", OPENSSL_ALGO_SHA384, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA512", OPENSSL_ALGO_SHA512, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_RMD160", OPENSSL_ALGO_RMD160, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	/* flags for S/MIME */
+	REGISTER_LONG_CONSTANT("PKCS7_DETACHED", PKCS7_DETACHED, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_TEXT", PKCS7_TEXT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOINTERN", PKCS7_NOINTERN, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOVERIFY", PKCS7_NOVERIFY, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOCHAIN", PKCS7_NOCHAIN, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOCERTS", PKCS7_NOCERTS, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOATTR", PKCS7_NOATTR, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_BINARY", PKCS7_BINARY, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOSIGS", PKCS7_NOSIGS, CONST_CS|CONST_PERSISTENT);
+
+	REGISTER_LONG_CONSTANT("OPENSSL_PKCS1_PADDING", RSA_PKCS1_PADDING, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_SSLV23_PADDING", RSA_SSLV23_PADDING, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_NO_PADDING", RSA_NO_PADDING, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_PKCS1_OAEP_PADDING", RSA_PKCS1_OAEP_PADDING, CONST_CS|CONST_PERSISTENT);
+
+	/* Informational stream wrapper constants */
+	REGISTER_STRING_CONSTANT("OPENSSL_DEFAULT_STREAM_CIPHERS", OPENSSL_DEFAULT_STREAM_CIPHERS, CONST_CS|CONST_PERSISTENT);
+
+	/* Ciphers */
+#ifndef OPENSSL_NO_RC2
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_RC2_40", PHP_OPENSSL_CIPHER_RC2_40, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_RC2_128", PHP_OPENSSL_CIPHER_RC2_128, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_RC2_64", PHP_OPENSSL_CIPHER_RC2_64, CONST_CS|CONST_PERSISTENT);
+#endif
+#ifndef OPENSSL_NO_DES
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_DES", PHP_OPENSSL_CIPHER_DES, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_3DES", PHP_OPENSSL_CIPHER_3DES, CONST_CS|CONST_PERSISTENT);
+#endif
+#ifndef OPENSSL_NO_AES
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_AES_128_CBC", PHP_OPENSSL_CIPHER_AES_128_CBC, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_AES_192_CBC", PHP_OPENSSL_CIPHER_AES_192_CBC, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_AES_256_CBC", PHP_OPENSSL_CIPHER_AES_256_CBC, CONST_CS|CONST_PERSISTENT);
+#endif
+ 
+	/* Values for key types */
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_RSA", OPENSSL_KEYTYPE_RSA, CONST_CS|CONST_PERSISTENT);
+#ifndef NO_DSA
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_DSA", OPENSSL_KEYTYPE_DSA, CONST_CS|CONST_PERSISTENT);
+#endif
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_DH", OPENSSL_KEYTYPE_DH, CONST_CS|CONST_PERSISTENT);
+#ifdef HAVE_EVP_PKEY_EC
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_EC", OPENSSL_KEYTYPE_EC, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	REGISTER_LONG_CONSTANT("OPENSSL_RAW_DATA", OPENSSL_RAW_DATA, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ZERO_PADDING", OPENSSL_ZERO_PADDING, CONST_CS|CONST_PERSISTENT);
+
+#if OPENSSL_VERSION_NUMBER >= 0x0090806fL && !defined(OPENSSL_NO_TLSEXT)
+	/* SNI support included in OpenSSL >= 0.9.8j */
+	REGISTER_LONG_CONSTANT("OPENSSL_TLSEXT_SERVER_NAME", 1, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	/* Determine default SSL configuration file */
+	config_filename = getenv("OPENSSL_CONF");
+	if (config_filename == NULL) {
+		config_filename = getenv("SSLEAY_CONF");
+	}
+
+	/* default to 'openssl.cnf' if no environment variable is set */
+	if (config_filename == NULL) {
+		snprintf(default_ssl_conf_filename, sizeof(default_ssl_conf_filename), "%s/%s",
+				X509_get_default_cert_area(),
+				"openssl.cnf");
+	} else {
+		strlcpy(default_ssl_conf_filename, config_filename, sizeof(default_ssl_conf_filename));
+	}
+
+	php_stream_xport_register("ssl", php_openssl_ssl_socket_factory TSRMLS_CC);
+#ifndef OPENSSL_NO_SSL3
+	php_stream_xport_register("sslv3", php_openssl_ssl_socket_factory TSRMLS_CC);
+#endif
+#ifndef OPENSSL_NO_SSL2
+	php_stream_xport_register("sslv2", php_openssl_ssl_socket_factory TSRMLS_CC);
+#endif
+	php_stream_xport_register("tls", php_openssl_ssl_socket_factory TSRMLS_CC);
+	php_stream_xport_register("tlsv1.0", php_openssl_ssl_socket_factory TSRMLS_CC);
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	php_stream_xport_register("tlsv1.1", php_openssl_ssl_socket_factory TSRMLS_CC);
+	php_stream_xport_register("tlsv1.2", php_openssl_ssl_socket_factory TSRMLS_CC);
+#endif
+
+	/* override the default tcp socket provider */
+	php_stream_xport_register("tcp", php_openssl_ssl_socket_factory TSRMLS_CC);
+
+	php_register_url_stream_wrapper("https", &php_stream_http_wrapper TSRMLS_CC);
+	php_register_url_stream_wrapper("ftps", &php_stream_ftp_wrapper TSRMLS_CC);
+
+	REGISTER_INI_ENTRIES();
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_MINFO_FUNCTION
+ */
+PHP_MINFO_FUNCTION(openssl)
+{
+	php_info_print_table_start();
+	php_info_print_table_row(2, "OpenSSL support", "enabled");
+	php_info_print_table_row(2, "OpenSSL Library Version", SSLeay_version(SSLEAY_VERSION));
+	php_info_print_table_row(2, "OpenSSL Header Version", OPENSSL_VERSION_TEXT);
+	php_info_print_table_row(2, "Openssl default config", default_ssl_conf_filename);
+	php_info_print_table_end();
+	DISPLAY_INI_ENTRIES();
+}
+/* }}} */
+
+/* {{{ PHP_MSHUTDOWN_FUNCTION
+ */
+PHP_MSHUTDOWN_FUNCTION(openssl)
+{
+	EVP_cleanup();
+
+#if OPENSSL_VERSION_NUMBER >= 0x00090805f
+	/* prevent accessing locking callback from unloaded extension */
+	CRYPTO_set_locking_callback(NULL);
+	/* free allocated error strings */
+	ERR_free_strings();
+#endif
+
+	php_unregister_url_stream_wrapper("https" TSRMLS_CC);
+	php_unregister_url_stream_wrapper("ftps" TSRMLS_CC);
+
+	php_stream_xport_unregister("ssl" TSRMLS_CC);
+#ifndef OPENSSL_NO_SSL2
+	php_stream_xport_unregister("sslv2" TSRMLS_CC);
+#endif
+#ifndef OPENSSL_NO_SSL3
+	php_stream_xport_unregister("sslv3" TSRMLS_CC);
+#endif
+	php_stream_xport_unregister("tls" TSRMLS_CC);
+	php_stream_xport_unregister("tlsv1.0" TSRMLS_CC);
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	php_stream_xport_unregister("tlsv1.1" TSRMLS_CC);
+	php_stream_xport_unregister("tlsv1.2" TSRMLS_CC);
+#endif
+
+	/* reinstate the default tcp handler */
+	php_stream_xport_register("tcp", php_stream_generic_socket_factory TSRMLS_CC);
+
+	UNREGISTER_INI_ENTRIES();
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ x509 cert functions */
+
+/* {{{ proto array openssl_get_cert_locations(void)
+   Retrieve an array mapping available certificate locations */
+PHP_FUNCTION(openssl_get_cert_locations)
+{
+	array_init(return_value);
+
+	add_assoc_string(return_value, "default_cert_file", (char *) X509_get_default_cert_file(), 1);
+	add_assoc_string(return_value, "default_cert_file_env", (char *) X509_get_default_cert_file_env(), 1);
+	add_assoc_string(return_value, "default_cert_dir", (char *) X509_get_default_cert_dir(), 1);
+	add_assoc_string(return_value, "default_cert_dir_env", (char *) X509_get_default_cert_dir_env(), 1);
+	add_assoc_string(return_value, "default_private_dir", (char *) X509_get_default_private_dir(), 1);
+	add_assoc_string(return_value, "default_default_cert_area", (char *) X509_get_default_cert_area(), 1);
+	add_assoc_string(return_value, "ini_cafile",
+		zend_ini_string("openssl.cafile", sizeof("openssl.cafile"), 0), 1);
+	add_assoc_string(return_value, "ini_capath",
+		zend_ini_string("openssl.capath", sizeof("openssl.capath"), 0), 1);
+}
+/* }}} */
+
+
+/* {{{ php_openssl_x509_from_zval
+	Given a zval, coerce it into an X509 object.
+	The zval can be:
+		. X509 resource created using openssl_read_x509()
+		. if it starts with file:// then it will be interpreted as the path to that cert
+		. it will be interpreted as the cert data
+	If you supply makeresource, the result will be registered as an x509 resource and
+	it's value returned in makeresource.
+*/
+static X509 * php_openssl_x509_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC)
+{
+	X509 *cert = NULL;
+
+	if (resourceval) {
+		*resourceval = -1;
+	}
+	if (Z_TYPE_PP(val) == IS_RESOURCE) {
+		/* is it an x509 resource ? */
+		void * what;
+		int type;
+
+		what = zend_fetch_resource(val TSRMLS_CC, -1, "OpenSSL X.509", &type, 1, le_x509);
+		if (!what) {
+			return NULL;
+		}
+		/* this is so callers can decide if they should free the X509 */
+		if (resourceval) {
+			*resourceval = Z_LVAL_PP(val);
+		}
+		if (type == le_x509) {
+			return (X509*)what;
+		}
+		/* other types could be used here - eg: file pointers and read in the data from them */
+
+		return NULL;
+	}
+
+	if (!(Z_TYPE_PP(val) == IS_STRING || Z_TYPE_PP(val) == IS_OBJECT)) {
+		return NULL;
+	}
+
+	/* force it to be a string and check if it refers to a file */
+	convert_to_string_ex(val);
+
+	if (Z_STRLEN_PP(val) > 7 && memcmp(Z_STRVAL_PP(val), "file://", sizeof("file://") - 1) == 0) {
+		/* read cert from the named file */
+		BIO *in;
+
+		if (php_openssl_open_base_dir_chk(Z_STRVAL_PP(val) + (sizeof("file://") - 1) TSRMLS_CC)) {
+			return NULL;
+		}
+
+		in = BIO_new_file(Z_STRVAL_PP(val) + (sizeof("file://") - 1), "r");
+		if (in == NULL) {
+			return NULL;
+		}
+		cert = PEM_read_bio_X509(in, NULL, NULL, NULL);
+		BIO_free(in);
+	} else {
+		BIO *in;
+
+		in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+		if (in == NULL) {
+			return NULL;
+		}
+#ifdef TYPEDEF_D2I_OF
+		cert = (X509 *) PEM_ASN1_read_bio((d2i_of_void *)d2i_X509, PEM_STRING_X509, in, NULL, NULL, NULL);
+#else
+		cert = (X509 *) PEM_ASN1_read_bio((char *(*)())d2i_X509, PEM_STRING_X509, in, NULL, NULL, NULL);
+#endif
+		BIO_free(in);
+	}
+
+	if (cert && makeresource && resourceval) {
+		*resourceval = zend_list_insert(cert, le_x509 TSRMLS_CC);
+	}
+	return cert;
+}
+
+/* }}} */
+
+/* {{{ proto bool openssl_x509_export_to_file(mixed x509, string outfilename [, bool notext = true])
+   Exports a CERT to file or a var */
+PHP_FUNCTION(openssl_x509_export_to_file)
+{
+	X509 * cert;
+	zval ** zcert;
+	zend_bool notext = 1;
+	BIO * bio_out;
+	long certresource;
+	char * filename;
+	int filename_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zp|b", &zcert, &filename, &filename_len, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		return;
+	}
+
+	bio_out = BIO_new_file(filename, "w");
+	if (bio_out) {
+		if (!notext) {
+			X509_print(bio_out, cert);
+		}
+		PEM_write_bio_X509(bio_out, cert);
+
+		RETVAL_TRUE;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening file %s", filename);
+	}
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+/* {{{ proto string openssl_spki_new(mixed zpkey, string challenge [, mixed method])
+   Creates new private key (or uses existing) and creates a new spki cert
+   outputting results to var */
+PHP_FUNCTION(openssl_spki_new)
+{
+	int challenge_len;
+	char * challenge = NULL, * spkstr = NULL, * s = NULL;
+	long keyresource = -1;
+	const char *spkac = "SPKAC=";
+	long algo = OPENSSL_ALGO_MD5;
+
+	zval *method = NULL;
+	zval * zpkey = NULL;
+	EVP_PKEY * pkey = NULL;
+	NETSCAPE_SPKI *spki=NULL;
+	const EVP_MD *mdtype;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs|z", &zpkey, &challenge, &challenge_len, &method) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	pkey = php_openssl_evp_from_zval(&zpkey, 0, challenge, 1, &keyresource TSRMLS_CC);
+
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied private key");
+		goto cleanup;
+	}
+
+	if (method != NULL) {
+		if (Z_TYPE_P(method) == IS_LONG) {
+			algo = Z_LVAL_P(method);
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Algorithm must be of supported type");
+			goto cleanup;
+		}
+	}
+	mdtype = php_openssl_get_evp_md_from_algo(algo);
+
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		goto cleanup;
+	}
+
+	if ((spki = NETSCAPE_SPKI_new()) == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to create new SPKAC");
+		goto cleanup;
+	}
+
+	if (challenge) {
+		ASN1_STRING_set(spki->spkac->challenge, challenge, challenge_len);
+	}
+
+	if (!NETSCAPE_SPKI_set_pubkey(spki, pkey)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to embed public key");
+		goto cleanup;
+	}
+
+	if (!NETSCAPE_SPKI_sign(spki, pkey, mdtype)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to sign with specified algorithm");
+		goto cleanup;
+	}
+
+	spkstr = NETSCAPE_SPKI_b64_encode(spki);
+	if (!spkstr){
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to encode SPKAC");
+		goto cleanup;
+	}
+
+	s = emalloc(strlen(spkac) + strlen(spkstr) + 1);
+	sprintf(s, "%s%s", spkac, spkstr);
+
+	RETVAL_STRINGL(s, strlen(s), 0);
+	goto cleanup;
+
+cleanup:
+
+	if (keyresource == -1 && spki != NULL) {
+		NETSCAPE_SPKI_free(spki);
+	}
+	if (keyresource == -1 && pkey != NULL) {
+		EVP_PKEY_free(pkey);
+	}
+	if (keyresource == -1 && spkstr != NULL) {
+		efree(spkstr);
+	}
+
+	if (s && strlen(s) <= 0) {
+		RETVAL_FALSE;
+	}
+
+	if (keyresource == -1 && s != NULL) {
+		efree(s);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_spki_verify(string spki)
+   Verifies spki returns boolean */
+PHP_FUNCTION(openssl_spki_verify)
+{
+	int spkstr_len, i = 0;
+	char *spkstr = NULL, * spkstr_cleaned = NULL;
+
+	EVP_PKEY *pkey = NULL;
+	NETSCAPE_SPKI *spki = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &spkstr, &spkstr_len) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (spkstr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied SPKAC");
+		goto cleanup;
+	}
+
+	spkstr_cleaned = emalloc(spkstr_len + 1);
+	openssl_spki_cleanup(spkstr, spkstr_cleaned);
+
+	if (strlen(spkstr_cleaned)<=0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid SPKAC");
+		goto cleanup;
+	}
+
+	spki = NETSCAPE_SPKI_b64_decode(spkstr_cleaned, strlen(spkstr_cleaned));
+	if (spki == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to decode supplied SPKAC");
+		goto cleanup;
+	}
+
+	pkey = X509_PUBKEY_get(spki->spkac->pubkey);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to acquire signed public key");
+		goto cleanup;
+	}
+
+	i = NETSCAPE_SPKI_verify(spki, pkey);
+	goto cleanup;
+
+cleanup:
+	if (spki != NULL) {
+		NETSCAPE_SPKI_free(spki);
+	}
+	if (pkey != NULL) {
+		EVP_PKEY_free(pkey);
+	}
+	if (spkstr_cleaned != NULL) {
+		efree(spkstr_cleaned);
+	}
+
+	if (i > 0) {
+		RETVAL_TRUE;
+	}
+}
+/* }}} */
+
+/* {{{ proto string openssl_spki_export(string spki)
+   Exports public key from existing spki to var */
+PHP_FUNCTION(openssl_spki_export)
+{
+	int spkstr_len;
+	char *spkstr = NULL, * spkstr_cleaned = NULL, * s = NULL;
+
+	EVP_PKEY *pkey = NULL;
+	NETSCAPE_SPKI *spki = NULL;
+	BIO *out = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &spkstr, &spkstr_len) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (spkstr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied SPKAC");
+		goto cleanup;
+	}
+
+	spkstr_cleaned = emalloc(spkstr_len + 1);
+	openssl_spki_cleanup(spkstr, spkstr_cleaned);
+
+	spki = NETSCAPE_SPKI_b64_decode(spkstr_cleaned, strlen(spkstr_cleaned));
+	if (spki == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to decode supplied SPKAC");
+		goto cleanup;
+	}
+
+	pkey = X509_PUBKEY_get(spki->spkac->pubkey);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to acquire signed public key");
+		goto cleanup;
+	}
+
+	out = BIO_new(BIO_s_mem());
+	if (out && PEM_write_bio_PUBKEY(out, pkey))  {
+		BUF_MEM *bio_buf;
+
+		BIO_get_mem_ptr(out, &bio_buf);
+		RETVAL_STRINGL((char *)bio_buf->data, bio_buf->length, 1);
+	}
+	goto cleanup;
+
+cleanup:
+
+	if (spki != NULL) {
+		NETSCAPE_SPKI_free(spki);
+	}
+	if (out != NULL) {
+		BIO_free_all(out);
+	}
+	if (pkey != NULL) {
+		EVP_PKEY_free(pkey);
+	}
+	if (spkstr_cleaned != NULL) {
+		efree(spkstr_cleaned);
+	}
+	if (s != NULL) {
+		efree(s);
+	}
+}
+/* }}} */
+
+/* {{{ proto string openssl_spki_export_challenge(string spki)
+   Exports spkac challenge from existing spki to var */
+PHP_FUNCTION(openssl_spki_export_challenge)
+{
+	int spkstr_len;
+	char *spkstr = NULL, * spkstr_cleaned = NULL;
+
+	NETSCAPE_SPKI *spki = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &spkstr, &spkstr_len) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (spkstr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied SPKAC");
+		goto cleanup;
+	}
+
+	spkstr_cleaned = emalloc(spkstr_len + 1);
+	openssl_spki_cleanup(spkstr, spkstr_cleaned);
+
+	spki = NETSCAPE_SPKI_b64_decode(spkstr_cleaned, strlen(spkstr_cleaned));
+	if (spki == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to decode SPKAC");
+		goto cleanup;
+	}
+
+	RETVAL_STRING((char *) ASN1_STRING_data(spki->spkac->challenge), 1);
+	goto cleanup;
+
+cleanup:
+	if (spkstr_cleaned != NULL) {
+		efree(spkstr_cleaned);
+	}
+}
+/* }}} */
+
+/* {{{ strip line endings from spkac */
+int openssl_spki_cleanup(const char *src, char *dest)
+{
+    int removed=0;
+
+    while (*src) {
+        if (*src!='\n'&&*src!='\r') {
+            *dest++=*src;
+        } else {
+            ++removed;
+        }
+        ++src;
+    }
+    *dest=0;
+    return removed;
+}
+/* }}} */
+
+/* {{{ proto bool openssl_x509_export(mixed x509, string &out [, bool notext = true])
+   Exports a CERT to file or a var */
+PHP_FUNCTION(openssl_x509_export)
+{
+	X509 * cert;
+	zval ** zcert, *zout;
+	zend_bool notext = 1;
+	BIO * bio_out;
+	long certresource;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zz|b", &zcert, &zout, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+
+	bio_out = BIO_new(BIO_s_mem());
+	if (!notext) {
+		X509_print(bio_out, cert);
+	}
+	if (PEM_write_bio_X509(bio_out, cert))  {
+		BUF_MEM *bio_buf;
+
+		zval_dtor(zout);
+		BIO_get_mem_ptr(bio_out, &bio_buf);
+		ZVAL_STRINGL(zout, bio_buf->data, bio_buf->length, 1);
+
+		RETVAL_TRUE;
+	}
+
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+int php_openssl_x509_fingerprint(X509 *peer, const char *method, zend_bool raw, char **out, int *out_len TSRMLS_DC)
+{
+	unsigned char md[EVP_MAX_MD_SIZE];
+	const EVP_MD *mdtype;
+	unsigned int n;
+
+	if (!(mdtype = EVP_get_digestbyname(method))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		return FAILURE;
+	} else if (!X509_digest(peer, mdtype, md, &n)) {
+		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Could not generate signature");
+		return FAILURE;
+	}
+
+	if (raw) {
+		*out_len = n;
+		*out = estrndup((char *) md, n);
+	} else {
+		*out_len = n * 2;
+		*out = emalloc(*out_len + 1);
+
+		make_digest_ex(*out, md, n);
+	}
+
+	return SUCCESS;
+}
+
+PHP_FUNCTION(openssl_x509_fingerprint)
+{
+	X509 *cert;
+	zval **zcert;
+	long certresource;
+	zend_bool raw_output = 0;
+	char *method = "sha1";
+	int method_len;
+
+	char *fingerprint;
+	int fingerprint_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|sb", &zcert, &method, &method_len, &raw_output) == FAILURE) {
+		return;
+	}
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		RETURN_FALSE;
+	}
+
+	if (php_openssl_x509_fingerprint(cert, method, raw_output, &fingerprint, &fingerprint_len TSRMLS_CC) == SUCCESS) {
+		RETVAL_STRINGL(fingerprint, fingerprint_len, 0);
+	} else {
+		RETVAL_FALSE;
+	}
+
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+}
+
+/* {{{ proto bool openssl_x509_check_private_key(mixed cert, mixed key)
+   Checks if a private key corresponds to a CERT */
+PHP_FUNCTION(openssl_x509_check_private_key)
+{
+	zval ** zcert, **zkey;
+	X509 * cert = NULL;
+	EVP_PKEY * key = NULL;
+	long certresource = -1, keyresource = -1;
+
+	RETVAL_FALSE;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ZZ", &zcert, &zkey) == FAILURE) {
+		return;
+	}
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		RETURN_FALSE;
+	}	
+	key = php_openssl_evp_from_zval(zkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (key) {
+		RETVAL_BOOL(X509_check_private_key(cert, key));
+	}
+
+	if (keyresource == -1 && key) {
+		EVP_PKEY_free(key);
+	}
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* Special handling of subjectAltName, see CVE-2013-4073
+ * Christian Heimes
+ */
+
+static int openssl_x509v3_subjectAltName(BIO *bio, X509_EXTENSION *extension)
+{
+	GENERAL_NAMES *names;
+	const X509V3_EXT_METHOD *method = NULL;
+	ASN1_OCTET_STRING *extension_data;
+	long i, length, num;
+	const unsigned char *p;
+
+	method = X509V3_EXT_get(extension);
+	if (method == NULL) {
+		return -1;
+	}
+
+	extension_data = X509_EXTENSION_get_data(extension);
+	p = extension_data->data;
+	length = extension_data->length;
+	if (method->it) {
+		names = (GENERAL_NAMES*)(ASN1_item_d2i(NULL, &p, length,
+						       ASN1_ITEM_ptr(method->it)));
+	} else {
+		names = (GENERAL_NAMES*)(method->d2i(NULL, &p, length));
+	}
+	if (names == NULL) {
+		return -1;
+	}
+
+	num = sk_GENERAL_NAME_num(names);
+	for (i = 0; i < num; i++) {
+			GENERAL_NAME *name;
+			ASN1_STRING *as;
+			name = sk_GENERAL_NAME_value(names, i);
+			switch (name->type) {
+				case GEN_EMAIL:
+					BIO_puts(bio, "email:");
+					as = name->d.rfc822Name;
+					BIO_write(bio, ASN1_STRING_data(as),
+						  ASN1_STRING_length(as));
+					break;
+				case GEN_DNS:
+					BIO_puts(bio, "DNS:");
+					as = name->d.dNSName;
+					BIO_write(bio, ASN1_STRING_data(as),
+						  ASN1_STRING_length(as));
+					break;
+				case GEN_URI:
+					BIO_puts(bio, "URI:");
+					as = name->d.uniformResourceIdentifier;
+					BIO_write(bio, ASN1_STRING_data(as),
+						  ASN1_STRING_length(as));
+					break;
+				default:
+					/* use builtin print for GEN_OTHERNAME, GEN_X400,
+					 * GEN_EDIPARTY, GEN_DIRNAME, GEN_IPADD and GEN_RID
+					 */
+					GENERAL_NAME_print(bio, name);
+			}
+			/* trailing ', ' except for last element */
+			if (i < (num - 1)) {
+				BIO_puts(bio, ", ");
+			}
+	}
+	sk_GENERAL_NAME_pop_free(names, GENERAL_NAME_free);
+
+	return 0;
+}
+
+/* {{{ proto array openssl_x509_parse(mixed x509 [, bool shortnames=true])
+   Returns an array of the fields/values of the CERT */
+PHP_FUNCTION(openssl_x509_parse)
+{
+	zval ** zcert;
+	X509 * cert = NULL;
+	long certresource = -1;
+	int i, sig_nid;
+	zend_bool useshortnames = 1;
+	char * tmpstr;
+	zval * subitem;
+	X509_EXTENSION *extension;
+	X509_NAME *subject_name;
+	char *cert_name;
+	char *extname;
+	BIO  *bio_out;
+	BUF_MEM *bio_buf;
+	char buf[256];
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|b", &zcert, &useshortnames) == FAILURE) {
+		return;
+	}
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		RETURN_FALSE;
+	}
+	array_init(return_value);
+
+	subject_name = X509_get_subject_name(cert);
+	cert_name = X509_NAME_oneline(subject_name, NULL, 0);
+	add_assoc_string(return_value, "name", cert_name, 1);
+	OPENSSL_free(cert_name);
+
+	add_assoc_name_entry(return_value, "subject", 		X509_get_subject_name(cert), useshortnames TSRMLS_CC);
+	/* hash as used in CA directories to lookup cert by subject name */
+	{
+		char buf[32];
+		snprintf(buf, sizeof(buf), "%08lx", X509_subject_name_hash(cert));
+		add_assoc_string(return_value, "hash", buf, 1);
+	}
+	
+	add_assoc_name_entry(return_value, "issuer", 		X509_get_issuer_name(cert), useshortnames TSRMLS_CC);
+	add_assoc_long(return_value, "version", 			X509_get_version(cert));
+
+	add_assoc_string(return_value, "serialNumber", i2s_ASN1_INTEGER(NULL, X509_get_serialNumber(cert)), 1); 
+
+	add_assoc_asn1_string(return_value, "validFrom", 	X509_get_notBefore(cert));
+	add_assoc_asn1_string(return_value, "validTo", 		X509_get_notAfter(cert));
+
+	add_assoc_long(return_value, "validFrom_time_t", 	asn1_time_to_time_t(X509_get_notBefore(cert) TSRMLS_CC));
+	add_assoc_long(return_value, "validTo_time_t", 		asn1_time_to_time_t(X509_get_notAfter(cert) TSRMLS_CC));
+
+	tmpstr = (char *)X509_alias_get0(cert, NULL);
+	if (tmpstr) {
+		add_assoc_string(return_value, "alias", tmpstr, 1);
+	}
+
+	sig_nid = X509_get_signature_nid(cert);
+	add_assoc_string(return_value, "signatureTypeSN", (char*)OBJ_nid2sn(sig_nid), 1);
+	add_assoc_string(return_value, "signatureTypeLN", (char*)OBJ_nid2ln(sig_nid), 1);
+	add_assoc_long(return_value, "signatureTypeNID", sig_nid);
+
+	MAKE_STD_ZVAL(subitem);
+	array_init(subitem);
+
+	/* NOTE: the purposes are added as integer keys - the keys match up to the X509_PURPOSE_SSL_XXX defines
+	   in x509v3.h */
+	for (i = 0; i < X509_PURPOSE_get_count(); i++) {
+		int id, purpset;
+		char * pname;
+		X509_PURPOSE * purp;
+		zval * subsub;
+
+		MAKE_STD_ZVAL(subsub);
+		array_init(subsub);
+
+		purp = X509_PURPOSE_get0(i);
+		id = X509_PURPOSE_get_id(purp);
+
+		purpset = X509_check_purpose(cert, id, 0);
+		add_index_bool(subsub, 0, purpset);
+
+		purpset = X509_check_purpose(cert, id, 1);
+		add_index_bool(subsub, 1, purpset);
+
+		pname = useshortnames ? X509_PURPOSE_get0_sname(purp) : X509_PURPOSE_get0_name(purp);
+		add_index_string(subsub, 2, pname, 1);
+
+		/* NOTE: if purpset > 1 then it's a warning - we should mention it ? */
+
+		add_index_zval(subitem, id, subsub);
+	}
+	add_assoc_zval(return_value, "purposes", subitem);
+
+	MAKE_STD_ZVAL(subitem);
+	array_init(subitem);
+
+
+	for (i = 0; i < X509_get_ext_count(cert); i++) {
+		int nid;
+		extension = X509_get_ext(cert, i);
+		nid = OBJ_obj2nid(X509_EXTENSION_get_object(extension));
+		if (nid != NID_undef) {
+			extname = (char *)OBJ_nid2sn(OBJ_obj2nid(X509_EXTENSION_get_object(extension)));
+		} else {
+			OBJ_obj2txt(buf, sizeof(buf)-1, X509_EXTENSION_get_object(extension), 1);
+			extname = buf;
+		}
+		bio_out = BIO_new(BIO_s_mem());
+		if (nid == NID_subject_alt_name) {
+			if (openssl_x509v3_subjectAltName(bio_out, extension) == 0) {
+				BIO_get_mem_ptr(bio_out, &bio_buf);
+				add_assoc_stringl(subitem, extname, bio_buf->data, bio_buf->length, 1);
+			} else {
+				zval_dtor(return_value);
+				if (certresource == -1 && cert) {
+					X509_free(cert);
+				}
+				BIO_free(bio_out);
+				RETURN_FALSE;
+			}
+		}
+		else if (X509V3_EXT_print(bio_out, extension, 0, 0)) {
+			BIO_get_mem_ptr(bio_out, &bio_buf);
+			add_assoc_stringl(subitem, extname, bio_buf->data, bio_buf->length, 1);
+		} else {
+			add_assoc_asn1_string(subitem, extname, X509_EXTENSION_get_data(extension));
+		}
+		BIO_free(bio_out);
+	}
+	add_assoc_zval(return_value, "extensions", subitem);
+
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ load_all_certs_from_file */
+static STACK_OF(X509) * load_all_certs_from_file(char *certfile)
+{
+	STACK_OF(X509_INFO) *sk=NULL;
+	STACK_OF(X509) *stack=NULL, *ret=NULL;
+	BIO *in=NULL;
+	X509_INFO *xi;
+	TSRMLS_FETCH();
+
+	if(!(stack = sk_X509_new_null())) {
+		php_error_docref(NULL TSRMLS_CC, E_ERROR, "memory allocation failure");
+		goto end;
+	}
+
+	if (php_openssl_open_base_dir_chk(certfile TSRMLS_CC)) {
+		sk_X509_free(stack);
+		goto end;
+	}
+
+	if(!(in=BIO_new_file(certfile, "r"))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening the file, %s", certfile);
+		sk_X509_free(stack);
+		goto end;
+	}
+
+	/* This loads from a file, a stack of x509/crl/pkey sets */
+	if(!(sk=PEM_X509_INFO_read_bio(in, NULL, NULL, NULL))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error reading the file, %s", certfile);
+		sk_X509_free(stack);
+		goto end;
+	}
+
+	/* scan over it and pull out the certs */
+	while (sk_X509_INFO_num(sk)) {
+		xi=sk_X509_INFO_shift(sk);
+		if (xi->x509 != NULL) {
+			sk_X509_push(stack,xi->x509);
+			xi->x509=NULL;
+		}
+		X509_INFO_free(xi);
+	}
+	if(!sk_X509_num(stack)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "no certificates in file, %s", certfile);
+		sk_X509_free(stack);
+		goto end;
+	}
+	ret=stack;
+end:
+	BIO_free(in);
+	sk_X509_INFO_free(sk);
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ check_cert */
+static int check_cert(X509_STORE *ctx, X509 *x, STACK_OF(X509) *untrustedchain, int purpose)
+{
+	int ret=0;
+	X509_STORE_CTX *csc;
+	TSRMLS_FETCH();
+
+	csc = X509_STORE_CTX_new();
+	if (csc == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_ERROR, "memory allocation failure");
+		return 0;
+	}
+	X509_STORE_CTX_init(csc, ctx, x, untrustedchain);
+	if(purpose >= 0) {
+		X509_STORE_CTX_set_purpose(csc, purpose);
+	}
+	ret = X509_verify_cert(csc);
+	X509_STORE_CTX_free(csc);
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ proto int openssl_x509_checkpurpose(mixed x509cert, int purpose, array cainfo [, string untrustedfile])
+   Checks the CERT to see if it can be used for the purpose in purpose. cainfo holds information about trusted CAs */
+PHP_FUNCTION(openssl_x509_checkpurpose)
+{
+	zval ** zcert, * zcainfo = NULL;
+	X509_STORE * cainfo = NULL;
+	X509 * cert = NULL;
+	long certresource = -1;
+	STACK_OF(X509) * untrustedchain = NULL;
+	long purpose;
+	char * untrusted = NULL;
+	int untrusted_len = 0, ret;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zl|a!s", &zcert, &purpose, &zcainfo, &untrusted, &untrusted_len) == FAILURE) {
+		return;
+	}
+
+	RETVAL_LONG(-1);
+
+	if (untrusted) {
+		untrustedchain = load_all_certs_from_file(untrusted);
+		if (untrustedchain == NULL) {
+			goto clean_exit;
+		}
+	}
+
+	cainfo = setup_verify(zcainfo TSRMLS_CC);
+	if (cainfo == NULL) {
+		goto clean_exit;
+	}
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		goto clean_exit;
+	}
+
+	ret = check_cert(cainfo, cert, untrustedchain, purpose);
+	if (ret != 0 && ret != 1) {
+		RETVAL_LONG(ret);
+	} else {
+		RETVAL_BOOL(ret);
+	}
+
+clean_exit:
+	if (certresource == 1 && cert) {
+		X509_free(cert);
+	}
+	if (cainfo) { 
+		X509_STORE_free(cainfo); 
+	}
+	if (untrustedchain) {
+		sk_X509_pop_free(untrustedchain, X509_free);
+	}
+}
+/* }}} */
+
+/* {{{ setup_verify
+ * calist is an array containing file and directory names.  create a
+ * certificate store and add those certs to it for use in verification.
+*/
+static X509_STORE * setup_verify(zval * calist TSRMLS_DC)
+{
+	X509_STORE *store;
+	X509_LOOKUP * dir_lookup, * file_lookup;
+	HashPosition pos;
+	int ndirs = 0, nfiles = 0;
+
+	store = X509_STORE_new();
+
+	if (store == NULL) {
+		return NULL;
+	}
+
+	if (calist && (Z_TYPE_P(calist) == IS_ARRAY)) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(calist), &pos);
+		for (;; zend_hash_move_forward_ex(HASH_OF(calist), &pos)) {
+			zval ** item;
+			struct stat sb;
+
+			if (zend_hash_get_current_data_ex(HASH_OF(calist), (void**)&item, &pos) == FAILURE) {
+				break;
+			}
+			convert_to_string_ex(item);
+
+			if (VCWD_STAT(Z_STRVAL_PP(item), &sb) == -1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to stat %s", Z_STRVAL_PP(item));
+				continue;
+			}
+
+			if ((sb.st_mode & S_IFREG) == S_IFREG) {
+				file_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
+				if (file_lookup == NULL || !X509_LOOKUP_load_file(file_lookup, Z_STRVAL_PP(item), X509_FILETYPE_PEM)) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "error loading file %s", Z_STRVAL_PP(item));
+				} else {
+					nfiles++;
+				}
+				file_lookup = NULL;
+			} else {
+				dir_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_hash_dir());
+				if (dir_lookup == NULL || !X509_LOOKUP_add_dir(dir_lookup, Z_STRVAL_PP(item), X509_FILETYPE_PEM)) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "error loading directory %s", Z_STRVAL_PP(item));
+				} else { 
+					ndirs++;
+				}
+				dir_lookup = NULL;
+			}
+		}
+	}
+	if (nfiles == 0) {
+		file_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
+		if (file_lookup) {
+			X509_LOOKUP_load_file(file_lookup, NULL, X509_FILETYPE_DEFAULT);
+		}
+	}
+	if (ndirs == 0) {
+		dir_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_hash_dir());
+		if (dir_lookup) {
+			X509_LOOKUP_add_dir(dir_lookup, NULL, X509_FILETYPE_DEFAULT);
+		}
+	}
+	return store;
+}
+/* }}} */
+
+/* {{{ proto resource openssl_x509_read(mixed cert)
+   Reads X.509 certificates */
+PHP_FUNCTION(openssl_x509_read)
+{
+	zval **cert;
+	X509 *x509;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z", &cert) == FAILURE) {
+		return;
+	}
+	Z_TYPE_P(return_value) = IS_RESOURCE;
+	x509 = php_openssl_x509_from_zval(cert, 1, &Z_LVAL_P(return_value) TSRMLS_CC);
+
+	if (x509 == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied parameter cannot be coerced into an X509 certificate!");
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+/* {{{ proto void openssl_x509_free(resource x509)
+   Frees X.509 certificates */
+PHP_FUNCTION(openssl_x509_free)
+{
+	zval *x509;
+	X509 *cert;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &x509) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(cert, X509 *, &x509, -1, "OpenSSL X.509", le_x509);
+	zend_list_delete(Z_LVAL_P(x509));
+}
+/* }}} */
+
+/* }}} */
+
+/* Pop all X509 from Stack and free them, free the stack afterwards */
+static void php_sk_X509_free(STACK_OF(X509) * sk) /* {{{ */
+{
+	for (;;) {
+		X509* x = sk_X509_pop(sk);
+		if (!x) break;
+		X509_free(x);
+	}
+	sk_X509_free(sk);
+}
+/* }}} */
+
+static STACK_OF(X509) * php_array_to_X509_sk(zval ** zcerts TSRMLS_DC) /* {{{ */
+{
+	HashPosition hpos;
+	zval ** zcertval;
+	STACK_OF(X509) * sk = NULL;
+    X509 * cert;
+    long certresource;
+
+	sk = sk_X509_new_null();
+
+	/* get certs */
+	if (Z_TYPE_PP(zcerts) == IS_ARRAY) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(*zcerts), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(*zcerts), (void**)&zcertval, &hpos) == SUCCESS) {
+
+			cert = php_openssl_x509_from_zval(zcertval, 0, &certresource TSRMLS_CC);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+
+			if (certresource != -1) {
+				cert = X509_dup(cert);
+				
+				if (cert == NULL) {
+					goto clean_exit;
+				}
+				
+			}
+			sk_X509_push(sk, cert);
+
+			zend_hash_move_forward_ex(HASH_OF(*zcerts), &hpos);
+		}
+	} else {
+		/* a single certificate */
+		cert = php_openssl_x509_from_zval(zcerts, 0, &certresource TSRMLS_CC);
+		
+		if (cert == NULL) {
+			goto clean_exit;
+		}
+
+		if (certresource != -1) {
+			cert = X509_dup(cert);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+		}
+		sk_X509_push(sk, cert);
+	}
+
+  clean_exit:
+    return sk;
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs12_export_to_file(mixed x509, string filename, mixed priv_key, string pass[, array args])
+   Creates and exports a PKCS to file */
+PHP_FUNCTION(openssl_pkcs12_export_to_file)
+{
+	X509 * cert = NULL;
+	BIO * bio_out = NULL;
+	PKCS12 * p12 = NULL;
+	char * filename;
+	char * friendly_name = NULL;
+	int filename_len;
+	char * pass;
+	int pass_len;
+	zval **zcert = NULL, *zpkey = NULL, *args = NULL;
+	EVP_PKEY *priv_key = NULL;
+	long certresource, keyresource;
+	zval ** item;
+	STACK_OF(X509) *ca = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zpzs|a", &zcert, &filename, &filename_len, &zpkey, &pass, &pass_len, &args) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+	priv_key = php_openssl_evp_from_zval(&zpkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (priv_key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get private key from parameter 3");
+		goto cleanup;
+	}
+	if (cert && !X509_check_private_key(cert, priv_key)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key does not correspond to cert");
+		goto cleanup;
+	}
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		goto cleanup;
+	}
+
+	/* parse extra config from args array, promote this to an extra function */
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "friendly_name", sizeof("friendly_name"), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_STRING)
+		friendly_name = Z_STRVAL_PP(item);
+	/* certpbe (default RC2-40)
+	   keypbe (default 3DES)
+	   friendly_caname
+	*/
+
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "extracerts", sizeof("extracerts"), (void**)&item) == SUCCESS)
+		ca = php_array_to_X509_sk(item TSRMLS_CC);
+	/* end parse extra config */
+
+	/*PKCS12 *PKCS12_create(char *pass, char *name, EVP_PKEY *pkey, X509 *cert, STACK_OF(X509) *ca,
+                                       int nid_key, int nid_cert, int iter, int mac_iter, int keytype);*/
+
+	p12 = PKCS12_create(pass, friendly_name, priv_key, cert, ca, 0, 0, 0, 0, 0);
+
+	bio_out = BIO_new_file(filename, "w"); 
+	if (bio_out) {
+		
+		i2d_PKCS12_bio(bio_out, p12);
+
+		RETVAL_TRUE;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening file %s", filename);
+	}
+
+	BIO_free(bio_out);
+	PKCS12_free(p12);
+	php_sk_X509_free(ca);
+	
+cleanup:
+
+	if (keyresource == -1 && priv_key) {
+		EVP_PKEY_free(priv_key);
+	}
+	if (certresource == -1 && cert) { 
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs12_export(mixed x509, string &out, mixed priv_key, string pass[, array args])
+   Creates and exports a PKCS12 to a var */
+PHP_FUNCTION(openssl_pkcs12_export)
+{
+	X509 * cert = NULL;
+	BIO * bio_out;
+	PKCS12 * p12 = NULL;
+	zval * zcert = NULL, *zout = NULL, *zpkey, *args = NULL;
+	EVP_PKEY *priv_key = NULL;
+	long certresource, keyresource;
+	char * pass;
+	int pass_len;
+	char * friendly_name = NULL;
+	zval ** item;
+	STACK_OF(X509) *ca = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zzzs|a", &zcert, &zout, &zpkey, &pass, &pass_len, &args) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	cert = php_openssl_x509_from_zval(&zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+	priv_key = php_openssl_evp_from_zval(&zpkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (priv_key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get private key from parameter 3");
+		goto cleanup;
+	}
+	if (cert && !X509_check_private_key(cert, priv_key)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key does not correspond to cert");
+		goto cleanup;
+	}
+
+	/* parse extra config from args array, promote this to an extra function */
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "friendly_name", sizeof("friendly_name"), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_STRING)
+		friendly_name = Z_STRVAL_PP(item);
+
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "extracerts", sizeof("extracerts"), (void**)&item) == SUCCESS)
+		ca = php_array_to_X509_sk(item TSRMLS_CC);
+	/* end parse extra config */
+	
+	p12 = PKCS12_create(pass, friendly_name, priv_key, cert, ca, 0, 0, 0, 0, 0);
+
+	bio_out = BIO_new(BIO_s_mem());
+	if (i2d_PKCS12_bio(bio_out, p12))  {
+		BUF_MEM *bio_buf;
+
+		zval_dtor(zout);
+		BIO_get_mem_ptr(bio_out, &bio_buf);
+		ZVAL_STRINGL(zout, bio_buf->data, bio_buf->length, 1);
+
+		RETVAL_TRUE;
+	}
+
+	BIO_free(bio_out);
+	PKCS12_free(p12);
+	php_sk_X509_free(ca);
+	
+cleanup:
+
+	if (keyresource == -1 && priv_key) {
+		EVP_PKEY_free(priv_key);
+	}
+	if (certresource == -1 && cert) { 
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs12_read(string PKCS12, array &certs, string pass)
+   Parses a PKCS12 to an array */
+PHP_FUNCTION(openssl_pkcs12_read)
+{
+	zval *zout = NULL, *zextracerts, *zcert, *zpkey;
+	char *pass, *zp12;
+	int pass_len, zp12_len;
+	PKCS12 * p12 = NULL;
+	EVP_PKEY * pkey = NULL;
+	X509 * cert = NULL;
+	STACK_OF(X509) * ca = NULL;
+	BIO * bio_in = NULL;
+	int i;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szs", &zp12, &zp12_len, &zout, &pass, &pass_len) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	bio_in = BIO_new(BIO_s_mem());
+	
+	if(!BIO_write(bio_in, zp12, zp12_len))
+		goto cleanup;
+	
+	if(d2i_PKCS12_bio(bio_in, &p12)) {
+		if(PKCS12_parse(p12, pass, &pkey, &cert, &ca)) {
+			BIO * bio_out;
+
+			zval_dtor(zout);
+			array_init(zout);
+
+			bio_out = BIO_new(BIO_s_mem());
+			if (PEM_write_bio_X509(bio_out, cert)) {
+				BUF_MEM *bio_buf;
+				BIO_get_mem_ptr(bio_out, &bio_buf);
+				MAKE_STD_ZVAL(zcert);
+				ZVAL_STRINGL(zcert, bio_buf->data, bio_buf->length, 1);
+				add_assoc_zval(zout, "cert", zcert);
+			}
+			BIO_free(bio_out);
+
+			bio_out = BIO_new(BIO_s_mem());
+			if (PEM_write_bio_PrivateKey(bio_out, pkey, NULL, NULL, 0, 0, NULL)) {
+				BUF_MEM *bio_buf;
+				BIO_get_mem_ptr(bio_out, &bio_buf);
+				MAKE_STD_ZVAL(zpkey);
+				ZVAL_STRINGL(zpkey, bio_buf->data, bio_buf->length, 1);
+				add_assoc_zval(zout, "pkey", zpkey);
+			}
+			BIO_free(bio_out);
+
+			MAKE_STD_ZVAL(zextracerts);
+			array_init(zextracerts);
+			
+			for (i=0;;i++) {
+				zval * zextracert;
+				X509* aCA = sk_X509_pop(ca);
+				if (!aCA) break;
+
+				/* fix for bug 69882 */
+				{
+					int err = ERR_peek_error();
+					if (err == OPENSSL_ERROR_X509_PRIVATE_KEY_VALUES_MISMATCH) {
+						ERR_get_error();
+					}
+				}
+
+				bio_out = BIO_new(BIO_s_mem());
+				if (PEM_write_bio_X509(bio_out, aCA)) {
+					BUF_MEM *bio_buf;
+					BIO_get_mem_ptr(bio_out, &bio_buf);
+					MAKE_STD_ZVAL(zextracert);
+					ZVAL_STRINGL(zextracert, bio_buf->data, bio_buf->length, 1);
+					add_index_zval(zextracerts, i, zextracert);
+					
+				}
+				BIO_free(bio_out);
+
+				X509_free(aCA);
+			}
+			if(ca) {
+				sk_X509_free(ca);
+				add_assoc_zval(zout, "extracerts", zextracerts);
+			} else {
+				zval_dtor(zextracerts);
+			}
+			
+			RETVAL_TRUE;
+			
+			PKCS12_free(p12);
+		}
+	}
+	
+  cleanup:
+	if (bio_in) {
+		BIO_free(bio_in);
+	}
+	if (pkey) {
+		EVP_PKEY_free(pkey);
+	}
+	if (cert) { 
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ x509 CSR functions */
+
+/* {{{ php_openssl_make_REQ */
+static int php_openssl_make_REQ(struct php_x509_request * req, X509_REQ * csr, zval * dn, zval * attribs TSRMLS_DC)
+{
+	STACK_OF(CONF_VALUE) * dn_sk, *attr_sk = NULL;
+	char * str, *dn_sect, *attr_sect;
+
+	dn_sect = CONF_get_string(req->req_config, req->section_name, "distinguished_name");
+	if (dn_sect == NULL) {
+		return FAILURE;
+	}
+	dn_sk = CONF_get_section(req->req_config, dn_sect);
+	if (dn_sk == NULL) { 
+		return FAILURE;
+	}
+	attr_sect = CONF_get_string(req->req_config, req->section_name, "attributes");
+	if (attr_sect == NULL) {
+		attr_sk = NULL;
+	} else {
+		attr_sk = CONF_get_section(req->req_config, attr_sect);
+		if (attr_sk == NULL) {
+			return FAILURE;
+		}
+	}
+	/* setup the version number: version 1 */
+	if (X509_REQ_set_version(csr, 0L)) {
+		int i, nid;
+		char * type;
+		CONF_VALUE * v;
+		X509_NAME * subj;
+		HashPosition hpos;
+		zval ** item;
+		
+		subj = X509_REQ_get_subject_name(csr);
+		/* apply values from the dn hash */
+		zend_hash_internal_pointer_reset_ex(HASH_OF(dn), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(dn), (void**)&item, &hpos) == SUCCESS) {
+			char * strindex = NULL; 
+			uint strindexlen = 0;
+			ulong intindex;
+			
+			zend_hash_get_current_key_ex(HASH_OF(dn), &strindex, &strindexlen, &intindex, 0, &hpos);
+
+			convert_to_string_ex(item);
+
+			if (strindex) {
+				int nid;
+
+				nid = OBJ_txt2nid(strindex);
+				if (nid != NID_undef) {
+					if (!X509_NAME_add_entry_by_NID(subj, nid, MBSTRING_UTF8, 
+								(unsigned char*)Z_STRVAL_PP(item), -1, -1, 0))
+					{
+						php_error_docref(NULL TSRMLS_CC, E_WARNING,
+							"dn: add_entry_by_NID %d -> %s (failed; check error"
+							" queue and value of string_mask OpenSSL option "
+							"if illegal characters are reported)",
+							nid, Z_STRVAL_PP(item));
+						return FAILURE;
+					}
+				} else {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "dn: %s is not a recognized name", strindex);
+				}
+			}
+			zend_hash_move_forward_ex(HASH_OF(dn), &hpos);
+		}
+
+		/* Finally apply defaults from config file */
+		for(i = 0; i < sk_CONF_VALUE_num(dn_sk); i++) {
+			int len;
+			char buffer[200 + 1]; /*200 + \0 !*/
+			
+			v = sk_CONF_VALUE_value(dn_sk, i);
+			type = v->name;
+			
+			len = strlen(type);
+			if (len < sizeof("_default")) {
+				continue;
+			}
+			len -= sizeof("_default") - 1;
+			if (strcmp("_default", type + len) != 0) {
+				continue;
+			}
+			if (len > 200) {
+				len = 200;
+			}
+			memcpy(buffer, type, len);
+			buffer[len] = '\0';
+			type = buffer;
+		
+			/* Skip past any leading X. X: X, etc to allow for multiple
+			 * instances */
+			for (str = type; *str; str++) {
+				if (*str == ':' || *str == ',' || *str == '.') {
+					str++;
+					if (*str) {
+						type = str;
+					}
+					break;
+				}
+			}
+			/* if it is already set, skip this */
+			nid = OBJ_txt2nid(type);
+			if (X509_NAME_get_index_by_NID(subj, nid, -1) >= 0) {
+				continue;
+			}
+			if (!X509_NAME_add_entry_by_txt(subj, type, MBSTRING_UTF8, (unsigned char*)v->value, -1, -1, 0)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "add_entry_by_txt %s -> %s (failed)", type, v->value);
+				return FAILURE;
+			}
+			if (!X509_NAME_entry_count(subj)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "no objects specified in config file");
+				return FAILURE;
+			}
+		}
+		if (attribs) {
+			zend_hash_internal_pointer_reset_ex(HASH_OF(attribs), &hpos);
+			while(zend_hash_get_current_data_ex(HASH_OF(attribs), (void**)&item, &hpos) == SUCCESS) {
+				char *strindex = NULL;
+				uint strindexlen;
+				ulong intindex;
+
+				zend_hash_get_current_key_ex(HASH_OF(attribs), &strindex, &strindexlen, &intindex, 0, &hpos);
+				convert_to_string_ex(item);
+
+				if (strindex) {
+					int nid;
+
+					nid = OBJ_txt2nid(strindex);
+					if (nid != NID_undef) {
+						if (!X509_NAME_add_entry_by_NID(subj, nid, MBSTRING_UTF8, (unsigned char*)Z_STRVAL_PP(item), -1, -1, 0)) {
+							php_error_docref(NULL TSRMLS_CC, E_WARNING, "attribs: add_entry_by_NID %d -> %s (failed)", nid, Z_STRVAL_PP(item));
+							return FAILURE;
+						}
+					} else {
+						php_error_docref(NULL TSRMLS_CC, E_WARNING, "dn: %s is not a recognized name", strindex);
+					}
+				}
+				zend_hash_move_forward_ex(HASH_OF(attribs), &hpos);
+			}
+			for (i = 0; i < sk_CONF_VALUE_num(attr_sk); i++) {
+				v = sk_CONF_VALUE_value(attr_sk, i);
+				/* if it is already set, skip this */
+				nid = OBJ_txt2nid(v->name);
+				if (X509_REQ_get_attr_by_NID(csr, nid, -1) >= 0) {
+					continue;
+				}
+				if (!X509_REQ_add1_attr_by_txt(csr, v->name, MBSTRING_UTF8, (unsigned char*)v->value, -1)) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+						"add1_attr_by_txt %s -> %s (failed; check error queue "
+						"and value of string_mask OpenSSL option if illegal "
+						"characters are reported)",
+						v->name, v->value);
+					return FAILURE;
+				}
+			}
+		}
+	}
+
+	X509_REQ_set_pubkey(csr, req->priv_key);
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ php_openssl_csr_from_zval */
+static X509_REQ * php_openssl_csr_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC)
+{
+	X509_REQ * csr = NULL;
+	char * filename = NULL;
+	BIO * in;
+	
+	if (resourceval) {
+		*resourceval = -1;
+	}
+	if (Z_TYPE_PP(val) == IS_RESOURCE) {
+		void * what;
+		int type;
+
+		what = zend_fetch_resource(val TSRMLS_CC, -1, "OpenSSL X.509 CSR", &type, 1, le_csr);
+		if (what) {
+			if (resourceval) {
+				*resourceval = Z_LVAL_PP(val);
+			}
+			return (X509_REQ*)what;
+		}
+		return NULL;
+	} else if (Z_TYPE_PP(val) != IS_STRING) {
+		return NULL;
+	}
+
+	if (Z_STRLEN_PP(val) > 7 && memcmp(Z_STRVAL_PP(val), "file://", sizeof("file://") - 1) == 0) {
+		filename = Z_STRVAL_PP(val) + (sizeof("file://") - 1);
+	}
+	if (filename) {
+		if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+			return NULL;
+		}
+		in = BIO_new_file(filename, "r");
+	} else {
+		in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+	}
+	csr = PEM_read_bio_X509_REQ(in, NULL,NULL,NULL);
+	BIO_free(in);
+
+	return csr;
+}
+/* }}} */
+
+/* {{{ proto bool openssl_csr_export_to_file(resource csr, string outfilename [, bool notext=true])
+   Exports a CSR to file */
+PHP_FUNCTION(openssl_csr_export_to_file)
+{
+	X509_REQ * csr;
+	zval * zcsr = NULL;
+	zend_bool notext = 1;
+	char * filename = NULL; int filename_len;
+	BIO * bio_out;
+	long csr_resource;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rp|b", &zcsr, &filename, &filename_len, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	csr = php_openssl_csr_from_zval(&zcsr, 0, &csr_resource TSRMLS_CC);
+	if (csr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get CSR from parameter 1");
+		return;
+	}
+
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		return;
+	}
+
+	bio_out = BIO_new_file(filename, "w");
+	if (bio_out) {
+		if (!notext) {
+			X509_REQ_print(bio_out, csr);
+		}
+		PEM_write_bio_X509_REQ(bio_out, csr);
+		RETVAL_TRUE;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening file %s", filename);
+	}
+
+	if (csr_resource == -1 && csr) {
+		X509_REQ_free(csr);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_csr_export(resource csr, string &out [, bool notext=true])
+   Exports a CSR to file or a var */
+PHP_FUNCTION(openssl_csr_export)
+{
+	X509_REQ * csr;
+	zval * zcsr = NULL, *zout=NULL;
+	zend_bool notext = 1;
+	BIO * bio_out;
+
+	long csr_resource;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz|b", &zcsr, &zout, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	csr = php_openssl_csr_from_zval(&zcsr, 0, &csr_resource TSRMLS_CC);
+	if (csr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get CSR from parameter 1");
+		return;
+	}
+
+	/* export to a var */
+
+	bio_out = BIO_new(BIO_s_mem());
+	if (!notext) {
+		X509_REQ_print(bio_out, csr);
+	}
+
+	if (PEM_write_bio_X509_REQ(bio_out, csr)) {
+		BUF_MEM *bio_buf;
+
+		BIO_get_mem_ptr(bio_out, &bio_buf);
+		zval_dtor(zout);
+		ZVAL_STRINGL(zout, bio_buf->data, bio_buf->length, 1);
+
+		RETVAL_TRUE;
+	}
+
+	if (csr_resource == -1 && csr) {
+		X509_REQ_free(csr);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+/* {{{ proto resource openssl_csr_sign(mixed csr, mixed x509, mixed priv_key, long days [, array config_args [, long serial]])
+   Signs a cert with another CERT */
+PHP_FUNCTION(openssl_csr_sign)
+{
+	zval ** zcert = NULL, **zcsr, **zpkey, *args = NULL;
+	long num_days;
+	long serial = 0L;
+	X509 * cert = NULL, *new_cert = NULL;
+	X509_REQ * csr;
+	EVP_PKEY * key = NULL, *priv_key = NULL;
+	long csr_resource, certresource = 0, keyresource = -1;
+	int i;
+	struct php_x509_request req;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ZZ!Zl|a!l", &zcsr, &zcert, &zpkey, &num_days, &args, &serial) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	PHP_SSL_REQ_INIT(&req);
+	
+	csr = php_openssl_csr_from_zval(zcsr, 0, &csr_resource TSRMLS_CC);
+	if (csr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get CSR from parameter 1");
+		return;
+	}
+	if (zcert) {
+		cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+		if (cert == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 2");
+			goto cleanup;
+		}
+	}
+	priv_key = php_openssl_evp_from_zval(zpkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (priv_key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get private key from parameter 3");
+		goto cleanup;
+	}
+	if (cert && !X509_check_private_key(cert, priv_key)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key does not correspond to signing cert");
+		goto cleanup;
+	}
+	
+	if (PHP_SSL_REQ_PARSE(&req, args) == FAILURE) {
+		goto cleanup;
+	}
+	/* Check that the request matches the signature */
+	key = X509_REQ_get_pubkey(csr);
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error unpacking public key");
+		goto cleanup;
+	}
+	i = X509_REQ_verify(csr, key);
+
+	if (i < 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Signature verification problems");
+		goto cleanup;
+	}
+	else if (i == 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Signature did not match the certificate request");
+		goto cleanup;
+	}
+	
+	/* Now we can get on with it */
+	
+	new_cert = X509_new();
+	if (new_cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No memory");
+		goto cleanup;
+	}
+	/* Version 3 cert */
+	if (!X509_set_version(new_cert, 2))
+		goto cleanup;
+
+	ASN1_INTEGER_set(X509_get_serialNumber(new_cert), serial);
+	
+	X509_set_subject_name(new_cert, X509_REQ_get_subject_name(csr));
+
+	if (cert == NULL) {
+		cert = new_cert;
+	}
+	if (!X509_set_issuer_name(new_cert, X509_get_subject_name(cert))) {
+		goto cleanup;
+	}
+	X509_gmtime_adj(X509_get_notBefore(new_cert), 0);
+	X509_gmtime_adj(X509_get_notAfter(new_cert), (long)60*60*24*num_days);
+	i = X509_set_pubkey(new_cert, key);
+	if (!i) {
+		goto cleanup;
+	}
+	if (req.extensions_section) {
+		X509V3_CTX ctx;
+		
+		X509V3_set_ctx(&ctx, cert, new_cert, csr, NULL, 0);
+		X509V3_set_conf_lhash(&ctx, req.req_config);
+		if (!X509V3_EXT_add_conf(req.req_config, &ctx, req.extensions_section, new_cert)) {
+			goto cleanup;
+		}
+	}
+
+	/* Now sign it */
+	if (!X509_sign(new_cert, priv_key, req.digest)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to sign it");
+		goto cleanup;
+	}
+	
+	/* Succeeded; lets return the cert */
+	RETVAL_RESOURCE(zend_list_insert(new_cert, le_x509 TSRMLS_CC));
+	new_cert = NULL;
+	
+cleanup:
+
+	if (cert == new_cert) {
+		cert = NULL;
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+
+	if (keyresource == -1 && priv_key) {
+		EVP_PKEY_free(priv_key);
+	}
+	if (key) {
+		EVP_PKEY_free(key);
+	}
+	if (csr_resource == -1 && csr) {
+		X509_REQ_free(csr);
+	}
+	if (certresource == -1 && cert) { 
+		X509_free(cert);
+	}
+	if (new_cert) {
+		X509_free(new_cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_csr_new(array dn, resource &privkey [, array configargs [, array extraattribs]])
+   Generates a privkey and CSR */
+PHP_FUNCTION(openssl_csr_new)
+{
+	struct php_x509_request req;
+	zval * args = NULL, * dn, *attribs = NULL;
+	zval * out_pkey;
+	X509_REQ * csr = NULL;
+	int we_made_the_key = 1;
+	long key_resource;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "az|a!a!", &dn, &out_pkey, &args, &attribs) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+	
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS) {
+		/* Generate or use a private key */
+		if (Z_TYPE_P(out_pkey) != IS_NULL) {
+			req.priv_key = php_openssl_evp_from_zval(&out_pkey, 0, NULL, 0, &key_resource TSRMLS_CC);
+			if (req.priv_key != NULL) {
+				we_made_the_key = 0;
+			}
+		}
+		if (req.priv_key == NULL) {
+			php_openssl_generate_private_key(&req TSRMLS_CC);
+		}
+		if (req.priv_key == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to generate a private key");
+		} else {
+			csr = X509_REQ_new();
+			if (csr) {
+				if (php_openssl_make_REQ(&req, csr, dn, attribs TSRMLS_CC) == SUCCESS) {
+					X509V3_CTX ext_ctx;
+
+					X509V3_set_ctx(&ext_ctx, NULL, NULL, csr, NULL, 0);
+					X509V3_set_conf_lhash(&ext_ctx, req.req_config);
+
+					/* Add extensions */
+					if (req.request_extensions_section && !X509V3_EXT_REQ_add_conf(req.req_config,
+								&ext_ctx, req.request_extensions_section, csr))
+					{
+						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error loading extension section %s", req.request_extensions_section);
+					} else {
+						RETVAL_TRUE;
+						
+						if (X509_REQ_sign(csr, req.priv_key, req.digest)) {
+							RETVAL_RESOURCE(zend_list_insert(csr, le_csr TSRMLS_CC));
+							csr = NULL;			
+						} else {
+							php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error signing request");
+						}
+
+						if (we_made_the_key) {
+							/* and a resource for the private key */
+							zval_dtor(out_pkey);
+							ZVAL_RESOURCE(out_pkey, zend_list_insert(req.priv_key, le_key TSRMLS_CC));
+							req.priv_key = NULL; /* make sure the cleanup code doesn't zap it! */
+						} else if (key_resource != -1) {
+							req.priv_key = NULL; /* make sure the cleanup code doesn't zap it! */
+						}
+					}
+				}
+				else {
+					if (!we_made_the_key) {
+						/* if we have not made the key we are not supposed to zap it by calling dispose! */
+						req.priv_key = NULL;
+					}
+				}
+			}
+		}
+	}
+	if (csr) {
+		X509_REQ_free(csr);
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+}
+/* }}} */
+
+/* {{{ proto mixed openssl_csr_get_subject(mixed csr)
+   Returns the subject of a CERT or FALSE on error */
+PHP_FUNCTION(openssl_csr_get_subject)
+{
+	zval ** zcsr;
+	zend_bool use_shortnames = 1;
+	long csr_resource;
+	X509_NAME * subject;
+	X509_REQ * csr;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|b", &zcsr, &use_shortnames) == FAILURE) {
+		return;
+	}
+
+	csr = php_openssl_csr_from_zval(zcsr, 0, &csr_resource TSRMLS_CC);
+
+	if (csr == NULL) {
+		RETURN_FALSE;
+	}
+
+	subject = X509_REQ_get_subject_name(csr);
+
+	array_init(return_value);
+	add_assoc_name_entry(return_value, NULL, subject, use_shortnames TSRMLS_CC);
+	return;
+}
+/* }}} */
+
+/* {{{ proto mixed openssl_csr_get_public_key(mixed csr)
+	Returns the subject of a CERT or FALSE on error */
+PHP_FUNCTION(openssl_csr_get_public_key)
+{
+	zval ** zcsr;
+	zend_bool use_shortnames = 1;
+	long csr_resource;
+
+	X509_REQ * csr;
+	EVP_PKEY *tpubkey;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|b", &zcsr, &use_shortnames) == FAILURE) {
+		return;
+	}
+
+	csr = php_openssl_csr_from_zval(zcsr, 0, &csr_resource TSRMLS_CC);
+
+	if (csr == NULL) {
+		RETURN_FALSE;
+	}
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+	/* Due to changes in OpenSSL 1.1 related to locking when decoding CSR,
+	 * the pub key is not changed after assigning. It means if we pass
+	 * a private key, it will be returned including the private part.
+	 * If we duplicate it, then we get just the public part which is
+	 * the same behavior as for OpenSSL 1.0 */
+	csr = X509_REQ_dup(csr);
+#endif
+	/* Retrieve the public key from the CSR */
+	tpubkey = X509_REQ_get_pubkey(csr);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+	/* We need to free the CSR as it was duplicated */
+	X509_REQ_free(csr);
+#endif
+	RETVAL_RESOURCE(zend_list_insert(tpubkey, le_key TSRMLS_CC));
+	return;
+}
+/* }}} */
+
+/* }}} */
+
+/* {{{ EVP Public/Private key functions */
+
+/* {{{ php_openssl_evp_from_zval
+   Given a zval, coerce it into a EVP_PKEY object.
+	It can be:
+		1. private key resource from openssl_get_privatekey()
+		2. X509 resource -> public key will be extracted from it
+		3. if it starts with file:// interpreted as path to key file
+		4. interpreted as the data from the cert/key file and interpreted in same way as openssl_get_privatekey()
+		5. an array(0 => [items 2..4], 1 => passphrase)
+		6. if val is a string (possibly starting with file:///) and it is not an X509 certificate, then interpret as public key
+	NOTE: If you are requesting a private key but have not specified a passphrase, you should use an
+	empty string rather than NULL for the passphrase - NULL causes a passphrase prompt to be emitted in
+	the Apache error log!
+*/
+static EVP_PKEY * php_openssl_evp_from_zval(zval ** val, int public_key, char * passphrase, int makeresource, long * resourceval TSRMLS_DC)
+{
+	EVP_PKEY * key = NULL;
+	X509 * cert = NULL;
+	int free_cert = 0;
+	long cert_res = -1;
+	char * filename = NULL;
+	zval tmp;
+
+	Z_TYPE(tmp) = IS_NULL;
+
+#define TMP_CLEAN \
+	if (Z_TYPE(tmp) == IS_STRING) {\
+		zval_dtor(&tmp); \
+	} \
+	return NULL;
+
+	if (resourceval) {
+		*resourceval = -1;
+	}
+	if (Z_TYPE_PP(val) == IS_ARRAY) {
+		zval ** zphrase;
+		
+		/* get passphrase */
+
+		if (zend_hash_index_find(HASH_OF(*val), 1, (void **)&zphrase) == FAILURE) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key array must be of the form array(0 => key, 1 => phrase)");
+			return NULL;
+		}
+		
+		if (Z_TYPE_PP(zphrase) == IS_STRING) {
+			passphrase = Z_STRVAL_PP(zphrase);
+		} else {
+			tmp = **zphrase;
+			zval_copy_ctor(&tmp);
+			convert_to_string(&tmp);
+			passphrase = Z_STRVAL(tmp);
+		}
+
+		/* now set val to be the key param and continue */
+		if (zend_hash_index_find(HASH_OF(*val), 0, (void **)&val) == FAILURE) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key array must be of the form array(0 => key, 1 => phrase)");
+			TMP_CLEAN;
+		}
+	}
+
+	if (Z_TYPE_PP(val) == IS_RESOURCE) {
+		void * what;
+		int type;
+
+		what = zend_fetch_resource(val TSRMLS_CC, -1, "OpenSSL X.509/key", &type, 2, le_x509, le_key);
+		if (!what) {
+			TMP_CLEAN;
+		}
+		if (resourceval) { 
+			*resourceval = Z_LVAL_PP(val);
+		}
+		if (type == le_x509) {
+			/* extract key from cert, depending on public_key param */
+			cert = (X509*)what;
+			free_cert = 0;
+		} else if (type == le_key) {
+			int is_priv;
+
+			is_priv = php_openssl_is_private_key((EVP_PKEY*)what TSRMLS_CC);
+
+			/* check whether it is actually a private key if requested */
+			if (!public_key && !is_priv) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied key param is a public key");
+				TMP_CLEAN;
+			}
+
+			if (public_key && is_priv) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Don't know how to get public key from this private key");
+				TMP_CLEAN;
+			} else {
+				if (Z_TYPE(tmp) == IS_STRING) {
+					zval_dtor(&tmp);
+				}
+				/* got the key - return it */
+				return (EVP_PKEY*)what;
+			}
+		} else {
+			/* other types could be used here - eg: file pointers and read in the data from them */
+			TMP_CLEAN;
+		}
+	} else {
+		/* force it to be a string and check if it refers to a file */
+		/* passing non string values leaks, object uses toString, it returns NULL 
+		 * See bug38255.phpt 
+		 */
+		if (!(Z_TYPE_PP(val) == IS_STRING || Z_TYPE_PP(val) == IS_OBJECT)) {
+			TMP_CLEAN;
+		}
+		convert_to_string_ex(val);
+
+		if (Z_STRLEN_PP(val) > 7 && memcmp(Z_STRVAL_PP(val), "file://", sizeof("file://") - 1) == 0) {
+			filename = Z_STRVAL_PP(val) + (sizeof("file://") - 1);
+		}
+		/* it's an X509 file/cert of some kind, and we need to extract the data from that */
+		if (public_key) {
+			cert = php_openssl_x509_from_zval(val, 0, &cert_res TSRMLS_CC);
+			free_cert = (cert_res == -1);
+			/* actual extraction done later */
+			if (!cert) {
+				/* not a X509 certificate, try to retrieve public key */
+				BIO* in;
+				if (filename) {
+					in = BIO_new_file(filename, "r");
+				} else {
+					in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+				}
+				if (in == NULL) {
+					TMP_CLEAN;
+				}
+				key = PEM_read_bio_PUBKEY(in, NULL,NULL, NULL);
+				BIO_free(in);
+			}
+		} else {
+			/* we want the private key */
+			BIO *in;
+
+			if (filename) {
+				if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+					TMP_CLEAN;
+				}
+				in = BIO_new_file(filename, "r");
+			} else {
+				in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+			}
+
+			if (in == NULL) {
+				TMP_CLEAN;
+			}
+			key = PEM_read_bio_PrivateKey(in, NULL,NULL, passphrase);
+			BIO_free(in);
+		}
+	}
+
+	if (public_key && cert && key == NULL) {
+		/* extract public key from X509 cert */
+		key = (EVP_PKEY *) X509_get_pubkey(cert);
+	}
+
+	if (free_cert && cert) {
+		X509_free(cert);
+	}
+	if (key && makeresource && resourceval) {
+		*resourceval = ZEND_REGISTER_RESOURCE(NULL, key, le_key);
+	}
+	if (Z_TYPE(tmp) == IS_STRING) {
+		zval_dtor(&tmp);
+	}
+	return key;
+}
+/* }}} */
+
+/* {{{ php_openssl_generate_private_key */
+static EVP_PKEY * php_openssl_generate_private_key(struct php_x509_request * req TSRMLS_DC)
+{
+	char * randfile = NULL;
+	int egdsocket, seeded;
+	EVP_PKEY * return_val = NULL;
+	
+	if (req->priv_key_bits < MIN_KEY_LENGTH) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key length is too short; it needs to be at least %d bits, not %d",
+				MIN_KEY_LENGTH, req->priv_key_bits);
+		return NULL;
+	}
+
+	randfile = CONF_get_string(req->req_config, req->section_name, "RANDFILE");
+	php_openssl_load_rand_file(randfile, &egdsocket, &seeded TSRMLS_CC);
+	
+	if ((req->priv_key = EVP_PKEY_new()) != NULL) {
+		switch(req->priv_key_type) {
+			case OPENSSL_KEYTYPE_RSA:
+				PHP_OPENSSL_RAND_ADD_TIME();
+				if (EVP_PKEY_assign_RSA(req->priv_key, RSA_generate_key(req->priv_key_bits, 0x10001, NULL, NULL))) {
+					return_val = req->priv_key;
+				}
+				break;
+#if !defined(NO_DSA) && defined(HAVE_DSA_DEFAULT_METHOD)
+			case OPENSSL_KEYTYPE_DSA:
+				PHP_OPENSSL_RAND_ADD_TIME();
+				{
+					DSA *dsapar = DSA_generate_parameters(req->priv_key_bits, NULL, 0, NULL, NULL, NULL, NULL);
+					if (dsapar) {
+						DSA_set_method(dsapar, DSA_get_default_method());
+						if (DSA_generate_key(dsapar)) {
+							if (EVP_PKEY_assign_DSA(req->priv_key, dsapar)) {
+								return_val = req->priv_key;
+							}
+						} else {
+							DSA_free(dsapar);
+						}
+					}
+				}
+				break;
+#endif
+#if !defined(NO_DH)
+			case OPENSSL_KEYTYPE_DH:
+				PHP_OPENSSL_RAND_ADD_TIME();
+				{
+					DH *dhpar = DH_generate_parameters(req->priv_key_bits, 2, NULL, NULL);
+					int codes = 0;
+
+					if (dhpar) {
+						DH_set_method(dhpar, DH_get_default_method());
+						if (DH_check(dhpar, &codes) && codes == 0 && DH_generate_key(dhpar)) {
+							if (EVP_PKEY_assign_DH(req->priv_key, dhpar)) {
+								return_val = req->priv_key;
+							}
+						} else {
+							DH_free(dhpar);
+						}
+					}
+				}
+				break;
+#endif
+			default:
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unsupported private key type");
+		}
+	}
+
+	php_openssl_write_rand_file(randfile, egdsocket, seeded);
+	
+	if (return_val == NULL) {
+		EVP_PKEY_free(req->priv_key);
+		req->priv_key = NULL;
+		return NULL;
+	}
+	
+	return return_val;
+}
+/* }}} */
+
+/* {{{ php_openssl_is_private_key
+	Check whether the supplied key is a private key by checking if the secret prime factors are set */
+static int php_openssl_is_private_key(EVP_PKEY* pkey TSRMLS_DC)
+{
+	assert(pkey != NULL);
+
+	switch (EVP_PKEY_id(pkey)) {
+#ifndef NO_RSA
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			{
+				RSA *rsa = EVP_PKEY_get0_RSA(pkey);
+				if (rsa != NULL) {
+					const BIGNUM *p, *q;
+
+					RSA_get0_factors(rsa, &p, &q);
+					 if (p == NULL || q == NULL) {
+						return 0;
+					 }
+				}
+			}
+			break;
+#endif
+#ifndef NO_DSA
+		case EVP_PKEY_DSA:
+		case EVP_PKEY_DSA1:
+		case EVP_PKEY_DSA2:
+		case EVP_PKEY_DSA3:
+		case EVP_PKEY_DSA4:
+			{
+				DSA *dsa = EVP_PKEY_get0_DSA(pkey);
+				if (dsa != NULL) {
+					const BIGNUM *p, *q, *g, *pub_key, *priv_key;
+
+					DSA_get0_pqg(dsa, &p, &q, &g);
+					if (p == NULL || q == NULL) {
+						return 0;
+					}
+ 
+					DSA_get0_key(dsa, &pub_key, &priv_key);
+					if (priv_key == NULL) {
+						return 0;
+					}
+				}
+			}
+			break;
+#endif
+#ifndef NO_DH
+		case EVP_PKEY_DH:
+			{
+				DH *dh = EVP_PKEY_get0_DH(pkey);
+				if (dh != NULL) {
+					const BIGNUM *p, *q, *g, *pub_key, *priv_key;
+
+					DH_get0_pqg(dh, &p, &q, &g);
+					if (p == NULL) {
+						return 0;
+					}
+ 
+					DH_get0_key(dh, &pub_key, &priv_key);
+					if (priv_key == NULL) {
+						return 0;
+					}
+				}
+			}
+			break;
+#endif
+#ifdef HAVE_EVP_PKEY_EC
+		case EVP_PKEY_EC:
+			{
+				EC_KEY *ec = EVP_PKEY_get0_EC_KEY(pkey);
+				if (ec != NULL && NULL == EC_KEY_get0_private_key(ec)) {
+					return 0;
+				}
+			}
+			break;
+#endif
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+			break;
+	}
+	return 1;
+}
+/* }}} */
+
+#define OPENSSL_GET_BN(_array, _bn, _name) do { \
+		if (_bn != NULL) { \
+			int len = BN_num_bytes(_bn); \
+			char *str = emalloc(len + 1); \
+			BN_bn2bin(_bn, (unsigned char*)str); \
+			str[len] = 0; \
+			add_assoc_stringl(_array, #_name, str, len, 0); \
+		} \
+	} while (0);
+
+#define OPENSSL_PKEY_GET_BN(_type, _name) OPENSSL_GET_BN(_type, _name, _name)
+
+#define OPENSSL_PKEY_SET_BN(_data, _name) do { \
+		zval **bn; \
+		if (zend_hash_find(Z_ARRVAL_P(_data), #_name, sizeof(#_name),(void**)&bn) == SUCCESS && \
+				Z_TYPE_PP(bn) == IS_STRING) { \
+			_name = BN_bin2bn( \
+				(unsigned char*)Z_STRVAL_PP(bn), \
+				Z_STRLEN_PP(bn), NULL); \
+		} else { \
+			_name = NULL; \
+		} \
+ 	} while (0);
+
+/* {{{ php_openssl_pkey_init_rsa */
+zend_bool php_openssl_pkey_init_and_assign_rsa(EVP_PKEY *pkey, RSA *rsa, zval *data)
+{
+	BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp;
+
+	OPENSSL_PKEY_SET_BN(data, n);
+	OPENSSL_PKEY_SET_BN(data, e);
+	OPENSSL_PKEY_SET_BN(data, d);
+	if (!n || !d || !RSA_set0_key(rsa, n, e, d)) {
+		return 0;
+	}
+
+	OPENSSL_PKEY_SET_BN(data, p);
+	OPENSSL_PKEY_SET_BN(data, q);
+	if ((p || q) && !RSA_set0_factors(rsa, p, q)) {
+		return 0;
+	}
+
+	OPENSSL_PKEY_SET_BN(data, dmp1);
+	OPENSSL_PKEY_SET_BN(data, dmq1);
+	OPENSSL_PKEY_SET_BN(data, iqmp);
+	if ((dmp1 || dmq1 || iqmp) && !RSA_set0_crt_params(rsa, dmp1, dmq1, iqmp)) {
+		return 0;
+	}
+
+	if (!EVP_PKEY_assign_RSA(pkey, rsa)) {
+		return 0;
+	}
+
+	return 1;
+}
+/* }}} */
+
+/* {{{ php_openssl_pkey_init_dsa */
+zend_bool php_openssl_pkey_init_dsa(DSA *dsa, zval *data)
+{
+	BIGNUM *p, *q, *g, *priv_key, *pub_key;
+	const BIGNUM *priv_key_const, *pub_key_const;
+
+	OPENSSL_PKEY_SET_BN(data, p);
+	OPENSSL_PKEY_SET_BN(data, q);
+	OPENSSL_PKEY_SET_BN(data, g);
+	if (!p || !q || !g || !DSA_set0_pqg(dsa, p, q, g)) {
+		return 0;
+	}
+
+	OPENSSL_PKEY_SET_BN(data, pub_key);
+	OPENSSL_PKEY_SET_BN(data, priv_key);
+	if (pub_key) {
+		return DSA_set0_key(dsa, pub_key, priv_key);
+	}
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (!DSA_generate_key(dsa)) {
+		return 0;
+	}
+	/* if BN_mod_exp return -1, then DSA_generate_key succeed for failed key
+	 * so we need to double check that public key is created */
+	DSA_get0_key(dsa, &pub_key_const, &priv_key_const);
+	if (!pub_key_const || BN_is_zero(pub_key_const)) {
+		return 0;
+	}
+	/* all good */
+	return 1;
+}
+/* }}} */
+
+/* {{{ php_openssl_dh_pub_from_priv */
+static BIGNUM *php_openssl_dh_pub_from_priv(BIGNUM *priv_key, BIGNUM *g, BIGNUM *p)
+{
+	BIGNUM *pub_key, *priv_key_const_time;
+	BN_CTX *ctx;
+
+	pub_key = BN_new();
+	if (pub_key == NULL) {
+		return NULL;
+	}
+
+	priv_key_const_time = BN_new();
+	if (priv_key_const_time == NULL) {
+		BN_free(pub_key);
+		return NULL;
+	}
+	ctx = BN_CTX_new();
+	if (ctx == NULL) {
+		BN_free(pub_key);
+		BN_free(priv_key_const_time);
+		return NULL;
+	}
+
+	BN_with_flags(priv_key_const_time, priv_key, BN_FLG_CONSTTIME);
+
+	if (!BN_mod_exp_mont(pub_key, g, priv_key_const_time, p, ctx, NULL)) {
+		BN_free(pub_key);
+		pub_key = NULL;
+	}
+
+	BN_free(priv_key_const_time);
+	BN_CTX_free(ctx);
+
+	return pub_key;
+}
+/* }}} */
+
+/* {{{ php_openssl_pkey_init_dh */
+zend_bool php_openssl_pkey_init_dh(DH *dh, zval *data)
+{
+	BIGNUM *p, *q, *g, *priv_key, *pub_key;
+
+	OPENSSL_PKEY_SET_BN(data, p);
+	OPENSSL_PKEY_SET_BN(data, q);
+	OPENSSL_PKEY_SET_BN(data, g);
+	if (!p || !g || !DH_set0_pqg(dh, p, q, g)) {
+		return 0;
+	}
+
+	OPENSSL_PKEY_SET_BN(data, priv_key);
+	OPENSSL_PKEY_SET_BN(data, pub_key);
+	if (pub_key) {
+		return DH_set0_key(dh, pub_key, priv_key);
+	}
+	if (priv_key) {
+		pub_key = php_openssl_dh_pub_from_priv(priv_key, g, p);
+		if (pub_key == NULL) {
+			return 0;
+		}
+		return DH_set0_key(dh, pub_key, priv_key);
+	}
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (!DH_generate_key(dh)) {
+		return 0;
+	}
+	/* all good */
+	return 1;
+}
+/* }}} */
+
+/* {{{ proto resource openssl_pkey_new([array configargs])
+   Generates a new private key */
+PHP_FUNCTION(openssl_pkey_new)
+{
+	struct php_x509_request req;
+	zval * args = NULL;
+	zval **data;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|a!", &args) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (args && Z_TYPE_P(args) == IS_ARRAY) {
+		EVP_PKEY *pkey;
+
+		if (zend_hash_find(Z_ARRVAL_P(args), "rsa", sizeof("rsa"), (void**)&data) == SUCCESS &&
+		    Z_TYPE_PP(data) == IS_ARRAY) {
+		    pkey = EVP_PKEY_new();
+		    if (pkey) {
+				RSA *rsa = RSA_new();
+				if (rsa) {
+					if (php_openssl_pkey_init_and_assign_rsa(pkey, rsa, *data)) {
+						RETURN_RESOURCE(zend_list_insert(pkey, le_key TSRMLS_CC));
+					}
+					RSA_free(rsa);
+				}
+				EVP_PKEY_free(pkey);
+			}
+			RETURN_FALSE;
+		} else if (zend_hash_find(Z_ARRVAL_P(args), "dsa", sizeof("dsa"), (void**)&data) == SUCCESS &&
+		           Z_TYPE_PP(data) == IS_ARRAY) {
+		    pkey = EVP_PKEY_new();
+		    if (pkey) {
+				DSA *dsa = DSA_new();
+				if (dsa) {
+					if (php_openssl_pkey_init_dsa(dsa, *data)) {
+						if (EVP_PKEY_assign_DSA(pkey, dsa)) {
+							RETURN_RESOURCE(zend_list_insert(pkey, le_key TSRMLS_CC));
+						}
+					}
+					DSA_free(dsa);
+				}
+				EVP_PKEY_free(pkey);
+			}
+			RETURN_FALSE;
+		} else if (zend_hash_find(Z_ARRVAL_P(args), "dh", sizeof("dh"), (void**)&data) == SUCCESS &&
+		           Z_TYPE_PP(data) == IS_ARRAY) {
+		    pkey = EVP_PKEY_new();
+		    if (pkey) {
+				DH *dh = DH_new();
+				if (dh) {
+					if (php_openssl_pkey_init_dh(dh, *data)) {
+						if (EVP_PKEY_assign_DH(pkey, dh)) {
+							RETURN_RESOURCE(zend_list_insert(pkey, le_key TSRMLS_CC));
+						}
+					}
+					DH_free(dh);
+				}
+				EVP_PKEY_free(pkey);
+			}
+			RETURN_FALSE;
+		}
+	} 
+
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS)
+	{
+		if (php_openssl_generate_private_key(&req TSRMLS_CC)) {
+			/* pass back a key resource */
+			RETVAL_RESOURCE(zend_list_insert(req.priv_key, le_key TSRMLS_CC));
+			/* make sure the cleanup code doesn't zap it! */
+			req.priv_key = NULL;
+		}
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkey_export_to_file(mixed key, string outfilename [, string passphrase, array config_args)
+   Gets an exportable representation of a key into a file */
+PHP_FUNCTION(openssl_pkey_export_to_file)
+{
+	struct php_x509_request req;
+	zval ** zpkey, * args = NULL;
+	char * passphrase = NULL; 
+	int passphrase_len = 0;
+	char * filename = NULL; 
+	int filename_len = 0;
+	long key_resource = -1;
+	int pem_write = 0;
+	EVP_PKEY * key;
+	BIO * bio_out = NULL;
+	const EVP_CIPHER * cipher;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zp|s!a!", &zpkey, &filename, &filename_len, &passphrase, &passphrase_len, &args) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	key = php_openssl_evp_from_zval(zpkey, 0, passphrase, 0, &key_resource TSRMLS_CC);
+
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get key from parameter 1");
+		RETURN_FALSE;
+	}
+	
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		RETURN_FALSE;
+	}
+	
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS) {
+		bio_out = BIO_new_file(filename, "w");
+
+		if (passphrase && req.priv_key_encrypt) {
+			if (req.priv_key_encrypt_cipher) {
+				cipher = req.priv_key_encrypt_cipher;
+			} else {
+				cipher = (EVP_CIPHER *) EVP_des_ede3_cbc();
+			}
+		} else {
+			cipher = NULL;
+		}
+
+		switch (EVP_PKEY_base_id(key)) {
+#ifdef HAVE_EVP_PKEY_EC
+			case EVP_PKEY_EC:
+				pem_write = PEM_write_bio_ECPrivateKey(bio_out, EVP_PKEY_get0_EC_KEY(key), cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+#endif
+			default:
+				pem_write = PEM_write_bio_PrivateKey(bio_out, key, cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+		}
+
+		if (pem_write) {
+			/* Success!
+			 * If returning the output as a string, do so now */
+			RETVAL_TRUE;
+		}
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+
+	if (key_resource == -1 && key) {
+		EVP_PKEY_free(key);
+	}
+	if (bio_out) {
+		BIO_free(bio_out);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkey_export(mixed key, &mixed out [, string passphrase [, array config_args]])
+   Gets an exportable representation of a key into a string or file */
+PHP_FUNCTION(openssl_pkey_export)
+{
+	struct php_x509_request req;
+	zval ** zpkey, * args = NULL, *out;
+	char * passphrase = NULL; 
+	int passphrase_len = 0;
+	long key_resource = -1;
+	int pem_write = 0;
+	EVP_PKEY * key;
+	BIO * bio_out = NULL;
+	const EVP_CIPHER * cipher;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zz|s!a!", &zpkey, &out, &passphrase, &passphrase_len, &args) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	key = php_openssl_evp_from_zval(zpkey, 0, passphrase, 0, &key_resource TSRMLS_CC);
+
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get key from parameter 1");
+		RETURN_FALSE;
+	}
+	
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS) {
+		bio_out = BIO_new(BIO_s_mem());
+
+		if (passphrase && req.priv_key_encrypt) {
+			if (req.priv_key_encrypt_cipher) {
+				cipher = req.priv_key_encrypt_cipher;
+			} else {
+				cipher = (EVP_CIPHER *) EVP_des_ede3_cbc();
+			}
+		} else {
+			cipher = NULL;
+		}
+
+		switch (EVP_PKEY_base_id(key)) {
+#ifdef HAVE_EVP_PKEY_EC
+			case EVP_PKEY_EC:
+				pem_write = PEM_write_bio_ECPrivateKey(bio_out, EVP_PKEY_get1_EC_KEY(key), cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+#endif
+			default:
+				pem_write = PEM_write_bio_PrivateKey(bio_out, key, cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+		}
+
+		if (pem_write) {
+			/* Success!
+			 * If returning the output as a string, do so now */
+
+			char * bio_mem_ptr;
+			long bio_mem_len;
+			RETVAL_TRUE;
+
+			bio_mem_len = BIO_get_mem_data(bio_out, &bio_mem_ptr);
+			zval_dtor(out);
+			ZVAL_STRINGL(out, bio_mem_ptr, bio_mem_len, 1);
+		}
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+
+	if (key_resource == -1 && key) {
+		EVP_PKEY_free(key);
+	}
+	if (bio_out) {
+		BIO_free(bio_out);
+	}
+}
+/* }}} */
+
+/* {{{ proto int openssl_pkey_get_public(mixed cert)
+   Gets public key from X.509 certificate */
+PHP_FUNCTION(openssl_pkey_get_public)
+{
+	zval **cert;
+	EVP_PKEY *pkey;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z", &cert) == FAILURE) {
+		return;
+	}
+	Z_TYPE_P(return_value) = IS_RESOURCE;
+	pkey = php_openssl_evp_from_zval(cert, 1, NULL, 1, &Z_LVAL_P(return_value) TSRMLS_CC);
+
+	if (pkey == NULL) {
+		RETURN_FALSE;
+	}
+	zend_list_addref(Z_LVAL_P(return_value));
+}
+/* }}} */
+
+/* {{{ proto void openssl_pkey_free(int key)
+   Frees a key */
+PHP_FUNCTION(openssl_pkey_free)
+{
+	zval *key;
+	EVP_PKEY *pkey;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &key) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(pkey, EVP_PKEY *, &key, -1, "OpenSSL key", le_key);
+	zend_list_delete(Z_LVAL_P(key));
+}
+/* }}} */
+
+/* {{{ proto int openssl_pkey_get_private(string key [, string passphrase])
+   Gets private keys */
+PHP_FUNCTION(openssl_pkey_get_private)
+{
+	zval **cert;
+	EVP_PKEY *pkey;
+	char * passphrase = "";
+	int passphrase_len = sizeof("")-1;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|s", &cert, &passphrase, &passphrase_len) == FAILURE) {
+		return;
+	}
+	Z_TYPE_P(return_value) = IS_RESOURCE;
+	pkey = php_openssl_evp_from_zval(cert, 0, passphrase, 1, &Z_LVAL_P(return_value) TSRMLS_CC);
+
+	if (pkey == NULL) {
+		RETURN_FALSE;
+	}
+	zend_list_addref(Z_LVAL_P(return_value));
+}
+
+/* }}} */
+
+/* {{{ proto resource openssl_pkey_get_details(resource key)
+	returns an array with the key details (bits, pkey, type)*/
+PHP_FUNCTION(openssl_pkey_get_details)
+{
+	zval *key;
+	EVP_PKEY *pkey;
+	BIO *out;
+	unsigned int pbio_len;
+	char *pbio;
+	long ktype;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &key) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(pkey, EVP_PKEY *, &key, -1, "OpenSSL key", le_key);
+	if (!pkey) {
+		RETURN_FALSE;
+	}
+	out = BIO_new(BIO_s_mem());
+	PEM_write_bio_PUBKEY(out, pkey);
+	pbio_len = BIO_get_mem_data(out, &pbio);
+
+	array_init(return_value);
+	add_assoc_long(return_value, "bits", EVP_PKEY_bits(pkey));
+	add_assoc_stringl(return_value, "key", pbio, pbio_len, 1);
+	/*TODO: Use the real values once the openssl constants are used 
+	 * See the enum at the top of this file
+	 */
+	switch (EVP_PKEY_base_id(pkey)) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			{
+				RSA *rsa = EVP_PKEY_get0_RSA(pkey);
+				ktype = OPENSSL_KEYTYPE_RSA;
+
+				if (rsa != NULL) {
+					zval *z_rsa;
+					const BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp;
+
+					RSA_get0_key(rsa, &n, &e, &d);
+					RSA_get0_factors(rsa, &p, &q);
+					RSA_get0_crt_params(rsa, &dmp1, &dmq1, &iqmp);
+
+					ALLOC_INIT_ZVAL(z_rsa);
+					array_init(z_rsa);
+					OPENSSL_PKEY_GET_BN(z_rsa, n);
+					OPENSSL_PKEY_GET_BN(z_rsa, e);
+					OPENSSL_PKEY_GET_BN(z_rsa, d);
+					OPENSSL_PKEY_GET_BN(z_rsa, p);
+					OPENSSL_PKEY_GET_BN(z_rsa, q);
+					OPENSSL_PKEY_GET_BN(z_rsa, dmp1);
+					OPENSSL_PKEY_GET_BN(z_rsa, dmq1);
+					OPENSSL_PKEY_GET_BN(z_rsa, iqmp);
+					add_assoc_zval(return_value, "rsa", z_rsa);
+				}
+			}
+
+			break;	
+		case EVP_PKEY_DSA:
+		case EVP_PKEY_DSA2:
+		case EVP_PKEY_DSA3:
+		case EVP_PKEY_DSA4:
+			{
+				DSA *dsa = EVP_PKEY_get0_DSA(pkey);
+				ktype = OPENSSL_KEYTYPE_DSA;
+
+				if (dsa != NULL) {
+					zval *z_dsa;
+					const BIGNUM *p, *q, *g, *priv_key, *pub_key;
+
+					DSA_get0_pqg(dsa, &p, &q, &g);
+					DSA_get0_key(dsa, &pub_key, &priv_key);
+
+					ALLOC_INIT_ZVAL(z_dsa);
+					array_init(z_dsa);
+					OPENSSL_PKEY_GET_BN(z_dsa, p);
+					OPENSSL_PKEY_GET_BN(z_dsa, q);
+					OPENSSL_PKEY_GET_BN(z_dsa, g);
+					OPENSSL_PKEY_GET_BN(z_dsa, priv_key);
+					OPENSSL_PKEY_GET_BN(z_dsa, pub_key);
+					add_assoc_zval(return_value, "dsa", z_dsa);
+				}
+			}
+			break;
+		case EVP_PKEY_DH:
+			{
+				DH *dh = EVP_PKEY_get0_DH(pkey);
+				ktype = OPENSSL_KEYTYPE_DH;
+
+				if (dh != NULL) {
+					zval *z_dh;
+					const BIGNUM *p, *q, *g, *priv_key, *pub_key;
+
+					DH_get0_pqg(dh, &p, &q, &g);
+					DH_get0_key(dh, &pub_key, &priv_key);
+
+					ALLOC_INIT_ZVAL(z_dh);
+					array_init(z_dh);
+					OPENSSL_PKEY_GET_BN(z_dh, p);
+					OPENSSL_PKEY_GET_BN(z_dh, g);
+					OPENSSL_PKEY_GET_BN(z_dh, priv_key);
+					OPENSSL_PKEY_GET_BN(z_dh, pub_key);
+					add_assoc_zval(return_value, "dh", z_dh);
+				}
+			}
+
+			break;
+#ifdef HAVE_EVP_PKEY_EC
+		case EVP_PKEY_EC:
+			ktype = OPENSSL_KEYTYPE_EC;
+			if (EVP_PKEY_get0_EC_KEY(pkey) != NULL) {
+				zval *ec;
+				const EC_GROUP *ec_group;
+				int nid;
+				char *crv_sn;
+				ASN1_OBJECT *obj;
+				// openssl recommends a buffer length of 80
+				char oir_buf[80];
+
+				ec_group = EC_KEY_get0_group(EVP_PKEY_get1_EC_KEY(pkey));
+
+				// Curve nid (numerical identifier) used for ASN1 mapping
+				nid = EC_GROUP_get_curve_name(ec_group);
+				if (nid == NID_undef) {
+					break;
+				}
+				ALLOC_INIT_ZVAL(ec);
+				array_init(ec);
+
+				// Short object name
+				crv_sn = (char*) OBJ_nid2sn(nid);
+				if (crv_sn != NULL) {
+					add_assoc_string(ec, "curve_name", crv_sn, 1);
+				}
+
+				obj = OBJ_nid2obj(nid);
+				if (obj != NULL) {
+					int oir_len = OBJ_obj2txt(oir_buf, sizeof(oir_buf), obj, 1);
+					add_assoc_stringl(ec, "curve_oid", (char*)oir_buf, oir_len, 1);
+					ASN1_OBJECT_free(obj);
+				}
+
+				add_assoc_zval(return_value, "ec", ec);
+			}
+			break;
+#endif
+		default:
+			ktype = -1;
+			break;
+	}
+	add_assoc_long(return_value, "type", ktype);
+
+	BIO_free(out);
+}
+/* }}} */
+
+/* }}} */
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+
+/* {{{ proto string openssl_pbkdf2(string password, string salt, long key_length, long iterations [, string digest_method = "sha1"])
+   Generates a PKCS5 v2 PBKDF2 string, defaults to sha1 */
+PHP_FUNCTION(openssl_pbkdf2)
+{
+	long key_length = 0, iterations = 0;
+	char *password; int password_len;
+	char *salt; int salt_len;
+	char *method; int method_len = 0;
+	unsigned char *out_buffer;
+
+	const EVP_MD *digest;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssll|s",
+				&password, &password_len,
+				&salt, &salt_len,
+				&key_length, &iterations,
+				&method, &method_len) == FAILURE) {
+		return;
+	}
+
+	if (key_length <= 0 || key_length > INT_MAX) {
+		RETURN_FALSE;
+	}
+
+	if (method_len) {
+		digest = EVP_get_digestbyname(method);
+	} else {
+		digest = EVP_sha1();
+	}
+
+	if (!digest) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		RETURN_FALSE;
+	}
+
+	out_buffer = emalloc(key_length + 1);
+	out_buffer[key_length] = '\0';
+
+	if (PKCS5_PBKDF2_HMAC(password, password_len, (unsigned char *)salt, salt_len, iterations, digest, key_length, out_buffer) == 1) {
+		RETVAL_STRINGL((char *)out_buffer, key_length, 0);
+	} else {
+		efree(out_buffer);
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+#endif
+
+/* {{{ PKCS7 S/MIME functions */
+
+/* {{{ proto bool openssl_pkcs7_verify(string filename, long flags [, string signerscerts [, array cainfo [, string extracerts [, string content]]]])
+   Verifys that the data block is intact, the signer is who they say they are, and returns the CERTs of the signers */
+PHP_FUNCTION(openssl_pkcs7_verify)
+{
+	X509_STORE * store = NULL;
+	zval * cainfo = NULL;
+	STACK_OF(X509) *signers= NULL;
+	STACK_OF(X509) *others = NULL;
+	PKCS7 * p7 = NULL;
+	BIO * in = NULL, * datain = NULL, * dataout = NULL;
+	long flags = 0;
+	char * filename; int filename_len;
+	char * extracerts = NULL; int extracerts_len = 0;
+	char * signersfilename = NULL; int signersfilename_len = 0;
+	char * datafilename = NULL; int datafilename_len = 0;
+	
+	RETVAL_LONG(-1);
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "pl|papp", &filename, &filename_len,
+				&flags, &signersfilename, &signersfilename_len, &cainfo,
+				&extracerts, &extracerts_len, &datafilename, &datafilename_len) == FAILURE) {
+		return;
+	}
+	
+	if (extracerts) {
+		others = load_all_certs_from_file(extracerts);
+		if (others == NULL) {
+			goto clean_exit;
+		}
+	}
+
+	flags = flags & ~PKCS7_DETACHED;
+
+	store = setup_verify(cainfo TSRMLS_CC);
+
+	if (!store) {
+		goto clean_exit;
+	}
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		goto clean_exit;
+	}
+
+	in = BIO_new_file(filename, (flags & PKCS7_BINARY) ? "rb" : "r");
+	if (in == NULL) {
+		goto clean_exit;
+	}
+	p7 = SMIME_read_PKCS7(in, &datain);
+	if (p7 == NULL) {
+#if DEBUG_SMIME
+		zend_printf("SMIME_read_PKCS7 failed\n");
+#endif
+		goto clean_exit;
+	}
+
+	if (datafilename) {
+
+		if (php_openssl_open_base_dir_chk(datafilename TSRMLS_CC)) {
+			goto clean_exit;
+		}
+
+		dataout = BIO_new_file(datafilename, "w");
+		if (dataout == NULL) {
+			goto clean_exit;
+		}
+	}
+#if DEBUG_SMIME
+	zend_printf("Calling PKCS7 verify\n");
+#endif
+
+	if (PKCS7_verify(p7, others, store, datain, dataout, flags)) {
+
+		RETVAL_TRUE;
+
+		if (signersfilename) {
+			BIO *certout;
+		
+			if (php_openssl_open_base_dir_chk(signersfilename TSRMLS_CC)) {
+				goto clean_exit;
+			}
+		
+			certout = BIO_new_file(signersfilename, "w");
+			if (certout) {
+				int i;
+				signers = PKCS7_get0_signers(p7, NULL, flags);
+
+				for(i = 0; i < sk_X509_num(signers); i++) {
+					PEM_write_bio_X509(certout, sk_X509_value(signers, i));
+				}
+				BIO_free(certout);
+				sk_X509_free(signers);
+			} else {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "signature OK, but cannot open %s for writing", signersfilename);
+				RETVAL_LONG(-1);
+			}
+		}
+		goto clean_exit;
+	} else {
+		RETVAL_FALSE;
+	}
+clean_exit:
+	X509_STORE_free(store);
+	BIO_free(datain);
+	BIO_free(in);
+	BIO_free(dataout);
+	PKCS7_free(p7);
+	sk_X509_free(others);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs7_encrypt(string infile, string outfile, mixed recipcerts, array headers [, long flags [, long cipher]])
+   Encrypts the message in the file named infile with the certificates in recipcerts and output the result to the file named outfile */
+PHP_FUNCTION(openssl_pkcs7_encrypt)
+{
+	zval ** zrecipcerts, * zheaders = NULL;
+	STACK_OF(X509) * recipcerts = NULL;
+	BIO * infile = NULL, * outfile = NULL;
+	long flags = 0;
+	PKCS7 * p7 = NULL;
+	HashPosition hpos;
+	zval ** zcertval;
+	X509 * cert;
+	const EVP_CIPHER *cipher = NULL;
+	long cipherid = PHP_OPENSSL_CIPHER_DEFAULT;
+	uint strindexlen;
+	ulong intindex;
+	char * strindex;
+	char * infilename = NULL;	int infilename_len;
+	char * outfilename = NULL;	int outfilename_len;
+	
+	RETVAL_FALSE;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ppZa!|ll", &infilename, &infilename_len,
+				&outfilename, &outfilename_len, &zrecipcerts, &zheaders, &flags, &cipherid) == FAILURE)
+		return;
+
+	
+	if (php_openssl_open_base_dir_chk(infilename TSRMLS_CC) || php_openssl_open_base_dir_chk(outfilename TSRMLS_CC)) {
+		return;
+	}
+
+	infile = BIO_new_file(infilename, "r");
+	if (infile == NULL) {
+		goto clean_exit;
+	}
+
+	outfile = BIO_new_file(outfilename, "w");
+	if (outfile == NULL) { 
+		goto clean_exit;
+	}
+
+	recipcerts = sk_X509_new_null();
+
+	/* get certs */
+	if (Z_TYPE_PP(zrecipcerts) == IS_ARRAY) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(*zrecipcerts), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(*zrecipcerts), (void**)&zcertval, &hpos) == SUCCESS) {
+			long certresource;
+
+			cert = php_openssl_x509_from_zval(zcertval, 0, &certresource TSRMLS_CC);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+
+			if (certresource != -1) {
+				/* we shouldn't free this particular cert, as it is a resource.
+					make a copy and push that on the stack instead */
+				cert = X509_dup(cert);
+				if (cert == NULL) {
+					goto clean_exit;
+				}
+			}
+			sk_X509_push(recipcerts, cert);
+
+			zend_hash_move_forward_ex(HASH_OF(*zrecipcerts), &hpos);
+		}
+	} else {
+		/* a single certificate */
+		long certresource;
+
+		cert = php_openssl_x509_from_zval(zrecipcerts, 0, &certresource TSRMLS_CC);
+		if (cert == NULL) {
+			goto clean_exit;
+		}
+
+		if (certresource != -1) {
+			/* we shouldn't free this particular cert, as it is a resource.
+				make a copy and push that on the stack instead */
+			cert = X509_dup(cert);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+		}
+		sk_X509_push(recipcerts, cert);
+	}
+
+	/* sanity check the cipher */
+	cipher = php_openssl_get_evp_cipher_from_algo(cipherid);
+	if (cipher == NULL) {
+		/* shouldn't happen */
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to get cipher");
+		goto clean_exit;
+	}
+
+	p7 = PKCS7_encrypt(recipcerts, infile, (EVP_CIPHER*)cipher, flags);
+
+	if (p7 == NULL) {
+		goto clean_exit;
+	}
+
+	/* tack on extra headers */
+	if (zheaders) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(zheaders), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(zheaders), (void**)&zcertval, &hpos) == SUCCESS) {
+			strindex = NULL;
+			zend_hash_get_current_key_ex(HASH_OF(zheaders), &strindex, &strindexlen, &intindex, 0, &hpos);
+
+			convert_to_string_ex(zcertval);
+
+			if (strindex) {
+				BIO_printf(outfile, "%s: %s\n", strindex, Z_STRVAL_PP(zcertval));
+			} else {
+				BIO_printf(outfile, "%s\n", Z_STRVAL_PP(zcertval));
+			}
+
+			zend_hash_move_forward_ex(HASH_OF(zheaders), &hpos);
+		}
+	}
+
+	(void)BIO_reset(infile);
+
+	/* write the encrypted data */
+	SMIME_write_PKCS7(outfile, p7, infile, flags);
+
+	RETVAL_TRUE;
+
+clean_exit:
+	PKCS7_free(p7);
+	BIO_free(infile);
+	BIO_free(outfile);
+	if (recipcerts) {
+		sk_X509_pop_free(recipcerts, X509_free);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs7_sign(string infile, string outfile, mixed signcert, mixed signkey, array headers [, long flags [, string extracertsfilename]])
+   Signs the MIME message in the file named infile with signcert/signkey and output the result to file name outfile. headers lists plain text headers to exclude from the signed portion of the message, and should include to, from and subject as a minimum */
+
+PHP_FUNCTION(openssl_pkcs7_sign)
+{
+	zval ** zcert, ** zprivkey, * zheaders;
+	zval ** hval;
+	X509 * cert = NULL;
+	EVP_PKEY * privkey = NULL;
+	long flags = PKCS7_DETACHED;
+	PKCS7 * p7 = NULL;
+	BIO * infile = NULL, * outfile = NULL;
+	STACK_OF(X509) *others = NULL;
+	long certresource = -1, keyresource = -1;
+	ulong intindex;
+	uint strindexlen;
+	HashPosition hpos;
+	char * strindex;
+	char * infilename;	int infilename_len;
+	char * outfilename;	int outfilename_len;
+	char * extracertsfilename = NULL; int extracertsfilename_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ppZZa!|lp!",
+				&infilename, &infilename_len, &outfilename, &outfilename_len,
+				&zcert, &zprivkey, &zheaders, &flags, &extracertsfilename,
+				&extracertsfilename_len) == FAILURE) {
+		return;
+	}
+	
+	RETVAL_FALSE;
+
+	if (extracertsfilename) {
+		others = load_all_certs_from_file(extracertsfilename);
+		if (others == NULL) { 
+			goto clean_exit;
+		}
+	}
+
+	privkey = php_openssl_evp_from_zval(zprivkey, 0, "", 0, &keyresource TSRMLS_CC);
+	if (privkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error getting private key");
+		goto clean_exit;
+	}
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error getting cert");
+		goto clean_exit;
+	}
+
+	if (php_openssl_open_base_dir_chk(infilename TSRMLS_CC) || php_openssl_open_base_dir_chk(outfilename TSRMLS_CC)) {
+		goto clean_exit;
+	}
+
+	infile = BIO_new_file(infilename, "r");
+	if (infile == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening input file %s!", infilename);
+		goto clean_exit;
+	}
+
+	outfile = BIO_new_file(outfilename, "w");
+	if (outfile == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening output file %s!", outfilename);
+		goto clean_exit;
+	}
+
+	p7 = PKCS7_sign(cert, privkey, others, infile, flags);
+	if (p7 == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error creating PKCS7 structure!");
+		goto clean_exit;
+	}
+
+	(void)BIO_reset(infile);
+
+	/* tack on extra headers */
+	if (zheaders) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(zheaders), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(zheaders), (void**)&hval, &hpos) == SUCCESS) {
+			strindex = NULL;
+			zend_hash_get_current_key_ex(HASH_OF(zheaders), &strindex, &strindexlen, &intindex, 0, &hpos);
+
+			convert_to_string_ex(hval);
+
+			if (strindex) {
+				BIO_printf(outfile, "%s: %s\n", strindex, Z_STRVAL_PP(hval));
+			} else {
+				BIO_printf(outfile, "%s\n", Z_STRVAL_PP(hval));
+			}
+			zend_hash_move_forward_ex(HASH_OF(zheaders), &hpos);
+		}
+	}
+	/* write the signed data */
+	SMIME_write_PKCS7(outfile, p7, infile, flags);
+
+	RETVAL_TRUE;
+
+clean_exit:
+	PKCS7_free(p7);
+	BIO_free(infile);
+	BIO_free(outfile);
+	if (others) {
+		sk_X509_pop_free(others, X509_free);
+	}
+	if (privkey && keyresource == -1) {
+		EVP_PKEY_free(privkey);
+	}
+	if (cert && certresource == -1) {
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs7_decrypt(string infilename, string outfilename, mixed recipcert [, mixed recipkey])
+   Decrypts the S/MIME message in the file name infilename and output the results to the file name outfilename.  recipcert is a CERT for one of the recipients. recipkey specifies the private key matching recipcert, if recipcert does not include the key */
+
+PHP_FUNCTION(openssl_pkcs7_decrypt)
+{
+	zval ** recipcert, ** recipkey = NULL;
+	X509 * cert = NULL;
+	EVP_PKEY * key = NULL;
+	long certresval, keyresval;
+	BIO * in = NULL, * out = NULL, * datain = NULL;
+	PKCS7 * p7 = NULL;
+	char * infilename;	int infilename_len;
+	char * outfilename;	int outfilename_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ppZ|Z", &infilename, &infilename_len,
+				&outfilename, &outfilename_len, &recipcert, &recipkey) == FAILURE) {
+		return;
+	}
+
+	RETVAL_FALSE;
+
+	cert = php_openssl_x509_from_zval(recipcert, 0, &certresval TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to coerce parameter 3 to x509 cert");
+		goto clean_exit;
+	}
+
+	key = php_openssl_evp_from_zval(recipkey ? recipkey : recipcert, 0, "", 0, &keyresval TSRMLS_CC);
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to get private key");
+		goto clean_exit;
+	}
+	
+	if (php_openssl_open_base_dir_chk(infilename TSRMLS_CC) || php_openssl_open_base_dir_chk(outfilename TSRMLS_CC)) {
+		goto clean_exit;
+	}
+
+	in = BIO_new_file(infilename, "r");
+	if (in == NULL) {
+		goto clean_exit;
+	}
+	out = BIO_new_file(outfilename, "w");
+	if (out == NULL) {
+		goto clean_exit;
+	}
+
+	p7 = SMIME_read_PKCS7(in, &datain);
+
+	if (p7 == NULL) {
+		goto clean_exit;
+	}
+	if (PKCS7_decrypt(p7, key, cert, out, PKCS7_DETACHED)) { 
+		RETVAL_TRUE;
+	}
+clean_exit:
+	PKCS7_free(p7);
+	BIO_free(datain);
+	BIO_free(in);
+	BIO_free(out);
+	if (cert && certresval == -1) {
+		X509_free(cert);
+	}
+	if (key && keyresval == -1) {
+		EVP_PKEY_free(key);
+	}
+}
+/* }}} */
+
+/* }}} */
+
+/* {{{ proto bool openssl_private_encrypt(string data, string &crypted, mixed key [, int padding])
+   Encrypts data with private key */
+PHP_FUNCTION(openssl_private_encrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf = NULL;
+	int successful = 0;
+	long keyresource = -1;
+	char * data;
+	int data_len;
+	long padding = RSA_PKCS1_PADDING;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE) { 
+		return;
+	}
+	RETVAL_FALSE;
+
+	pkey = php_openssl_evp_from_zval(key, 0, "", 0, &keyresource TSRMLS_CC);
+
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key param is not a valid private key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	cryptedbuf = emalloc(cryptedlen + 1);
+
+	switch (EVP_PKEY_id(pkey)) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			successful =  (RSA_private_encrypt(data_len, 
+						(unsigned char *)data, 
+						cryptedbuf, 
+						EVP_PKEY_get0_RSA(pkey), 
+						padding) == cryptedlen);
+			break;
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+	}
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+	if (cryptedbuf) {
+		efree(cryptedbuf);
+	}
+	if (keyresource == -1) { 
+		EVP_PKEY_free(pkey);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_private_decrypt(string data, string &decrypted, mixed key [, int padding])
+   Decrypts data with private key */
+PHP_FUNCTION(openssl_private_decrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf = NULL;
+	unsigned char *crypttemp;
+	int successful = 0;
+	long padding = RSA_PKCS1_PADDING;
+	long keyresource = -1;
+	char * data;
+	int data_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	pkey = php_openssl_evp_from_zval(key, 0, "", 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key parameter is not a valid private key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	crypttemp = emalloc(cryptedlen + 1);
+
+	switch (EVP_PKEY_id(pkey)) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			cryptedlen = RSA_private_decrypt(data_len, 
+					(unsigned char *)data, 
+					crypttemp, 
+					EVP_PKEY_get0_RSA(pkey), 
+					padding);
+			if (cryptedlen != -1) {
+				cryptedbuf = emalloc(cryptedlen + 1);
+				memcpy(cryptedbuf, crypttemp, cryptedlen);
+				successful = 1;
+			}
+			break;
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+	}
+
+	efree(crypttemp);
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	if (cryptedbuf) { 
+		efree(cryptedbuf);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_public_encrypt(string data, string &crypted, mixed key [, int padding])
+   Encrypts data with public key */
+PHP_FUNCTION(openssl_public_encrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf;
+	int successful = 0;
+	long keyresource = -1;
+	long padding = RSA_PKCS1_PADDING;
+	char * data;
+	int data_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	pkey = php_openssl_evp_from_zval(key, 1, NULL, 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key parameter is not a valid public key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	cryptedbuf = emalloc(cryptedlen + 1);
+
+	switch (EVP_PKEY_id(pkey)) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			successful = (RSA_public_encrypt(data_len, 
+						(unsigned char *)data, 
+						cryptedbuf, 
+						EVP_PKEY_get0_RSA(pkey), 
+						padding) == cryptedlen);
+			break;
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+
+	}
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	if (cryptedbuf) {
+		efree(cryptedbuf);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_public_decrypt(string data, string &crypted, resource key [, int padding])
+   Decrypts data with public key */
+PHP_FUNCTION(openssl_public_decrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf = NULL;
+	unsigned char *crypttemp;
+	int successful = 0;
+	long keyresource = -1;
+	long padding = RSA_PKCS1_PADDING;
+	char * data;
+	int data_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+	
+	pkey = php_openssl_evp_from_zval(key, 1, NULL, 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key parameter is not a valid public key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	crypttemp = emalloc(cryptedlen + 1);
+
+	switch (EVP_PKEY_id(pkey)) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			cryptedlen = RSA_public_decrypt(data_len, 
+					(unsigned char *)data, 
+					crypttemp, 
+					EVP_PKEY_get0_RSA(pkey), 
+					padding);
+			if (cryptedlen != -1) {
+				cryptedbuf = emalloc(cryptedlen + 1);
+				memcpy(cryptedbuf, crypttemp, cryptedlen);
+				successful = 1;
+			}
+			break;
+			
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+		 
+	}
+
+	efree(crypttemp);
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+
+	if (cryptedbuf) {
+		efree(cryptedbuf);
+	}
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+}
+/* }}} */
+
+/* {{{ proto mixed openssl_error_string(void)
+   Returns a description of the last error, and alters the index of the error messages. Returns false when the are no more messages */
+PHP_FUNCTION(openssl_error_string)
+{
+	char buf[512];
+	unsigned long val;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	val = ERR_get_error();
+	if (val) {
+		RETURN_STRING(ERR_error_string(val, buf), 1);
+	} else {
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_sign(string data, &string signature, mixed key[, mixed method])
+   Signs data */
+PHP_FUNCTION(openssl_sign)
+{
+	zval **key, *signature;
+	EVP_PKEY *pkey;
+	int siglen;
+	unsigned char *sigbuf;
+	long keyresource = -1;
+	char * data;
+	int data_len;
+	EVP_MD_CTX *md_ctx;
+	zval *method = NULL;
+	long signature_algo = OPENSSL_ALGO_SHA1;
+	const EVP_MD *mdtype;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|z", &data, &data_len, &signature, &key, &method) == FAILURE) {
+		return;
+	}
+	pkey = php_openssl_evp_from_zval(key, 0, "", 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied key param cannot be coerced into a private key");
+		RETURN_FALSE;
+	}
+
+	if (method == NULL || Z_TYPE_P(method) == IS_LONG) {
+		if (method != NULL) {
+			signature_algo = Z_LVAL_P(method);
+		}
+		mdtype = php_openssl_get_evp_md_from_algo(signature_algo);
+	} else if (Z_TYPE_P(method) == IS_STRING) {
+		mdtype = EVP_get_digestbyname(Z_STRVAL_P(method));
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+
+	siglen = EVP_PKEY_size(pkey);
+	sigbuf = emalloc(siglen + 1);
+
+	md_ctx = EVP_MD_CTX_create();
+	EVP_SignInit(md_ctx, mdtype);
+	EVP_SignUpdate(md_ctx, data, data_len);
+	if (EVP_SignFinal (md_ctx, sigbuf,(unsigned int *)&siglen, pkey)) {
+		zval_dtor(signature);
+		sigbuf[siglen] = '\0';
+		ZVAL_STRINGL(signature, (char *)sigbuf, siglen, 0);
+		RETVAL_TRUE;
+	} else {
+		efree(sigbuf);
+		RETVAL_FALSE;
+	}
+	EVP_MD_CTX_destroy(md_ctx);
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+}
+/* }}} */
+
+/* {{{ proto int openssl_verify(string data, string signature, mixed key[, mixed method])
+   Verifys data */
+PHP_FUNCTION(openssl_verify)
+{
+	zval **key;
+	EVP_PKEY *pkey;
+	int err;
+	EVP_MD_CTX     *md_ctx;
+	const EVP_MD *mdtype;
+	long keyresource = -1;
+	char * data;	int data_len;
+	char * signature;	int signature_len;
+	zval *method = NULL;
+	long signature_algo = OPENSSL_ALGO_SHA1;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssZ|z", &data, &data_len, &signature, &signature_len, &key, &method) == FAILURE) {
+		return;
+	}
+
+	if (method == NULL || Z_TYPE_P(method) == IS_LONG) {
+		if (method != NULL) {
+			signature_algo = Z_LVAL_P(method);
+		}
+		mdtype = php_openssl_get_evp_md_from_algo(signature_algo);
+	} else if (Z_TYPE_P(method) == IS_STRING) {
+		mdtype = EVP_get_digestbyname(Z_STRVAL_P(method));
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+
+	pkey = php_openssl_evp_from_zval(key, 1, NULL, 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied key param cannot be coerced into a public key");
+		RETURN_FALSE;
+	}
+
+	md_ctx = EVP_MD_CTX_create();
+	EVP_VerifyInit   (md_ctx, mdtype);
+	EVP_VerifyUpdate (md_ctx, data, data_len);
+	err = EVP_VerifyFinal (md_ctx, (unsigned char *)signature, signature_len, pkey);
+	EVP_MD_CTX_destroy(md_ctx);
+
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	RETURN_LONG(err);
+}
+/* }}} */
+
+/* {{{ proto int openssl_seal(string data, &string sealdata, &array ekeys, array pubkeys)
+   Seals data */
+PHP_FUNCTION(openssl_seal)
+{
+	zval *pubkeys, **pubkey, *sealdata, *ekeys;
+	HashTable *pubkeysht;
+	HashPosition pos;
+	EVP_PKEY **pkeys;
+	long * key_resources;	/* so we know what to cleanup */
+	int i, len1, len2, *eksl, nkeys;
+	unsigned char *buf = NULL, **eks;
+	char * data; int data_len;
+	char *method =NULL;
+	int method_len = 0;
+	const EVP_CIPHER *cipher;
+	EVP_CIPHER_CTX *ctx;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szza/|s", &data, &data_len, &sealdata, &ekeys, &pubkeys, &method, &method_len) == FAILURE) {
+		return;
+	}
+	
+	pubkeysht = HASH_OF(pubkeys);
+	nkeys = pubkeysht ? zend_hash_num_elements(pubkeysht) : 0;
+	if (!nkeys) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Fourth argument to openssl_seal() must be a non-empty array");
+		RETURN_FALSE;
+	}
+
+	if (method) {
+		cipher = EVP_get_cipherbyname(method);
+		if (!cipher) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+			RETURN_FALSE;
+		}
+		if (EVP_CIPHER_iv_length(cipher) > 0) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Ciphers with modes requiring IV are not supported");
+			RETURN_FALSE;
+		}
+	} else {
+		cipher = EVP_rc4();
+	}
+
+	pkeys = safe_emalloc(nkeys, sizeof(*pkeys), 0);
+	eksl = safe_emalloc(nkeys, sizeof(*eksl), 0);
+	eks = safe_emalloc(nkeys, sizeof(*eks), 0);
+	memset(eks, 0, sizeof(*eks) * nkeys);
+	key_resources = safe_emalloc(nkeys, sizeof(long), 0);
+	memset(key_resources, 0, sizeof(*key_resources) * nkeys);
+	memset(pkeys, 0, sizeof(*pkeys) * nkeys);
+
+	/* get the public keys we are using to seal this data */
+	zend_hash_internal_pointer_reset_ex(pubkeysht, &pos);
+	i = 0;
+	while (zend_hash_get_current_data_ex(pubkeysht, (void **) &pubkey,
+				&pos) == SUCCESS) {
+		pkeys[i] = php_openssl_evp_from_zval(pubkey, 1, NULL, 0, &key_resources[i] TSRMLS_CC);
+		if (pkeys[i] == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "not a public key (%dth member of pubkeys)", i+1);
+			RETVAL_FALSE;
+			goto clean_exit;
+		}
+		eks[i] = emalloc(EVP_PKEY_size(pkeys[i]) + 1);
+		zend_hash_move_forward_ex(pubkeysht, &pos);
+		i++;
+	}
+
+	ctx = EVP_CIPHER_CTX_new();
+	if (ctx == NULL || !EVP_EncryptInit(ctx,cipher,NULL,NULL)) {
+		RETVAL_FALSE;
+		EVP_CIPHER_CTX_free(ctx);
+		goto clean_exit;
+	}
+
+#if 0
+	/* Need this if allow ciphers that require initialization vector */
+	ivlen = EVP_CIPHER_CTX_iv_length(ctx);
+	iv = ivlen ? emalloc(ivlen + 1) : NULL;
+#endif
+	/* allocate one byte extra to make room for \0 */
+	buf = emalloc(data_len + EVP_CIPHER_CTX_block_size(ctx));
+	EVP_CIPHER_CTX_cleanup(ctx);
+
+	if (EVP_SealInit(ctx, cipher, eks, eksl, NULL, pkeys, nkeys) <= 0 ||
+			!EVP_SealUpdate(ctx, buf, &len1, (unsigned char *)data, data_len) ||
+			!EVP_SealFinal(ctx, buf + len1, &len2)) {
+		RETVAL_FALSE;
+		efree(buf);
+		EVP_CIPHER_CTX_free(ctx);
+		goto clean_exit;
+	}
+
+	if (len1 + len2 > 0) {
+		zval_dtor(sealdata);
+		buf[len1 + len2] = '\0';
+		buf = erealloc(buf, len1 + len2 + 1);
+		ZVAL_STRINGL(sealdata, (char *)buf, len1 + len2, 0);
+
+		zval_dtor(ekeys);
+		array_init(ekeys);
+		for (i=0; i<nkeys; i++) {
+			eks[i][eksl[i]] = '\0';
+			add_next_index_stringl(ekeys, erealloc(eks[i], eksl[i] + 1), eksl[i], 0);
+			eks[i] = NULL;
+		}
+#if 0
+		/* If allow ciphers that need IV, we need this */
+		zval_dtor(*ivec);
+		if (ivlen) {
+			iv[ivlen] = '\0';
+			ZVAL_STRINGL(*ivec, erealloc(iv, ivlen + 1), ivlen, 0);
+		} else {
+			ZVAL_EMPTY_STRING(*ivec);
+		}
+#endif
+	} else {
+		efree(buf);
+	}
+	RETVAL_LONG(len1 + len2);
+	EVP_CIPHER_CTX_free(ctx);
+
+clean_exit:
+	for (i=0; i<nkeys; i++) {
+		if (key_resources[i] == -1) {
+			EVP_PKEY_free(pkeys[i]);
+		}
+		if (eks[i]) { 
+			efree(eks[i]);
+		}
+	}
+	efree(eks);
+	efree(eksl);
+	efree(pkeys);
+	efree(key_resources);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_open(string data, &string opendata, string ekey, mixed privkey)
+   Opens data */
+PHP_FUNCTION(openssl_open)
+{
+	zval **privkey, *opendata;
+	EVP_PKEY *pkey;
+	int len1, len2;
+	unsigned char *buf;
+	long keyresource = -1;
+	EVP_CIPHER_CTX *ctx;
+	char * data;	int data_len;
+	char * ekey;	int ekey_len;
+	char *method =NULL;
+	int method_len = 0;
+	const EVP_CIPHER *cipher;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szsZ|s", &data, &data_len, &opendata, &ekey, &ekey_len, &privkey, &method, &method_len) == FAILURE) {
+		return;
+	}
+
+	pkey = php_openssl_evp_from_zval(privkey, 0, "", 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to coerce parameter 4 into a private key");
+		RETURN_FALSE;
+	}
+
+	if (method) {
+		cipher = EVP_get_cipherbyname(method);
+		if (!cipher) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+			RETURN_FALSE;
+		}
+	} else {
+		cipher = EVP_rc4();
+	}
+	
+	buf = emalloc(data_len + 1);
+
+	ctx = EVP_CIPHER_CTX_new();
+	if (EVP_OpenInit(ctx, cipher, (unsigned char *)ekey, ekey_len, NULL, pkey) && EVP_OpenUpdate(ctx, buf, &len1, (unsigned char *)data, data_len)) {
+		if (!EVP_OpenFinal(ctx, buf + len1, &len2) || (len1 + len2 == 0)) {
+			efree(buf);
+			RETVAL_FALSE;
+		} else {
+			zval_dtor(opendata);
+			buf[len1 + len2] = '\0';
+			ZVAL_STRINGL(opendata, erealloc(buf, len1 + len2 + 1), len1 + len2, 0);
+			RETVAL_TRUE;
+		}
+	} else {
+		efree(buf);
+		RETVAL_FALSE;
+	}
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	EVP_CIPHER_CTX_free(ctx);
+}
+/* }}} */
+
+
+
+static void openssl_add_method_or_alias(const OBJ_NAME *name, void *arg) /* {{{ */
+{
+	add_next_index_string((zval*)arg, (char*)name->name, 1);
+}
+/* }}} */
+
+static void openssl_add_method(const OBJ_NAME *name, void *arg) /* {{{ */
+{
+	if (name->alias == 0) {
+		add_next_index_string((zval*)arg, (char*)name->name, 1);
+	}
+}
+/* }}} */
+
+/* {{{ proto array openssl_get_md_methods([bool aliases = false])
+   Return array of available digest methods */
+PHP_FUNCTION(openssl_get_md_methods)
+{
+	zend_bool aliases = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &aliases) == FAILURE) {
+		return;
+	}
+	array_init(return_value);
+	OBJ_NAME_do_all_sorted(OBJ_NAME_TYPE_MD_METH,
+		aliases ? openssl_add_method_or_alias: openssl_add_method, 
+		return_value);
+}
+/* }}} */
+
+/* {{{ proto array openssl_get_cipher_methods([bool aliases = false])
+   Return array of available cipher methods */
+PHP_FUNCTION(openssl_get_cipher_methods)
+{
+	zend_bool aliases = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &aliases) == FAILURE) {
+		return;
+	}
+	array_init(return_value);
+	OBJ_NAME_do_all_sorted(OBJ_NAME_TYPE_CIPHER_METH,
+		aliases ? openssl_add_method_or_alias: openssl_add_method, 
+		return_value);
+}
+/* }}} */
+
+/* {{{ proto string openssl_digest(string data, string method [, bool raw_output=false])
+   Computes digest hash value for given data using given method, returns raw or binhex encoded string */
+PHP_FUNCTION(openssl_digest)
+{
+	zend_bool raw_output = 0;
+	char *data, *method;
+	int data_len, method_len;
+	const EVP_MD *mdtype;
+	EVP_MD_CTX *md_ctx;
+	int siglen;
+	unsigned char *sigbuf;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|b", &data, &data_len, &method, &method_len, &raw_output) == FAILURE) {
+		return;
+	}
+	mdtype = EVP_get_digestbyname(method);
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		RETURN_FALSE;
+	}
+
+	siglen = EVP_MD_size(mdtype);
+	sigbuf = emalloc(siglen + 1);
+
+	md_ctx = EVP_MD_CTX_create();
+	EVP_DigestInit(md_ctx, mdtype);
+	EVP_DigestUpdate(md_ctx, (unsigned char *)data, data_len);
+	if (EVP_DigestFinal (md_ctx, (unsigned char *)sigbuf, (unsigned int *)&siglen)) {
+		if (raw_output) {
+			sigbuf[siglen] = '\0';
+			RETVAL_STRINGL((char *)sigbuf, siglen, 0);
+		} else {
+			int digest_str_len = siglen * 2;
+			char *digest_str = emalloc(digest_str_len + 1);
+
+			make_digest_ex(digest_str, sigbuf, siglen);
+			efree(sigbuf);
+			RETVAL_STRINGL(digest_str, digest_str_len, 0);
+		}
+	} else {
+		efree(sigbuf);
+		RETVAL_FALSE;
+	}
+
+	EVP_MD_CTX_destroy(md_ctx);
+}
+/* }}} */
+
+static zend_bool php_openssl_validate_iv(char **piv, int *piv_len, int iv_required_len TSRMLS_DC)
+{
+	char *iv_new;
+
+	/* Best case scenario, user behaved */
+	if (*piv_len == iv_required_len) {
+		return 0;
+	}
+
+	iv_new = ecalloc(1, iv_required_len + 1);
+
+	if (*piv_len <= 0) {
+		/* BC behavior */
+		*piv_len = iv_required_len;
+		*piv     = iv_new;
+		return 1;
+	}
+
+	if (*piv_len < iv_required_len) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "IV passed is only %d bytes long, cipher expects an IV of precisely %d bytes, padding with \\0", *piv_len, iv_required_len);
+		memcpy(iv_new, *piv, *piv_len);
+		*piv_len = iv_required_len;
+		*piv     = iv_new;
+		return 1;
+	}
+
+	php_error_docref(NULL TSRMLS_CC, E_WARNING, "IV passed is %d bytes long which is longer than the %d expected by selected cipher, truncating", *piv_len, iv_required_len);
+	memcpy(iv_new, *piv, iv_required_len);
+	*piv_len = iv_required_len;
+	*piv     = iv_new;
+	return 1;
+
+}
+
+/* {{{ proto string openssl_encrypt(string data, string method, string password [, long options=0 [, string $iv='']])
+   Encrypts given data with given method and key, returns raw or base64 encoded string */
+PHP_FUNCTION(openssl_encrypt)
+{
+	long options = 0;
+	char *data, *method, *password, *iv = "";
+	int data_len, method_len, password_len, iv_len = 0, max_iv_len;
+	const EVP_CIPHER *cipher_type;
+	EVP_CIPHER_CTX *cipher_ctx;
+	int i=0, outlen, keylen;
+	unsigned char *outbuf, *key;
+	zend_bool free_iv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss|ls", &data, &data_len, &method, &method_len, &password, &password_len, &options, &iv, &iv_len) == FAILURE) {
+		return;
+	}
+	cipher_type = EVP_get_cipherbyname(method);
+	if (!cipher_type) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	keylen = EVP_CIPHER_key_length(cipher_type);
+	if (keylen > password_len) {
+		key = emalloc(keylen);
+		memset(key, 0, keylen);
+		memcpy(key, password, password_len);
+	} else {
+		key = (unsigned char*)password;
+	}
+
+	max_iv_len = EVP_CIPHER_iv_length(cipher_type);
+	if (iv_len <= 0 && max_iv_len > 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Using an empty Initialization Vector (iv) is potentially insecure and not recommended");
+	}
+	free_iv = php_openssl_validate_iv(&iv, &iv_len, max_iv_len TSRMLS_CC);
+
+	outlen = data_len + EVP_CIPHER_block_size(cipher_type);
+	outbuf = safe_emalloc(outlen, 1, 1);
+
+	cipher_ctx = EVP_CIPHER_CTX_new();
+	if (!cipher_ctx) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to create cipher context");
+		RETURN_FALSE;
+	}
+	EVP_EncryptInit(cipher_ctx, cipher_type, NULL, NULL);
+	if (password_len > keylen) {
+		EVP_CIPHER_CTX_set_key_length(cipher_ctx, password_len);
+	}
+	EVP_EncryptInit_ex(cipher_ctx, NULL, NULL, key, (unsigned char *)iv);
+	if (options & OPENSSL_ZERO_PADDING) {
+		EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
+	}
+	if (data_len > 0) {
+		EVP_EncryptUpdate(cipher_ctx, outbuf, &i, (unsigned char *)data, data_len);
+	}
+	outlen = i;
+	if (EVP_EncryptFinal(cipher_ctx, (unsigned char *)outbuf + i, &i)) {
+		outlen += i;
+		if (options & OPENSSL_RAW_DATA) {
+			outbuf[outlen] = '\0';
+			RETVAL_STRINGL_CHECK((char *)outbuf, outlen, 0);
+		} else {
+			int base64_str_len;
+			char *base64_str;
+
+			base64_str = (char*)php_base64_encode(outbuf, outlen, &base64_str_len);
+			efree(outbuf);
+			if (!base64_str) {
+				RETVAL_FALSE;
+			} else {
+				RETVAL_STRINGL(base64_str, base64_str_len, 0);
+			}
+		}
+	} else {
+		efree(outbuf);
+		RETVAL_FALSE;
+	}
+	if (key != (unsigned char*)password) {
+		efree(key);
+	}
+	if (free_iv) {
+		efree(iv);
+	}
+	EVP_CIPHER_CTX_cleanup(cipher_ctx);
+	EVP_CIPHER_CTX_free(cipher_ctx);
+}
+/* }}} */
+
+/* {{{ proto string openssl_decrypt(string data, string method, string password [, long options=0 [, string $iv = '']])
+   Takes raw or base64 encoded string and dectupt it using given method and key */
+PHP_FUNCTION(openssl_decrypt)
+{
+	long options = 0;
+	char *data, *method, *password, *iv = "";
+	int data_len, method_len, password_len, iv_len = 0;
+	const EVP_CIPHER *cipher_type;
+	EVP_CIPHER_CTX *cipher_ctx;
+	int i, outlen, keylen;
+	unsigned char *outbuf, *key;
+	int base64_str_len;
+	char *base64_str = NULL;
+	zend_bool free_iv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss|ls", &data, &data_len, &method, &method_len, &password, &password_len, &options, &iv, &iv_len) == FAILURE) {
+		return;
+	}
+
+	if (!method_len) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	cipher_type = EVP_get_cipherbyname(method);
+	if (!cipher_type) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	if (!(options & OPENSSL_RAW_DATA)) {
+		base64_str = (char*)php_base64_decode((unsigned char*)data, data_len, &base64_str_len);
+		if (!base64_str) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to base64 decode the input");
+			RETURN_FALSE;
+		}
+		data_len = base64_str_len;
+		data = base64_str;
+	}
+
+	keylen = EVP_CIPHER_key_length(cipher_type);
+	if (keylen > password_len) {
+		key = emalloc(keylen);
+		memset(key, 0, keylen);
+		memcpy(key, password, password_len);
+	} else {
+		key = (unsigned char*)password;
+	}
+
+	free_iv = php_openssl_validate_iv(&iv, &iv_len, EVP_CIPHER_iv_length(cipher_type) TSRMLS_CC);
+
+	outlen = data_len + EVP_CIPHER_block_size(cipher_type);
+	outbuf = emalloc(outlen + 1);
+
+	cipher_ctx = EVP_CIPHER_CTX_new();
+	if (!cipher_ctx) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to create cipher context");
+		RETURN_FALSE;
+	}
+
+	EVP_DecryptInit(cipher_ctx, cipher_type, NULL, NULL);
+	if (password_len > keylen) {
+		EVP_CIPHER_CTX_set_key_length(cipher_ctx, password_len);
+	}
+	EVP_DecryptInit_ex(cipher_ctx, NULL, NULL, key, (unsigned char *)iv);
+	if (options & OPENSSL_ZERO_PADDING) {
+		EVP_CIPHER_CTX_set_padding(cipher_ctx, 0);
+	}
+	EVP_DecryptUpdate(cipher_ctx, outbuf, &i, (unsigned char *)data, data_len);
+	outlen = i;
+	if (EVP_DecryptFinal(cipher_ctx, (unsigned char *)outbuf + i, &i)) {
+		outlen += i;
+		outbuf[outlen] = '\0';
+		RETVAL_STRINGL((char *)outbuf, outlen, 0);
+	} else {
+		efree(outbuf);
+		RETVAL_FALSE;
+	}
+	if (key != (unsigned char*)password) {
+		efree(key);
+	}
+	if (free_iv) {
+		efree(iv);
+	}
+	if (base64_str) {
+		efree(base64_str);
+	}
+ 	EVP_CIPHER_CTX_cleanup(cipher_ctx);
+ 	EVP_CIPHER_CTX_free(cipher_ctx);
+}
+/* }}} */
+
+/* {{{ proto int openssl_cipher_iv_length(string $method) */
+PHP_FUNCTION(openssl_cipher_iv_length)
+{
+	char *method;
+	int method_len;
+	const EVP_CIPHER *cipher_type;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &method, &method_len) == FAILURE) {
+		return;
+	}
+
+	if (!method_len) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	cipher_type = EVP_get_cipherbyname(method);
+	if (!cipher_type) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	RETURN_LONG(EVP_CIPHER_iv_length(cipher_type));
+}
+/* }}} */
+
+
+/* {{{ proto string openssl_dh_compute_key(string pub_key, resource dh_key)
+   Computes shared secret for public value of remote DH key and local DH key */
+PHP_FUNCTION(openssl_dh_compute_key)
+{
+	zval *key;
+	char *pub_str;
+	int pub_len;
+	DH *dh;
+	EVP_PKEY *pkey;
+	BIGNUM *pub;
+	char *data;
+	int len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sr", &pub_str, &pub_len, &key) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(pkey, EVP_PKEY *, &key, -1, "OpenSSL key", le_key);
+	if (pkey == NULL) {
+		RETURN_FALSE;
+	}
+	if (EVP_PKEY_base_id(pkey) != EVP_PKEY_DH) {
+		RETURN_FALSE;
+	}
+	dh = EVP_PKEY_get0_DH(pkey);
+	if (dh == NULL) {
+		RETURN_FALSE;
+	}
+
+	pub = BN_bin2bn((unsigned char*)pub_str, pub_len, NULL);
+
+	data = emalloc(DH_size(dh) + 1);
+	len = DH_compute_key((unsigned char*)data, pub, dh);
+
+	if (len >= 0) {
+		data[len] = 0;
+		RETVAL_STRINGL(data, len, 0);
+	} else {
+		efree(data);
+		RETVAL_FALSE;
+	}
+
+	BN_free(pub);
+}
+/* }}} */
+
+/* {{{ proto string openssl_random_pseudo_bytes(integer length [, &bool returned_strong_result])
+   Returns a string of the length specified filled with random pseudo bytes */
+PHP_FUNCTION(openssl_random_pseudo_bytes)
+{
+	long buffer_length;
+	unsigned char *buffer = NULL;
+	zval *zstrong_result_returned = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|z", &buffer_length, &zstrong_result_returned) == FAILURE) {
+		return;
+	}
+
+	if (zstrong_result_returned) {
+		zval_dtor(zstrong_result_returned);
+		ZVAL_BOOL(zstrong_result_returned, 0);
+	}
+
+	if (buffer_length <= 0 || buffer_length > INT_MAX) {
+		RETURN_FALSE;
+	}
+
+	buffer = safe_emalloc(buffer_length, 1, 1);
+
+#ifdef PHP_WIN32
+	/* random/urandom equivalent on Windows */
+	if (php_win32_get_random_bytes(buffer, (size_t) buffer_length) == FAILURE){
+		efree(buffer);
+		if (zstrong_result_returned) {
+			ZVAL_BOOL(zstrong_result_returned, 0);
+		}
+		RETURN_FALSE;
+	}
+#else
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (RAND_bytes(buffer, buffer_length) <= 0) {
+		efree(buffer);
+		if (zstrong_result_returned) {
+			ZVAL_BOOL(zstrong_result_returned, 0);
+		}
+		RETURN_FALSE;
+	}
+#endif
+
+	buffer[buffer_length] = 0;
+	RETVAL_STRINGL((char *)buffer, buffer_length, 0);
+
+	if (zstrong_result_returned) {
+		ZVAL_BOOL(zstrong_result_returned, 1);
+	}
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 8
+ * c-basic-offset: 8
+ * End:
+ * vim600: sw=4 ts=4 fdm=marker
+ * vim<600: sw=4 ts=4
+ */
+

--- a/tests/expected/php/5.6.40-php56-openssl11-patch/ext/openssl/xp_ssl.c
+++ b/tests/expected/php/5.6.40-php56-openssl11-patch/ext/openssl/xp_ssl.c
@@ -1,0 +1,2486 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 5                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2016 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Wez Furlong <wez@thebrainroom.com>                          |
+  |          Daniel Lowrey <rdlowrey@php.net>                            |
+  |          Chris Wright <daverandom@php.net>                           |
+  +----------------------------------------------------------------------+
+*/
+
+/* $Id$ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "ext/standard/file.h"
+#include "ext/standard/url.h"
+#include "streams/php_streams_int.h"
+#include "ext/standard/php_smart_str.h"
+#include "php_openssl.h"
+#include "php_network.h"
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/err.h>
+
+#ifdef PHP_WIN32
+#include "win32/winutil.h"
+#include "win32/time.h"
+#include <Wincrypt.h>
+/* These are from Wincrypt.h, they conflict with OpenSSL */
+#undef X509_NAME
+#undef X509_CERT_PAIR
+#undef X509_EXTENSIONS
+#endif
+
+#ifdef NETWARE
+#include <sys/select.h>
+#endif
+
+#if !defined(OPENSSL_NO_ECDH) && OPENSSL_VERSION_NUMBER >= 0x0090800fL
+#define HAVE_ECDH 1
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x00908070L && !defined(OPENSSL_NO_TLSEXT)
+#define HAVE_SNI 1 
+#endif
+
+/* Flags for determining allowed stream crypto methods */
+#define STREAM_CRYPTO_IS_CLIENT            (1<<0)
+#define STREAM_CRYPTO_METHOD_SSLv2         (1<<1)
+#define STREAM_CRYPTO_METHOD_SSLv3         (1<<2)
+#define STREAM_CRYPTO_METHOD_TLSv1_0       (1<<3)
+#define STREAM_CRYPTO_METHOD_TLSv1_1       (1<<4)
+#define STREAM_CRYPTO_METHOD_TLSv1_2       (1<<5)
+
+/* Simplify ssl context option retrieval */
+#define GET_VER_OPT(name)               (stream->context && SUCCESS == php_stream_context_get_option(stream->context, "ssl", name, &val))
+#define GET_VER_OPT_STRING(name, str)   if (GET_VER_OPT(name)) { convert_to_string_ex(val); str = Z_STRVAL_PP(val); }
+#define GET_VER_OPT_LONG(name, num)     if (GET_VER_OPT(name)) { convert_to_long_ex(val); num = Z_LVAL_PP(val); }
+
+/* Used for peer verification in windows */
+#define PHP_X509_NAME_ENTRY_TO_UTF8(ne, i, out) ASN1_STRING_to_UTF8(&out, X509_NAME_ENTRY_get_data(X509_NAME_get_entry(ne, i)))
+
+extern php_stream* php_openssl_get_stream_from_ssl_handle(const SSL *ssl);
+extern int php_openssl_x509_fingerprint(X509 *peer, const char *method, zend_bool raw, char **out, int *out_len TSRMLS_DC);
+extern int php_openssl_get_ssl_stream_data_index();
+extern int php_openssl_get_x509_list_id(void);
+static struct timeval subtract_timeval( struct timeval a, struct timeval b );
+static int compare_timeval( struct timeval a, struct timeval b );
+static size_t php_openssl_sockop_io(int read, php_stream *stream, char *buf, size_t count TSRMLS_DC);
+
+php_stream_ops php_openssl_socket_ops;
+
+/* Certificate contexts used for server-side SNI selection */
+typedef struct _php_openssl_sni_cert_t {
+	char *name;
+	SSL_CTX *ctx;
+} php_openssl_sni_cert_t;
+
+/* Provides leaky bucket handhsake renegotiation rate-limiting  */
+typedef struct _php_openssl_handshake_bucket_t {
+	long prev_handshake;
+	long limit;
+	long window;
+	float tokens;
+	unsigned should_close;
+} php_openssl_handshake_bucket_t;
+
+/* This implementation is very closely tied to the that of the native
+ * sockets implemented in the core.
+ * Don't try this technique in other extensions!
+ * */
+typedef struct _php_openssl_netstream_data_t {
+	php_netstream_data_t s;
+	SSL *ssl_handle;
+	SSL_CTX *ctx;
+	struct timeval connect_timeout;
+	int enable_on_connect;
+	int is_client;
+	int ssl_active;
+	php_stream_xport_crypt_method_t method;
+	php_openssl_handshake_bucket_t *reneg;
+	php_openssl_sni_cert_t *sni_certs;
+	unsigned sni_cert_count;
+	char *url_name;
+	unsigned state_set:1;
+	unsigned _spare:31;
+} php_openssl_netstream_data_t;
+
+/* it doesn't matter that we do some hash traversal here, since it is done only
+ * in an error condition arising from a network connection problem */
+static int is_http_stream_talking_to_iis(php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	if (stream->wrapperdata && stream->wrapper && strcasecmp(stream->wrapper->wops->label, "HTTP") == 0) {
+		/* the wrapperdata is an array zval containing the headers */
+		zval **tmp;
+
+#define SERVER_MICROSOFT_IIS	"Server: Microsoft-IIS"
+#define SERVER_GOOGLE "Server: GFE/"
+		
+		zend_hash_internal_pointer_reset(Z_ARRVAL_P(stream->wrapperdata));
+		while (SUCCESS == zend_hash_get_current_data(Z_ARRVAL_P(stream->wrapperdata), (void**)&tmp)) {
+
+			if (strncasecmp(Z_STRVAL_PP(tmp), SERVER_MICROSOFT_IIS, sizeof(SERVER_MICROSOFT_IIS)-1) == 0) {
+				return 1;
+			} else if (strncasecmp(Z_STRVAL_PP(tmp), SERVER_GOOGLE, sizeof(SERVER_GOOGLE)-1) == 0) {
+				return 1;
+			}
+			
+			zend_hash_move_forward(Z_ARRVAL_P(stream->wrapperdata));
+		}
+	}
+	return 0;
+}
+/* }}} */
+
+static int handle_ssl_error(php_stream *stream, int nr_bytes, zend_bool is_init TSRMLS_DC) /* {{{ */
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	int err = SSL_get_error(sslsock->ssl_handle, nr_bytes);
+	char esbuf[512];
+	smart_str ebuf = {0};
+	unsigned long ecode;
+	int retry = 1;
+
+	switch(err) {
+		case SSL_ERROR_ZERO_RETURN:
+			/* SSL terminated (but socket may still be active) */
+			retry = 0;
+			break;
+		case SSL_ERROR_WANT_READ:
+		case SSL_ERROR_WANT_WRITE:
+			/* re-negotiation, or perhaps the SSL layer needs more
+			 * packets: retry in next iteration */
+			errno = EAGAIN;
+			retry = is_init ? 1 : sslsock->s.is_blocked;
+			break;
+		case SSL_ERROR_SYSCALL:
+			if (ERR_peek_error() == 0) {
+				if (nr_bytes == 0) {
+					if (!is_http_stream_talking_to_iis(stream TSRMLS_CC) && ERR_get_error() != 0) {
+						php_error_docref(NULL TSRMLS_CC, E_WARNING,
+								"SSL: fatal protocol error");
+					}
+					SSL_set_shutdown(sslsock->ssl_handle, SSL_SENT_SHUTDOWN|SSL_RECEIVED_SHUTDOWN);
+					stream->eof = 1;
+					retry = 0;
+				} else {
+					char *estr = php_socket_strerror(php_socket_errno(), NULL, 0);
+
+					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+							"SSL: %s", estr);
+
+					efree(estr);
+					retry = 0;
+				}
+				break;
+			}
+
+			
+			/* fall through */
+		default:
+			/* some other error */
+			ecode = ERR_get_error();
+
+			switch (ERR_GET_REASON(ecode)) {
+				case SSL_R_NO_SHARED_CIPHER:
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL_R_NO_SHARED_CIPHER: no suitable shared cipher could be used.  This could be because the server is missing an SSL certificate (local_cert context option)");
+					retry = 0;
+					break;
+
+				default:
+					do {
+						/* NULL is automatically added */
+						ERR_error_string_n(ecode, esbuf, sizeof(esbuf));
+						if (ebuf.c) {
+							smart_str_appendc(&ebuf, '\n');
+						}
+						smart_str_appends(&ebuf, esbuf);
+					} while ((ecode = ERR_get_error()) != 0);
+
+					smart_str_0(&ebuf);
+
+					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+							"SSL operation failed with code %d. %s%s",
+							err,
+							ebuf.c ? "OpenSSL Error messages:\n" : "",
+							ebuf.c ? ebuf.c : "");
+					if (ebuf.c) {
+						smart_str_free(&ebuf);
+					}
+			}
+				
+			retry = 0;
+			errno = 0;
+	}
+	return retry;
+}
+/* }}} */
+
+static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx) /* {{{ */
+{
+	php_stream *stream;
+	SSL *ssl;
+	int err, depth, ret;
+	zval **val;
+	unsigned long allowed_depth = OPENSSL_DEFAULT_STREAM_VERIFY_DEPTH;
+
+	ret = preverify_ok;
+
+	/* determine the status for the current cert */
+	err = X509_STORE_CTX_get_error(ctx);
+	depth = X509_STORE_CTX_get_error_depth(ctx);
+
+	/* conjure the stream & context to use */
+	ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+	stream = (php_stream*)SSL_get_ex_data(ssl, php_openssl_get_ssl_stream_data_index());
+
+	/* if allow_self_signed is set, make sure that verification succeeds */
+	if (err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT &&
+		GET_VER_OPT("allow_self_signed") &&
+		zend_is_true(*val)
+	) {
+		ret = 1;
+	}
+
+	/* check the depth */
+	GET_VER_OPT_LONG("verify_depth", allowed_depth);
+	if ((unsigned long)depth > allowed_depth) {
+		ret = 0;
+		X509_STORE_CTX_set_error(ctx, X509_V_ERR_CERT_CHAIN_TOO_LONG);
+	}
+
+	return ret;
+}
+/* }}} */
+
+static int php_x509_fingerprint_cmp(X509 *peer, const char *method, const char *expected TSRMLS_DC)
+{
+	char *fingerprint;
+	int fingerprint_len;
+	int result = -1;
+
+	if (php_openssl_x509_fingerprint(peer, method, 0, &fingerprint, &fingerprint_len TSRMLS_CC) == SUCCESS) {
+		result = strcasecmp(expected, fingerprint);
+		efree(fingerprint);
+	}
+
+	return result;
+}
+
+static zend_bool php_x509_fingerprint_match(X509 *peer, zval *val TSRMLS_DC)
+{
+	if (Z_TYPE_P(val) == IS_STRING) {
+		const char *method = NULL;
+
+		switch (Z_STRLEN_P(val)) {
+			case 32:
+				method = "md5";
+				break;
+
+			case 40:
+				method = "sha1";
+				break;
+		}
+
+		return method && php_x509_fingerprint_cmp(peer, method, Z_STRVAL_P(val) TSRMLS_CC) == 0;
+
+	} else if (Z_TYPE_P(val) == IS_ARRAY) {
+		HashPosition pos;
+		zval **current;
+		char *key;
+		uint key_len;
+		ulong key_index;
+
+		if (!zend_hash_num_elements(Z_ARRVAL_P(val))) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid peer_fingerprint array; [algo => fingerprint] form required");
+			return 0;
+		}
+
+		for (zend_hash_internal_pointer_reset_ex(Z_ARRVAL_P(val), &pos);
+			zend_hash_get_current_data_ex(Z_ARRVAL_P(val), (void **)&current, &pos) == SUCCESS;
+			zend_hash_move_forward_ex(Z_ARRVAL_P(val), &pos)
+		) {
+			int key_type = zend_hash_get_current_key_ex(Z_ARRVAL_P(val), &key, &key_len, &key_index, 0, &pos);
+
+			if (!(key_type == HASH_KEY_IS_STRING && Z_TYPE_PP(current) == IS_STRING)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid peer_fingerprint array; [algo => fingerprint] form required");
+				return 0;
+			}
+			if (php_x509_fingerprint_cmp(peer, key, Z_STRVAL_PP(current) TSRMLS_CC) != 0) {
+				return 0;
+			}
+		}
+
+		return 1;
+
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"Invalid peer_fingerprint value; fingerprint string or array of the form [algo => fingerprint] required");
+	}
+
+	return 0;
+}
+
+static zend_bool matches_wildcard_name(const char *subjectname, const char *certname) /* {{{ */
+{
+	char *wildcard = NULL;
+	int prefix_len, suffix_len, subject_len;
+
+	if (strcasecmp(subjectname, certname) == 0) {
+		return 1;
+	}
+
+	/* wildcard, if present, must only be present in the left-most component */
+	if (!(wildcard = strchr(certname, '*')) || memchr(certname, '.', wildcard - certname)) {
+		return 0;
+	}
+
+	/* 1) prefix, if not empty, must match subject */
+	prefix_len = wildcard - certname;
+	if (prefix_len && strncasecmp(subjectname, certname, prefix_len) != 0) {
+		return 0;
+	}
+
+	suffix_len = strlen(wildcard + 1);
+	subject_len = strlen(subjectname);
+	if (suffix_len <= subject_len) {
+		/* 2) suffix must match
+		 * 3) no . between prefix and suffix
+		 **/
+		return strcasecmp(wildcard + 1, subjectname + subject_len - suffix_len) == 0 &&
+			memchr(subjectname + prefix_len, '.', subject_len - suffix_len - prefix_len) == NULL;
+	}
+
+	return 0;
+}
+/* }}} */
+
+static zend_bool matches_san_list(X509 *peer, const char *subject_name) /* {{{ */
+{
+	int i, len;
+	unsigned char *cert_name = NULL;
+	char ipbuffer[64];
+
+	GENERAL_NAMES *alt_names = X509_get_ext_d2i(peer, NID_subject_alt_name, 0, 0);
+	int alt_name_count = sk_GENERAL_NAME_num(alt_names);
+
+	for (i = 0; i < alt_name_count; i++) {
+		GENERAL_NAME *san = sk_GENERAL_NAME_value(alt_names, i);
+
+		if (san->type == GEN_DNS) {
+			ASN1_STRING_to_UTF8(&cert_name, san->d.dNSName);
+			if (ASN1_STRING_length(san->d.dNSName) != strlen((const char*)cert_name)) {
+				OPENSSL_free(cert_name);
+				/* prevent null-byte poisoning*/
+				continue;
+			}
+
+			/* accommodate valid FQDN entries ending in "." */
+			len = strlen((const char*)cert_name);
+			if (len && strcmp((const char *)&cert_name[len-1], ".") == 0) {
+				cert_name[len-1] = '\0';
+			}
+
+			if (matches_wildcard_name(subject_name, (const char *)cert_name)) {
+				OPENSSL_free(cert_name);
+				return 1;
+			}
+			OPENSSL_free(cert_name);
+		} else if (san->type == GEN_IPADD) {
+			if (san->d.iPAddress->length == 4) {
+				sprintf(ipbuffer, "%d.%d.%d.%d",
+					san->d.iPAddress->data[0],
+					san->d.iPAddress->data[1],
+					san->d.iPAddress->data[2],
+					san->d.iPAddress->data[3]
+				);
+				if (strcasecmp(subject_name, (const char*)ipbuffer) == 0) {
+					return 1;
+				}
+			}
+			/* No, we aren't bothering to check IPv6 addresses. Why?
+			 * Because IP SAN names are officially deprecated and are
+			 * not allowed by CAs starting in 2015. Deal with it.
+			 */
+		}
+	}
+
+	return 0;
+}
+/* }}} */
+
+static zend_bool matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC) /* {{{ */
+{
+	char buf[1024];
+	X509_NAME *cert_name;
+	zend_bool is_match = 0;
+	int cert_name_len;
+
+	cert_name = X509_get_subject_name(peer);
+	cert_name_len = X509_NAME_get_text_by_NID(cert_name, NID_commonName, buf, sizeof(buf));
+
+	if (cert_name_len == -1) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate peer certificate CN");
+	} else if (cert_name_len != strlen(buf)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Peer certificate CN=`%.*s' is malformed", cert_name_len, buf);
+	} else if (matches_wildcard_name(subject_name, buf)) {
+		is_match = 1;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Peer certificate CN=`%.*s' did not match expected CN=`%s'", cert_name_len, buf, subject_name);
+	}
+
+	return is_match;
+}
+/* }}} */
+
+static int apply_peer_verification_policy(SSL *ssl, X509 *peer, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	zval **val = NULL;
+	char *peer_name = NULL;
+	int err,
+		must_verify_peer,
+		must_verify_peer_name,
+		must_verify_fingerprint,
+		has_cnmatch_ctx_opt;
+
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	must_verify_peer = GET_VER_OPT("verify_peer")
+		? zend_is_true(*val)
+		: sslsock->is_client;
+
+	has_cnmatch_ctx_opt = GET_VER_OPT("CN_match");
+	must_verify_peer_name = (has_cnmatch_ctx_opt || GET_VER_OPT("verify_peer_name"))
+		? zend_is_true(*val)
+		: sslsock->is_client;
+
+	must_verify_fingerprint = GET_VER_OPT("peer_fingerprint");
+
+	if ((must_verify_peer || must_verify_peer_name || must_verify_fingerprint) && peer == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not get peer certificate");
+		return FAILURE;
+	}
+
+	/* Verify the peer against using CA file/path settings */
+	if (must_verify_peer) {
+		err = SSL_get_verify_result(ssl);
+		switch (err) {
+			case X509_V_OK:
+				/* fine */
+				break;
+			case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+				if (GET_VER_OPT("allow_self_signed") && zend_is_true(*val)) {
+					/* allowed */
+					break;
+				}
+				/* not allowed, so fall through */
+			default:
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+						"Could not verify peer: code:%d %s",
+						err,
+						X509_verify_cert_error_string(err)
+				);
+				return FAILURE;
+		}
+	}
+
+	/* If a peer_fingerprint match is required this trumps peer and peer_name verification */
+	if (must_verify_fingerprint) {
+		if (Z_TYPE_PP(val) == IS_STRING || Z_TYPE_PP(val) == IS_ARRAY) {
+			if (!php_x509_fingerprint_match(peer, *val TSRMLS_CC)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					"peer_fingerprint match failure"
+				);
+				return FAILURE;
+			}
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"Expected peer fingerprint must be a string or an array"
+			);
+			return FAILURE;
+		}
+	}
+
+	/* verify the host name presented in the peer certificate */
+	if (must_verify_peer_name) {
+		GET_VER_OPT_STRING("peer_name", peer_name);
+
+		if (has_cnmatch_ctx_opt) {
+			GET_VER_OPT_STRING("CN_match", peer_name);
+			php_error(E_DEPRECATED,
+				"the 'CN_match' SSL context option is deprecated in favor of 'peer_name'"
+			);
+		}
+		/* If no peer name was specified we use the autodetected url name in client environments */
+		if (peer_name == NULL && sslsock->is_client) {
+			peer_name = sslsock->url_name;
+		}
+
+		if (peer_name) {
+			if (matches_san_list(peer, peer_name)) {
+				return SUCCESS;
+			} else if (matches_common_name(peer, peer_name TSRMLS_CC)) {
+				return SUCCESS;
+			} else {
+				return FAILURE;
+			}
+		} else {
+			return FAILURE;
+		}
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+static int passwd_callback(char *buf, int num, int verify, void *data) /* {{{ */
+{
+	php_stream *stream = (php_stream *)data;
+	zval **val = NULL;
+	char *passphrase = NULL;
+	/* TODO: could expand this to make a callback into PHP user-space */
+
+	GET_VER_OPT_STRING("passphrase", passphrase);
+
+	if (passphrase) {
+		if (Z_STRLEN_PP(val) < num - 1) {
+			memcpy(buf, Z_STRVAL_PP(val), Z_STRLEN_PP(val)+1);
+			return Z_STRLEN_PP(val);
+		}
+	}
+	return 0;
+}
+/* }}} */
+
+#if defined(PHP_WIN32) && OPENSSL_VERSION_NUMBER >= 0x00907000L
+#define RETURN_CERT_VERIFY_FAILURE(code) X509_STORE_CTX_set_error(x509_store_ctx, code); return 0;
+static int win_cert_verify_callback(X509_STORE_CTX *x509_store_ctx, void *arg) /* {{{ */
+{
+	PCCERT_CONTEXT cert_ctx = NULL;
+	PCCERT_CHAIN_CONTEXT cert_chain_ctx = NULL;
+
+	php_stream *stream;
+	php_openssl_netstream_data_t *sslsock;
+	zval **val;
+	zend_bool is_self_signed = 0;
+
+	TSRMLS_FETCH();
+
+	stream = (php_stream*)arg;
+	sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	{ /* First convert the x509 struct back to a DER encoded buffer and let Windows decode it into a form it can work with */
+		unsigned char *der_buf = NULL;
+		int der_len;
+
+		der_len = i2d_X509(x509_store_ctx->cert, &der_buf);
+		if (der_len < 0) {
+			unsigned long err_code, e;
+			char err_buf[512];
+
+			while ((e = ERR_get_error()) != 0) {
+				err_code = e;
+			}
+
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error encoding X509 certificate: %d: %s", err_code, ERR_error_string(err_code, err_buf));
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+
+		cert_ctx = CertCreateCertificateContext(X509_ASN_ENCODING, der_buf, der_len);
+		OPENSSL_free(der_buf);
+
+		if (cert_ctx == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error creating certificate context: %s", php_win_err());
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+	}
+
+	{ /* Next fetch the relevant cert chain from the store */
+		CERT_ENHKEY_USAGE enhkey_usage = {0};
+		CERT_USAGE_MATCH cert_usage = {0};
+		CERT_CHAIN_PARA chain_params = {sizeof(CERT_CHAIN_PARA)};
+		LPSTR usages[] = {szOID_PKIX_KP_SERVER_AUTH, szOID_SERVER_GATED_CRYPTO, szOID_SGC_NETSCAPE};
+		DWORD chain_flags = 0;
+		unsigned long allowed_depth = OPENSSL_DEFAULT_STREAM_VERIFY_DEPTH;
+		unsigned int i;
+
+		enhkey_usage.cUsageIdentifier = 3;
+		enhkey_usage.rgpszUsageIdentifier = usages;
+		cert_usage.dwType = USAGE_MATCH_TYPE_OR;
+		cert_usage.Usage = enhkey_usage;
+		chain_params.RequestedUsage = cert_usage;
+		chain_flags = CERT_CHAIN_CACHE_END_CERT | CERT_CHAIN_REVOCATION_CHECK_CHAIN_EXCLUDE_ROOT;
+
+		if (!CertGetCertificateChain(NULL, cert_ctx, NULL, NULL, &chain_params, chain_flags, NULL, &cert_chain_ctx)) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error getting certificate chain: %s", php_win_err());
+			CertFreeCertificateContext(cert_ctx);
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+
+		/* check if the cert is self-signed */
+		if (cert_chain_ctx->cChain > 0 && cert_chain_ctx->rgpChain[0]->cElement > 0
+			&& (cert_chain_ctx->rgpChain[0]->rgpElement[0]->TrustStatus.dwInfoStatus & CERT_TRUST_IS_SELF_SIGNED) != 0) {
+			is_self_signed = 1;
+		}
+
+		/* check the depth */
+		GET_VER_OPT_LONG("verify_depth", allowed_depth);
+
+		for (i = 0; i < cert_chain_ctx->cChain; i++) {
+			if (cert_chain_ctx->rgpChain[i]->cElement > allowed_depth) {
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(X509_V_ERR_CERT_CHAIN_TOO_LONG);
+			}
+		}
+	}
+
+	{ /* Then verify it against a policy */
+		SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_policy_params = {sizeof(SSL_EXTRA_CERT_CHAIN_POLICY_PARA)};
+		CERT_CHAIN_POLICY_PARA chain_policy_params = {sizeof(CERT_CHAIN_POLICY_PARA)};
+		CERT_CHAIN_POLICY_STATUS chain_policy_status = {sizeof(CERT_CHAIN_POLICY_STATUS)};
+		LPWSTR server_name = NULL;
+		BOOL verify_result;
+
+		{ /* This looks ridiculous and it is - but we validate the name ourselves using the peer_name
+		     ctx option, so just use the CN from the cert here */
+
+			X509_NAME *cert_name;
+			unsigned char *cert_name_utf8;
+			int index, cert_name_utf8_len;
+			DWORD num_wchars;
+
+			cert_name = X509_get_subject_name(x509_store_ctx->cert);
+			index = X509_NAME_get_index_by_NID(cert_name, NID_commonName, -1);
+			if (index < 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate certificate CN");
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+
+			cert_name_utf8_len = PHP_X509_NAME_ENTRY_TO_UTF8(cert_name, index, cert_name_utf8);
+
+			num_wchars = MultiByteToWideChar(CP_UTF8, 0, (char*)cert_name_utf8, -1, NULL, 0);
+			if (num_wchars == 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to convert %s to wide character string", cert_name_utf8);
+				OPENSSL_free(cert_name_utf8);
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+
+			server_name = emalloc((num_wchars * sizeof(WCHAR)) + sizeof(WCHAR));
+
+			num_wchars = MultiByteToWideChar(CP_UTF8, 0, (char*)cert_name_utf8, -1, server_name, num_wchars);
+			if (num_wchars == 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to convert %s to wide character string", cert_name_utf8);
+				efree(server_name);
+				OPENSSL_free(cert_name_utf8);
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+
+			OPENSSL_free(cert_name_utf8);
+		}
+
+		ssl_policy_params.dwAuthType = (sslsock->is_client) ? AUTHTYPE_SERVER : AUTHTYPE_CLIENT;
+		ssl_policy_params.pwszServerName = server_name;
+		chain_policy_params.pvExtraPolicyPara = &ssl_policy_params;
+
+		verify_result = CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, cert_chain_ctx, &chain_policy_params, &chain_policy_status);
+
+		efree(server_name);
+		CertFreeCertificateChain(cert_chain_ctx);
+		CertFreeCertificateContext(cert_ctx);
+
+		if (!verify_result) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error verifying certificate chain policy: %s", php_win_err());
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+
+		if (chain_policy_status.dwError != 0) {
+			/* The chain does not match the policy */
+			if (is_self_signed && chain_policy_status.dwError == CERT_E_UNTRUSTEDROOT
+				&& GET_VER_OPT("allow_self_signed") && zend_is_true(*val)) {
+				/* allow self-signed certs */
+				X509_STORE_CTX_set_error(x509_store_ctx, X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT);
+			} else {
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+		}
+	}
+
+	return 1;
+}
+/* }}} */
+#endif
+
+static long load_stream_cafile(X509_STORE *cert_store, const char *cafile TSRMLS_DC) /* {{{ */
+{
+	php_stream *stream;
+	X509 *cert;
+	BIO *buffer;
+	int buffer_active = 0;
+	char *line = NULL;
+	size_t line_len;
+	long certs_added = 0;
+
+	stream = php_stream_open_wrapper(cafile, "rb", 0, NULL);
+
+	if (stream == NULL) {
+		php_error(E_WARNING, "failed loading cafile stream: `%s'", cafile);
+		return 0;
+	} else if (stream->wrapper->is_url) {
+		php_stream_close(stream);
+		php_error(E_WARNING, "remote cafile streams are disabled for security purposes");
+		return 0;
+	}
+
+	cert_start: {
+		line = php_stream_get_line(stream, NULL, 0, &line_len);
+		if (line == NULL) {
+			goto stream_complete;
+		} else if (!strcmp(line, "-----BEGIN CERTIFICATE-----\n") ||
+			!strcmp(line, "-----BEGIN CERTIFICATE-----\r\n")
+		) {
+			buffer = BIO_new(BIO_s_mem());
+			buffer_active = 1;
+			goto cert_line;
+		} else {
+			efree(line);
+			goto cert_start;
+		}
+	}
+
+	cert_line: {
+		BIO_puts(buffer, line);
+		efree(line);
+		line = php_stream_get_line(stream, NULL, 0, &line_len);
+		if (line == NULL) {
+			goto stream_complete;
+		} else if (!strcmp(line, "-----END CERTIFICATE-----") ||
+			!strcmp(line, "-----END CERTIFICATE-----\n") ||
+			!strcmp(line, "-----END CERTIFICATE-----\r\n")
+		) {
+			goto add_cert;
+		} else {
+			goto cert_line;
+		}
+	}
+
+	add_cert: {
+		BIO_puts(buffer, line);
+		efree(line);
+		cert = PEM_read_bio_X509(buffer, NULL, 0, NULL);
+		BIO_free(buffer);
+		buffer_active = 0;
+		if (cert && X509_STORE_add_cert(cert_store, cert)) {
+			++certs_added;
+		}
+		goto cert_start;
+	}
+
+	stream_complete: {
+		php_stream_close(stream);
+		if (buffer_active == 1) {
+			BIO_free(buffer);
+		}
+	}
+
+	if (certs_added == 0) {
+		php_error(E_WARNING, "no valid certs found cafile stream: `%s'", cafile);
+	}
+
+	return certs_added;
+}
+/* }}} */
+
+static int enable_peer_verification(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	zval **val = NULL;
+	char *cafile = NULL;
+	char *capath = NULL;
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	GET_VER_OPT_STRING("cafile", cafile);
+	GET_VER_OPT_STRING("capath", capath);
+
+	if (cafile == NULL) {
+		cafile = zend_ini_string("openssl.cafile", sizeof("openssl.cafile"), 0);
+		cafile = strlen(cafile) ? cafile : NULL;
+	} else if (!sslsock->is_client) {
+		/* Servers need to load and assign CA names from the cafile */
+		STACK_OF(X509_NAME) *cert_names = SSL_load_client_CA_file(cafile);
+		if (cert_names != NULL) {
+			SSL_CTX_set_client_CA_list(ctx, cert_names);
+		} else {
+			php_error(E_WARNING, "SSL: failed loading CA names from cafile");
+			return FAILURE;
+		}
+	}
+
+	if (capath == NULL) {
+		capath = zend_ini_string("openssl.capath", sizeof("openssl.capath"), 0);
+		capath = strlen(capath) ? capath : NULL;
+	}
+
+	if (cafile || capath) {
+		if (!SSL_CTX_load_verify_locations(ctx, cafile, capath)) {
+			if (cafile && !load_stream_cafile(SSL_CTX_get_cert_store(ctx), cafile TSRMLS_CC)) {
+				return FAILURE;
+			}
+		}
+	} else {
+#if defined(PHP_WIN32) && OPENSSL_VERSION_NUMBER >= 0x00907000L
+		SSL_CTX_set_cert_verify_callback(ctx, win_cert_verify_callback, (void *)stream);
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+#else
+		if (sslsock->is_client && !SSL_CTX_set_default_verify_paths(ctx)) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"Unable to set default verify locations and no CA settings specified");
+			return FAILURE;
+		}
+#endif
+	}
+
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_callback);
+
+	return SUCCESS;
+}
+/* }}} */
+
+static void disable_peer_verification(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+}
+/* }}} */
+
+static int set_local_cert(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	zval **val = NULL;
+	char *certfile = NULL;
+
+	GET_VER_OPT_STRING("local_cert", certfile);
+
+	if (certfile) {
+		char resolved_path_buff[MAXPATHLEN];
+		const char * private_key = NULL;
+
+		if (VCWD_REALPATH(certfile, resolved_path_buff)) {
+			/* a certificate to use for authentication */
+			if (SSL_CTX_use_certificate_chain_file(ctx, resolved_path_buff) != 1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to set local cert chain file `%s'; Check that your cafile/capath settings include details of your certificate and its issuer", certfile);
+				return FAILURE;
+			}
+			GET_VER_OPT_STRING("local_pk", private_key);
+
+			if (private_key) {
+				char resolved_path_buff_pk[MAXPATHLEN];
+				if (VCWD_REALPATH(private_key, resolved_path_buff_pk)) {
+					if (SSL_CTX_use_PrivateKey_file(ctx, resolved_path_buff_pk, SSL_FILETYPE_PEM) != 1) {
+						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to set private key file `%s'", resolved_path_buff_pk);
+						return FAILURE;
+					}
+				}
+			} else {
+				if (SSL_CTX_use_PrivateKey_file(ctx, resolved_path_buff, SSL_FILETYPE_PEM) != 1) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to set private key file `%s'", resolved_path_buff);
+					return FAILURE;
+				}		
+			}
+
+#if OPENSSL_VERSION_NUMBER < 0x10001001L
+			do {
+				/* Unnecessary as of OpenSSLv1.0.1 (will segfault if used with >= 10001001 ) */
+				X509 *cert = NULL;
+				EVP_PKEY *key = NULL;
+				SSL *tmpssl = SSL_new(ctx);
+				cert = SSL_get_certificate(tmpssl);
+
+				if (cert) {
+					key = X509_get_pubkey(cert);
+					EVP_PKEY_copy_parameters(key, SSL_get_privatekey(tmpssl));
+					EVP_PKEY_free(key);
+				}
+				SSL_free(tmpssl);
+			} while (0);
+#endif
+			if (!SSL_CTX_check_private_key(ctx)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Private key does not match certificate!");
+			}
+		}
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+static const SSL_METHOD *php_select_crypto_method(long method_value, int is_client TSRMLS_DC) /* {{{ */
+{
+	if (method_value == STREAM_CRYPTO_METHOD_SSLv2) {
+#if !defined(OPENSSL_NO_SSL2) && OPENSSL_VERSION_NUMBER < 0x10100000L
+		return is_client ? SSLv2_client_method() : SSLv2_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SSLv2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (method_value == STREAM_CRYPTO_METHOD_SSLv3) {
+#ifndef OPENSSL_NO_SSL3
+		return is_client ? SSLv3_client_method() : SSLv3_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SSLv3 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_0) {
+		return is_client ? TLSv1_client_method() : TLSv1_server_method();
+	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_1) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		return is_client ? TLSv1_1_client_method() : TLSv1_1_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"TLSv1.1 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_2) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		return is_client ? TLSv1_2_client_method() : TLSv1_2_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"TLSv1.2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"Invalid crypto method");
+		return NULL;
+	}
+}
+/* }}} */
+
+static long php_get_crypto_method_ctx_flags(long method_flags TSRMLS_DC) /* {{{ */
+{
+	long ssl_ctx_options = SSL_OP_ALL;
+
+#ifndef OPENSSL_NO_SSL2
+	if (!(method_flags & STREAM_CRYPTO_METHOD_SSLv2)) {
+		ssl_ctx_options |= SSL_OP_NO_SSLv2;
+	}
+#endif
+#ifndef OPENSSL_NO_SSL3
+	if (!(method_flags & STREAM_CRYPTO_METHOD_SSLv3)) {
+		ssl_ctx_options |= SSL_OP_NO_SSLv3;
+	}
+#endif
+#ifndef OPENSSL_NO_TLS1
+	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_0)) {
+		ssl_ctx_options |= SSL_OP_NO_TLSv1;
+	}
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_1)) {
+		ssl_ctx_options |= SSL_OP_NO_TLSv1_1;
+	}
+
+	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_2)) {
+		ssl_ctx_options |= SSL_OP_NO_TLSv1_2;
+	}
+#endif
+
+	return ssl_ctx_options;
+}
+/* }}} */
+
+static void limit_handshake_reneg(const SSL *ssl) /* {{{ */
+{
+	php_stream *stream;
+	php_openssl_netstream_data_t *sslsock;
+	struct timeval now;
+	long elapsed_time;
+
+	stream = php_openssl_get_stream_from_ssl_handle(ssl);
+	sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	gettimeofday(&now, NULL);
+
+	/* The initial handshake is never rate-limited */
+	if (sslsock->reneg->prev_handshake == 0) {
+		sslsock->reneg->prev_handshake = now.tv_sec;
+		return;
+	}
+
+	elapsed_time = (now.tv_sec - sslsock->reneg->prev_handshake);
+	sslsock->reneg->prev_handshake = now.tv_sec;
+	sslsock->reneg->tokens -= (elapsed_time * (sslsock->reneg->limit / sslsock->reneg->window));
+
+	if (sslsock->reneg->tokens < 0) {
+		sslsock->reneg->tokens = 0;
+	}
+	++sslsock->reneg->tokens;
+
+	/* The token level exceeds our allowed limit */
+	if (sslsock->reneg->tokens > sslsock->reneg->limit) {
+		zval **val;
+
+		TSRMLS_FETCH();
+
+		sslsock->reneg->should_close = 1;
+
+		if (stream->context && SUCCESS == php_stream_context_get_option(stream->context,
+				"ssl", "reneg_limit_callback", &val)
+		) {
+			zval *param, **params[1], *retval;
+
+			MAKE_STD_ZVAL(param);
+			php_stream_to_zval(stream, param);
+			params[0] = &param;
+
+			/* Closing the stream inside this callback would segfault! */
+			stream->flags |= PHP_STREAM_FLAG_NO_FCLOSE;
+			if (FAILURE == call_user_function_ex(EG(function_table), NULL, *val, &retval, 1, params, 0, NULL TSRMLS_CC)) {
+				php_error(E_WARNING, "SSL: failed invoking reneg limit notification callback");
+			}
+			stream->flags ^= PHP_STREAM_FLAG_NO_FCLOSE;
+
+			/* If the reneg_limit_callback returned true don't auto-close */
+			if (retval != NULL && Z_TYPE_P(retval) == IS_BOOL && Z_BVAL_P(retval) == 1) {
+				sslsock->reneg->should_close = 0;
+			}
+
+			FREE_ZVAL(param);
+			if (retval != NULL) {
+				zval_ptr_dtor(&retval);
+			}
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SSL: client-initiated handshake rate limit exceeded by peer");
+		}
+	}
+}
+/* }}} */
+
+static void info_callback(const SSL *ssl, int where, int ret) /* {{{ */
+{
+	/* Rate-limit client-initiated handshake renegotiation to prevent DoS */
+	if (where & SSL_CB_HANDSHAKE_START) {
+		limit_handshake_reneg(ssl);
+	}
+}
+/* }}} */
+
+static void init_server_reneg_limit(php_stream *stream, php_openssl_netstream_data_t *sslsock) /* {{{ */
+{
+	zval **val;
+	long limit = OPENSSL_DEFAULT_RENEG_LIMIT;
+	long window = OPENSSL_DEFAULT_RENEG_WINDOW;
+
+	if (stream->context &&
+		SUCCESS == php_stream_context_get_option(stream->context,
+				"ssl", "reneg_limit", &val)
+	) {
+		convert_to_long(*val);
+		limit = Z_LVAL_PP(val);
+	}
+
+	/* No renegotiation rate-limiting */
+	if (limit < 0) {
+		return;
+	}
+
+	if (stream->context &&
+		SUCCESS == php_stream_context_get_option(stream->context,
+				"ssl", "reneg_window", &val)
+	) {
+		convert_to_long(*val);
+		window = Z_LVAL_PP(val);
+	}
+
+	sslsock->reneg = (void*)pemalloc(sizeof(php_openssl_handshake_bucket_t),
+		php_stream_is_persistent(stream)
+	);
+
+	sslsock->reneg->limit = limit;
+	sslsock->reneg->window = window;
+	sslsock->reneg->prev_handshake = 0;
+	sslsock->reneg->tokens = 0;
+	sslsock->reneg->should_close = 0;
+
+	SSL_set_info_callback(sslsock->ssl_handle, info_callback);
+}
+/* }}} */
+
+static int set_server_rsa_key(php_stream *stream, SSL_CTX *ctx TSRMLS_DC) /* {{{ */
+{
+	zval ** val;
+	int rsa_key_size;
+	RSA* rsa;
+
+	if (php_stream_context_get_option(stream->context, "ssl", "rsa_key_size", &val) == SUCCESS) {
+		rsa_key_size = (int) Z_LVAL_PP(val);
+		if ((rsa_key_size != 1) && (rsa_key_size & (rsa_key_size - 1))) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RSA key size requires a power of 2: %d", rsa_key_size);
+			rsa_key_size = 2048;
+		}
+	} else {
+		rsa_key_size = 2048;
+	}
+
+	rsa = RSA_generate_key(rsa_key_size, RSA_F4, NULL, NULL);
+
+	if (!SSL_CTX_set_tmp_rsa(ctx, rsa)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting RSA key");
+		RSA_free(rsa);
+		return FAILURE;
+	}
+
+	RSA_free(rsa);
+
+	return SUCCESS;
+}
+/* }}} */
+
+static int set_server_dh_param(SSL_CTX *ctx, char *dh_path TSRMLS_DC) /* {{{ */
+{
+	DH *dh;
+	BIO* bio;
+
+	bio = BIO_new_file(dh_path, "r");
+
+	if (bio == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid dh_param file: %s", dh_path);
+		return FAILURE;
+	}
+
+	dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
+	BIO_free(bio);
+
+	if (dh == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed reading DH params from file: %s", dh_path);
+		return FAILURE;
+	}
+
+	if (SSL_CTX_set_tmp_dh(ctx, dh) < 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "DH param assignment failed");
+		DH_free(dh);
+		return FAILURE;
+	}
+
+	DH_free(dh);
+
+	return SUCCESS;
+}
+/* }}} */
+
+#ifdef HAVE_ECDH
+static int set_server_ecdh_curve(php_stream *stream, SSL_CTX *ctx TSRMLS_DC) /* {{{ */
+{
+	zval **val;
+	int curve_nid;
+	char *curve_str;
+	EC_KEY *ecdh;
+
+	if (php_stream_context_get_option(stream->context, "ssl", "ecdh_curve", &val) == SUCCESS) {
+		convert_to_string_ex(val);
+		curve_str = Z_STRVAL_PP(val);
+		curve_nid = OBJ_sn2nid(curve_str);
+		if (curve_nid == NID_undef) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid ECDH curve: %s", curve_str);
+			return FAILURE;
+		}
+	} else {
+		curve_nid = NID_X9_62_prime256v1;
+	}
+
+	ecdh = EC_KEY_new_by_curve_name(curve_nid);
+	if (ecdh == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"Failed generating ECDH curve");
+
+		return FAILURE;
+	}
+
+	SSL_CTX_set_tmp_ecdh(ctx, ecdh);
+	EC_KEY_free(ecdh);
+
+	return SUCCESS;
+}
+/* }}} */
+#endif
+
+static int set_server_specific_opts(php_stream *stream, SSL_CTX *ctx TSRMLS_DC) /* {{{ */
+{
+	zval **val;
+	long ssl_ctx_options = SSL_CTX_get_options(ctx);
+
+#ifdef HAVE_ECDH
+	if (FAILURE == set_server_ecdh_curve(stream, ctx TSRMLS_CC)) {
+		return FAILURE;
+	}
+#else
+	if (SUCCESS == php_stream_context_get_option(stream->context, "ssl", "ecdh_curve", &val)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"ECDH curve support not compiled into the OpenSSL lib against which PHP is linked");
+
+		return FAILURE;
+	}
+#endif
+
+	if (php_stream_context_get_option(stream->context, "ssl", "dh_param", &val) == SUCCESS) {
+		convert_to_string_ex(val);
+		if (FAILURE == set_server_dh_param(ctx,  Z_STRVAL_PP(val) TSRMLS_CC)) {
+			return FAILURE;
+		}
+	}
+
+	if (FAILURE == set_server_rsa_key(stream, ctx TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (SUCCESS == php_stream_context_get_option(
+				stream->context, "ssl", "honor_cipher_order", &val) &&
+			zend_is_true(*val)
+	) {
+		ssl_ctx_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+	}
+
+	if (SUCCESS == php_stream_context_get_option(
+				stream->context, "ssl", "single_dh_use", &val) &&
+			zend_is_true(*val)
+	) {
+		ssl_ctx_options |= SSL_OP_SINGLE_DH_USE;
+	}
+
+#ifdef HAVE_ECDH
+	if (SUCCESS == php_stream_context_get_option(
+				stream->context, "ssl", "single_ecdh_use", &val) &&
+			zend_is_true(*val)
+	) {
+		ssl_ctx_options |= SSL_OP_SINGLE_ECDH_USE;
+	}
+#endif
+
+	SSL_CTX_set_options(ctx, ssl_ctx_options);
+
+	return SUCCESS;
+}
+/* }}} */
+
+#ifdef HAVE_SNI
+static int server_sni_callback(SSL *ssl_handle, int *al, void *arg) /* {{{ */
+{
+	php_stream *stream;
+	php_openssl_netstream_data_t *sslsock;
+	unsigned i;
+	const char *server_name;
+
+	server_name = SSL_get_servername(ssl_handle, TLSEXT_NAMETYPE_host_name);
+
+	if (!server_name) {
+		return SSL_TLSEXT_ERR_NOACK;
+	}
+
+	stream = (php_stream*)SSL_get_ex_data(ssl_handle, php_openssl_get_ssl_stream_data_index());
+	sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	if (!(sslsock->sni_cert_count && sslsock->sni_certs)) {
+		return SSL_TLSEXT_ERR_NOACK;
+	}
+
+	for (i=0; i < sslsock->sni_cert_count; i++) {
+		if (matches_wildcard_name(server_name, sslsock->sni_certs[i].name)) {
+			SSL_set_SSL_CTX(ssl_handle, sslsock->sni_certs[i].ctx);
+			return SSL_TLSEXT_ERR_OK;
+		}
+	}
+
+	return SSL_TLSEXT_ERR_NOACK;
+}
+/* }}} */
+
+static int enable_server_sni(php_stream *stream, php_openssl_netstream_data_t *sslsock TSRMLS_DC)
+{
+	zval **val;
+	zval **current;
+	char *key;
+	uint key_len;
+	ulong key_index;
+	int key_type;
+	HashPosition pos;
+	int i = 0;
+	char resolved_path_buff[MAXPATHLEN];
+	SSL_CTX *ctx;
+
+	/* If the stream ctx disables SNI we're finished here */
+	if (GET_VER_OPT("SNI_enabled") && !zend_is_true(*val)) {
+		return SUCCESS;
+	}
+
+	/* If no SNI cert array is specified we're finished here */
+	if (!GET_VER_OPT("SNI_server_certs")) {
+		return SUCCESS;
+	}
+
+	if (Z_TYPE_PP(val) != IS_ARRAY) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"SNI_server_certs requires an array mapping host names to cert paths"
+		);
+		return FAILURE;
+	}
+
+	sslsock->sni_cert_count = zend_hash_num_elements(Z_ARRVAL_PP(val));
+	if (sslsock->sni_cert_count == 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"SNI_server_certs host cert array must not be empty"
+		);
+		return FAILURE;
+	}
+
+	sslsock->sni_certs = (php_openssl_sni_cert_t*)safe_pemalloc(sslsock->sni_cert_count,
+		sizeof(php_openssl_sni_cert_t), 0, php_stream_is_persistent(stream)
+	);
+	memset(sslsock->sni_certs, 0, sslsock->sni_cert_count * sizeof(php_openssl_sni_cert_t));
+
+	for (zend_hash_internal_pointer_reset_ex(Z_ARRVAL_PP(val), &pos);
+		zend_hash_get_current_data_ex(Z_ARRVAL_PP(val), (void **)&current, &pos) == SUCCESS;
+		zend_hash_move_forward_ex(Z_ARRVAL_PP(val), &pos)
+	) {
+		key_type = zend_hash_get_current_key_ex(Z_ARRVAL_PP(val), &key, &key_len, &key_index, 0, &pos);
+		if (key_type != HASH_KEY_IS_STRING) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SNI_server_certs array requires string host name keys"
+			);
+			return FAILURE;
+		}
+
+		if (VCWD_REALPATH(Z_STRVAL_PP(current), resolved_path_buff)) {
+			/* The hello method is not inherited by SSL structs when assigning a new context
+			 * inside the SNI callback, so the just use SSLv23 */
+			ctx = SSL_CTX_new(SSLv23_server_method());
+
+			if (SSL_CTX_use_certificate_chain_file(ctx, resolved_path_buff) != 1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					"failed setting local cert chain file `%s'; " \
+					"check that your cafile/capath settings include " \
+					"details of your certificate and its issuer",
+					resolved_path_buff
+				);
+				SSL_CTX_free(ctx);
+				return FAILURE;
+			} else if (SSL_CTX_use_PrivateKey_file(ctx, resolved_path_buff, SSL_FILETYPE_PEM) != 1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					"failed setting private key from file `%s'",
+					resolved_path_buff
+				);
+				SSL_CTX_free(ctx);
+				return FAILURE;
+			} else {
+				sslsock->sni_certs[i].name = pestrdup(key, php_stream_is_persistent(stream));
+				sslsock->sni_certs[i].ctx = ctx;
+				++i;
+			}
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"failed setting local cert chain file `%s'; file not found",
+				Z_STRVAL_PP(current)
+			);
+			return FAILURE;
+		}
+	}
+
+	SSL_CTX_set_tlsext_servername_callback(sslsock->ctx, server_sni_callback);
+
+	return SUCCESS;
+}
+
+static void enable_client_sni(php_stream *stream, php_openssl_netstream_data_t *sslsock) /* {{{ */
+{
+	zval **val;
+	char *sni_server_name;
+
+	/* If SNI is explicitly disabled we're finished here */
+	if (GET_VER_OPT("SNI_enabled") && !zend_is_true(*val)) {
+		return;
+	}
+
+	sni_server_name = sslsock->url_name;
+
+	GET_VER_OPT_STRING("peer_name", sni_server_name);
+
+	if (GET_VER_OPT("SNI_server_name")) {
+		GET_VER_OPT_STRING("SNI_server_name", sni_server_name);
+		php_error(E_DEPRECATED, "SNI_server_name is deprecated in favor of peer_name");
+	}
+
+	if (sni_server_name) {
+		SSL_set_tlsext_host_name(sslsock->ssl_handle, sni_server_name);
+	}
+}
+/* }}} */
+#endif
+
+int php_openssl_setup_crypto(php_stream *stream,
+		php_openssl_netstream_data_t *sslsock,
+		php_stream_xport_crypto_param *cparam
+		TSRMLS_DC) /* {{{ */
+{
+	const SSL_METHOD *method;
+	long ssl_ctx_options;
+	long method_flags;
+	char *cipherlist = NULL;
+	zval **val;
+
+	if (sslsock->ssl_handle) {
+		if (sslsock->s.is_blocked) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL/TLS already set-up for this stream");
+			return FAILURE;
+		} else {
+			return SUCCESS;
+		}
+	}
+
+	ERR_clear_error();
+
+	/* We need to do slightly different things based on client/server method
+	 * so lets remember which method was selected */
+	sslsock->is_client = cparam->inputs.method & STREAM_CRYPTO_IS_CLIENT;
+	method_flags = ((cparam->inputs.method >> 1) << 1);
+
+	/* Should we use a specific crypto method or is generic SSLv23 okay? */
+	if ((method_flags & (method_flags-1)) == 0) {
+		ssl_ctx_options = SSL_OP_ALL;
+		method = php_select_crypto_method(method_flags, sslsock->is_client TSRMLS_CC);
+		if (method == NULL) {
+			return FAILURE;
+		}
+	} else {
+		method = sslsock->is_client ? SSLv23_client_method() : SSLv23_server_method();
+		ssl_ctx_options = php_get_crypto_method_ctx_flags(method_flags TSRMLS_CC);
+		if (ssl_ctx_options == -1) {
+			return FAILURE;
+		}
+	}
+
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	sslsock->ctx = SSL_CTX_new(method);
+#else
+	/* Avoid const warning with old versions */
+	sslsock->ctx = SSL_CTX_new((SSL_METHOD*)method);
+#endif
+
+	if (sslsock->ctx == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL context creation failure");
+		return FAILURE;
+	}
+
+#if OPENSSL_VERSION_NUMBER >= 0x0090806fL
+	if (GET_VER_OPT("no_ticket") && zend_is_true(*val)) {
+		ssl_ctx_options |= SSL_OP_NO_TICKET;
+	}
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x0090605fL
+	ssl_ctx_options &= ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (!GET_VER_OPT("disable_compression") || zend_is_true(*val)) {
+		ssl_ctx_options |= SSL_OP_NO_COMPRESSION;
+	}
+#endif
+
+	if (GET_VER_OPT("verify_peer") && !zend_is_true(*val)) {
+		disable_peer_verification(sslsock->ctx, stream TSRMLS_CC);
+	} else if (FAILURE == enable_peer_verification(sslsock->ctx, stream TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	/* callback for the passphrase (for localcert) */
+	if (GET_VER_OPT("passphrase")) {
+		SSL_CTX_set_default_passwd_cb_userdata(sslsock->ctx, stream);
+		SSL_CTX_set_default_passwd_cb(sslsock->ctx, passwd_callback);
+	}
+
+	GET_VER_OPT_STRING("ciphers", cipherlist);
+#ifndef USE_OPENSSL_SYSTEM_CIPHERS
+	if (!cipherlist) {
+		cipherlist = OPENSSL_DEFAULT_STREAM_CIPHERS;
+	}
+#endif
+	if (cipherlist) {
+		if (SSL_CTX_set_cipher_list(sslsock->ctx, cipherlist) != 1) {
+			return FAILURE;
+		}
+	}
+	if (FAILURE == set_local_cert(sslsock->ctx, stream TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	SSL_CTX_set_options(sslsock->ctx, ssl_ctx_options);
+
+	if (sslsock->is_client == 0 &&
+		stream->context &&
+		FAILURE == set_server_specific_opts(stream, sslsock->ctx TSRMLS_CC)
+	) {
+		return FAILURE;
+	}
+
+	sslsock->ssl_handle = SSL_new(sslsock->ctx);
+	if (sslsock->ssl_handle == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL handle creation failure");
+		SSL_CTX_free(sslsock->ctx);
+		sslsock->ctx = NULL;
+		return FAILURE;
+	} else {
+		SSL_set_ex_data(sslsock->ssl_handle, php_openssl_get_ssl_stream_data_index(), stream);
+	}
+
+	if (!SSL_set_fd(sslsock->ssl_handle, sslsock->s.socket)) {
+		handle_ssl_error(stream, 0, 1 TSRMLS_CC);
+	}
+
+#ifdef HAVE_SNI
+	/* Enable server-side SNI */
+	if (sslsock->is_client == 0 && enable_server_sni(stream, sslsock TSRMLS_CC) == FAILURE) {
+		return FAILURE;
+	}
+#endif
+
+	/* Enable server-side handshake renegotiation rate-limiting */
+	if (sslsock->is_client == 0) {
+		init_server_reneg_limit(stream, sslsock);
+	}
+
+#ifdef SSL_MODE_RELEASE_BUFFERS
+	do {
+		long mode = SSL_get_mode(sslsock->ssl_handle);
+		SSL_set_mode(sslsock->ssl_handle, mode | SSL_MODE_RELEASE_BUFFERS);
+	} while (0);
+#endif
+
+	if (cparam->inputs.session) {
+		if (cparam->inputs.session->ops != &php_openssl_socket_ops) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied session stream must be an SSL enabled stream");
+		} else if (((php_openssl_netstream_data_t*)cparam->inputs.session->abstract)->ssl_handle == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied SSL session stream is not initialized");
+		} else {
+			SSL_copy_session_id(sslsock->ssl_handle, ((php_openssl_netstream_data_t*)cparam->inputs.session->abstract)->ssl_handle);
+		}
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+#define PHP_SSL_MAX_VERSION_LEN 32
+
+static char *php_ssl_cipher_get_version(const SSL_CIPHER *c, char *buffer, size_t max_len) /* {{{ */
+{
+	const char *version = SSL_CIPHER_get_version(c);
+	strncpy(buffer, version, max_len);
+	if (max_len <= strlen(version)) {
+		buffer[max_len - 1] = 0;
+	}
+	return buffer;
+}
+/* }}} */
+
+static zval *capture_session_meta(SSL *ssl_handle) /* {{{ */
+{
+	zval *meta_arr;
+	char *proto_str;
+	long proto = SSL_version(ssl_handle);
+	const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl_handle);
+	char version_str[PHP_SSL_MAX_VERSION_LEN];
+
+	switch (proto) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		case TLS1_2_VERSION: proto_str = "TLSv1.2"; break;
+		case TLS1_1_VERSION: proto_str = "TLSv1.1"; break;
+#endif
+		case TLS1_VERSION: proto_str = "TLSv1"; break;
+		case SSL3_VERSION: proto_str = "SSLv3"; break;
+		case SSL2_VERSION: proto_str = "SSLv2"; break;
+		default: proto_str = "UNKNOWN";
+	}
+
+	MAKE_STD_ZVAL(meta_arr);
+	array_init(meta_arr);
+	add_assoc_string(meta_arr, "protocol", proto_str, 1);
+	add_assoc_string(meta_arr, "cipher_name", (char *) SSL_CIPHER_get_name(cipher), 1);
+	add_assoc_long(meta_arr, "cipher_bits", SSL_CIPHER_get_bits(cipher, NULL));
+	add_assoc_string(meta_arr, "cipher_version", php_ssl_cipher_get_version(cipher, version_str, PHP_SSL_MAX_VERSION_LEN), 1);
+
+	return meta_arr;
+}
+/* }}} */
+
+static int capture_peer_certs(php_stream *stream, php_openssl_netstream_data_t *sslsock, X509 *peer_cert TSRMLS_DC) /* {{{ */
+{
+	zval **val, *zcert;
+	int cert_captured = 0;
+
+	if (SUCCESS == php_stream_context_get_option(stream->context,
+			"ssl", "capture_peer_cert", &val) &&
+		zend_is_true(*val)
+	) {
+		MAKE_STD_ZVAL(zcert);
+		ZVAL_RESOURCE(zcert, zend_list_insert(peer_cert, php_openssl_get_x509_list_id() TSRMLS_CC));
+		php_stream_context_set_option(stream->context, "ssl", "peer_certificate", zcert);
+		cert_captured = 1;
+		FREE_ZVAL(zcert);
+	}
+
+	if (SUCCESS == php_stream_context_get_option(stream->context,
+			"ssl", "capture_peer_cert_chain", &val) &&
+		zend_is_true(*val)
+	) {
+		zval *arr;
+		STACK_OF(X509) *chain;
+
+		MAKE_STD_ZVAL(arr);
+		chain = SSL_get_peer_cert_chain(sslsock->ssl_handle);
+
+		if (chain && sk_X509_num(chain) > 0) {
+			int i;
+			array_init(arr);
+
+			for (i = 0; i < sk_X509_num(chain); i++) {
+				X509 *mycert = X509_dup(sk_X509_value(chain, i));
+				MAKE_STD_ZVAL(zcert);
+				ZVAL_RESOURCE(zcert, zend_list_insert(mycert, php_openssl_get_x509_list_id() TSRMLS_CC));
+				add_next_index_zval(arr, zcert);
+			}
+
+		} else {
+			ZVAL_NULL(arr);
+		}
+
+		php_stream_context_set_option(stream->context, "ssl", "peer_certificate_chain", arr);
+		zval_dtor(arr);
+		efree(arr);
+	}
+
+	return cert_captured;
+}
+/* }}} */
+
+static int php_openssl_enable_crypto(php_stream *stream,
+		php_openssl_netstream_data_t *sslsock,
+		php_stream_xport_crypto_param *cparam
+		TSRMLS_DC)
+{
+	int n;
+	int retry = 1;
+	int cert_captured;
+	X509 *peer_cert;
+
+	if (cparam->inputs.activate && !sslsock->ssl_active) {
+		struct timeval	start_time,
+						*timeout;
+		int				blocked		= sslsock->s.is_blocked,
+						has_timeout = 0;
+
+#ifdef HAVE_SNI
+		if (sslsock->is_client) {
+			enable_client_sni(stream, sslsock);
+		}
+#endif
+
+		if (!sslsock->state_set) {
+			if (sslsock->is_client) {
+				SSL_set_connect_state(sslsock->ssl_handle);
+			} else {
+				SSL_set_accept_state(sslsock->ssl_handle);
+			}
+			sslsock->state_set = 1;
+		}
+
+		if (SUCCESS == php_set_sock_blocking(sslsock->s.socket, 0 TSRMLS_CC)) {
+			sslsock->s.is_blocked = 0;
+		}
+		
+		timeout = sslsock->is_client ? &sslsock->connect_timeout : &sslsock->s.timeout;
+		has_timeout = !sslsock->s.is_blocked && (timeout->tv_sec || timeout->tv_usec);
+		/* gettimeofday is not monotonic; using it here is not strictly correct */
+		if (has_timeout) {
+			gettimeofday(&start_time, NULL);
+		}
+		
+		do {
+			struct timeval	cur_time,
+							elapsed_time = {0};
+			
+			if (sslsock->is_client) {
+				n = SSL_connect(sslsock->ssl_handle);
+			} else {
+				n = SSL_accept(sslsock->ssl_handle);
+			}
+
+			if (has_timeout) {
+				gettimeofday(&cur_time, NULL);
+				elapsed_time = subtract_timeval( cur_time, start_time );
+			
+				if (compare_timeval( elapsed_time, *timeout) > 0) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL: Handshake timed out");
+					return -1;
+				}
+			}
+
+			if (n <= 0) {
+				/* in case of SSL_ERROR_WANT_READ/WRITE, do not retry in non-blocking mode */
+				retry = handle_ssl_error(stream, n, blocked TSRMLS_CC);
+				if (retry) {
+					/* wait until something interesting happens in the socket. It may be a
+					 * timeout. Also consider the unlikely of possibility of a write block  */
+					int err = SSL_get_error(sslsock->ssl_handle, n);
+					struct timeval left_time;
+					
+					if (has_timeout) {
+						left_time = subtract_timeval( *timeout, elapsed_time );
+					}
+					php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_READ) ?
+						(POLLIN|POLLPRI) : POLLOUT, has_timeout ? &left_time : NULL);
+				}
+			} else {
+				retry = 0;
+			}
+		} while (retry);
+
+		if (sslsock->s.is_blocked != blocked && SUCCESS == php_set_sock_blocking(sslsock->s.socket, blocked TSRMLS_CC)) {
+			sslsock->s.is_blocked = blocked;
+		}
+
+		if (n == 1) {
+			peer_cert = SSL_get_peer_certificate(sslsock->ssl_handle);
+			if (peer_cert && stream->context) {
+				cert_captured = capture_peer_certs(stream, sslsock, peer_cert TSRMLS_CC);
+			}
+
+			if (FAILURE == apply_peer_verification_policy(sslsock->ssl_handle, peer_cert, stream TSRMLS_CC)) {
+				SSL_shutdown(sslsock->ssl_handle);
+				n = -1;
+			} else {	
+				sslsock->ssl_active = 1;
+
+				if (stream->context) {
+					zval **val;
+
+					if (SUCCESS == php_stream_context_get_option(stream->context,
+							"ssl", "capture_session_meta", &val) &&
+						zend_is_true(*val)
+					) {
+						zval *meta_arr = capture_session_meta(sslsock->ssl_handle);
+						php_stream_context_set_option(stream->context, "ssl", "session_meta", meta_arr);
+						zval_dtor(meta_arr);
+						efree(meta_arr);
+					}
+				}
+			}
+		} else if (errno == EAGAIN) {
+			n = 0;
+		} else {
+			n = -1;
+			peer_cert = SSL_get_peer_certificate(sslsock->ssl_handle);
+			if (peer_cert && stream->context) {
+				cert_captured = capture_peer_certs(stream, sslsock, peer_cert TSRMLS_CC);
+			}
+		}
+
+		if (n && peer_cert && cert_captured == 0) {
+			X509_free(peer_cert);
+		}
+
+		return n;
+
+	} else if (!cparam->inputs.activate && sslsock->ssl_active) {
+		/* deactivate - common for server/client */
+		SSL_shutdown(sslsock->ssl_handle);
+		sslsock->ssl_active = 0;
+	}
+
+	return -1;
+}
+
+static size_t php_openssl_sockop_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)/* {{{ */
+{
+	return php_openssl_sockop_io(1, stream, buf, count TSRMLS_CC);
+}
+/* }}} */
+
+static size_t php_openssl_sockop_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC) /* {{{ */
+{
+	return php_openssl_sockop_io(0, stream, (char*)buf, count TSRMLS_CC);
+}
+/* }}} */
+
+/**
+ * Factored out common functionality (blocking, timeout, loop management) for read and write.
+ * Perform IO (read or write) to an SSL socket. If we have a timeout, we switch to non-blocking mode
+ * for the duration of the operation, using select to do our waits. If we time out, or we have an error
+ * report that back to PHP
+ *
+ */
+static size_t php_openssl_sockop_io(int read, php_stream *stream, char *buf, size_t count TSRMLS_DC)
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	int nr_bytes = 0;
+
+	/* Only do this if SSL is active. */
+	if (sslsock->ssl_active) {
+		int retry = 1;
+		struct timeval start_time;
+		struct timeval *timeout = NULL;
+		int began_blocked = sslsock->s.is_blocked;
+		int has_timeout = 0;
+
+		/* never use a timeout with non-blocking sockets */
+		if (began_blocked && &sslsock->s.timeout) {
+			timeout = &sslsock->s.timeout;
+		}
+
+		if (timeout && php_set_sock_blocking(sslsock->s.socket, 0 TSRMLS_CC) == SUCCESS) {
+			sslsock->s.is_blocked = 0;
+		}
+
+		if (!sslsock->s.is_blocked && timeout && (timeout->tv_sec || timeout->tv_usec)) {
+			has_timeout = 1;
+			/* gettimeofday is not monotonic; using it here is not strictly correct */
+			gettimeofday(&start_time, NULL);
+		}
+
+		/* Main IO loop. */
+		do {
+			struct timeval cur_time, elapsed_time, left_time;
+	
+			/* If we have a timeout to check, figure out how much time has elapsed since we started. */
+			if (has_timeout) {
+				gettimeofday(&cur_time, NULL);
+
+				/* Determine how much time we've taken so far. */
+				elapsed_time = subtract_timeval(cur_time, start_time);
+
+				/* and return an error if we've taken too long. */
+				if (compare_timeval(elapsed_time, *timeout) > 0 ) {
+					/* If the socket was originally blocking, set it back. */
+					if (began_blocked) {
+						php_set_sock_blocking(sslsock->s.socket, 1 TSRMLS_CC);
+						sslsock->s.is_blocked = 1;
+					}
+					sslsock->s.timeout_event = 1;
+					return -1;
+				}
+			}
+
+			/* Now, do the IO operation. Don't block if we can't complete... */
+			if (read) {
+				nr_bytes = SSL_read(sslsock->ssl_handle, buf, count);
+
+				if (sslsock->reneg && sslsock->reneg->should_close) {
+					/* renegotiation rate limiting triggered */
+					php_stream_xport_shutdown(stream, (stream_shutdown_t)SHUT_RDWR TSRMLS_CC);
+					nr_bytes = 0;
+					stream->eof = 1;
+					break;
+				}
+			} else {
+				nr_bytes = SSL_write(sslsock->ssl_handle, buf, count);
+			}
+
+			/* Now, how much time until we time out? */
+			if (has_timeout) {
+				left_time = subtract_timeval( *timeout, elapsed_time );
+			}
+
+			/* If we didn't do anything on the last loop (or an error) check to see if we should retry or exit. */
+			if (nr_bytes <= 0) {
+
+				/* Get the error code from SSL, and check to see if it's an error or not. */
+				int err = SSL_get_error(sslsock->ssl_handle, nr_bytes );
+				retry = handle_ssl_error(stream, nr_bytes, 0 TSRMLS_CC);
+
+				/* If we get this (the above doesn't check) then we'll retry as well. */
+				if (errno == EAGAIN && err == SSL_ERROR_WANT_READ && read) {
+					retry = 1;
+				}
+				if (errno == EAGAIN && err == SSL_ERROR_WANT_WRITE && read == 0) {
+					retry = 1;
+				}
+
+				/* Also, on reads, we may get this condition on an EOF. We should check properly. */
+				if (read) {
+					stream->eof = (retry == 0 && errno != EAGAIN && !SSL_pending(sslsock->ssl_handle));
+				}
+
+				/* Don't loop indefinitely in non-blocking mode if no data is available */
+				if (began_blocked == 0) {
+					break;
+				}
+
+				/* Now, if we have to wait some time, and we're supposed to be blocking, wait for the socket to become
+				 * available. Now, php_pollfd_for uses select to wait up to our time_left value only...
+				 */
+				if (retry) {
+					if (read) {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_WRITE) ?
+							(POLLOUT|POLLPRI) : (POLLIN|POLLPRI), has_timeout ? &left_time : NULL);
+					} else {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_READ) ?
+							(POLLIN|POLLPRI) : (POLLOUT|POLLPRI), has_timeout ? &left_time : NULL);
+					}
+				}
+			} else {
+				/* Else, if we got bytes back, check for possible errors. */
+				int err = SSL_get_error(sslsock->ssl_handle, nr_bytes);
+
+				/* If we didn't get any error, then let's return it to PHP. */
+				if (err == SSL_ERROR_NONE)
+				break;
+
+				/* Otherwise, we need to wait again (up to time_left or we get an error) */
+				if (began_blocked) {
+					if (read) {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_WRITE) ?
+							(POLLOUT|POLLPRI) : (POLLIN|POLLPRI), has_timeout ? &left_time : NULL);
+					} else {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_READ) ?
+							(POLLIN|POLLPRI) : (POLLOUT|POLLPRI), has_timeout ? &left_time : NULL);
+					}
+				}
+			}
+		/* Finally, we keep going until we got data, and an SSL_ERROR_NONE, unless we had an error. */
+		} while (retry);
+
+		/* Tell PHP if we read / wrote bytes. */
+		if (nr_bytes > 0) {
+			php_stream_notify_progress_increment(stream->context, nr_bytes, 0);
+		}
+
+		/* And if we were originally supposed to be blocking, let's reset the socket to that. */
+		if (began_blocked && php_set_sock_blocking(sslsock->s.socket, 1 TSRMLS_CC) == SUCCESS) {
+			sslsock->s.is_blocked = 1;
+		}
+	} else {
+		/*
+		 * This block is if we had no timeout... We will just sit and wait forever on the IO operation.
+		 */
+		if (read) {
+			nr_bytes = php_stream_socket_ops.read(stream, buf, count TSRMLS_CC);
+		} else {
+			nr_bytes = php_stream_socket_ops.write(stream, buf, count TSRMLS_CC);
+		}
+	}
+
+	/* PHP doesn't expect a negative return. */
+	if (nr_bytes < 0) {
+		nr_bytes = 0;
+	}
+
+	return nr_bytes;
+}
+/* }}} */
+
+struct timeval subtract_timeval( struct timeval a, struct timeval b )
+{
+	struct timeval difference;
+
+	difference.tv_sec  = a.tv_sec  - b.tv_sec;
+	difference.tv_usec = a.tv_usec - b.tv_usec;
+
+	if (a.tv_usec < b.tv_usec) {
+	  	b.tv_sec  -= 1L;
+	   	b.tv_usec += 1000000L;
+	}
+
+	return difference;
+}
+
+int compare_timeval( struct timeval a, struct timeval b )
+{
+	if (a.tv_sec > b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_usec > b.tv_usec) ) {
+		return 1;
+	} else if( a.tv_sec == b.tv_sec && a.tv_usec == b.tv_usec ) {
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int php_openssl_sockop_close(php_stream *stream, int close_handle TSRMLS_DC) /* {{{ */
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+#ifdef PHP_WIN32
+	int n;
+#endif
+	unsigned i;
+
+	if (close_handle) {
+		if (sslsock->ssl_active) {
+			SSL_shutdown(sslsock->ssl_handle);
+			sslsock->ssl_active = 0;
+		}
+		if (sslsock->ssl_handle) {
+			SSL_free(sslsock->ssl_handle);
+			sslsock->ssl_handle = NULL;
+		}
+		if (sslsock->ctx) {
+			SSL_CTX_free(sslsock->ctx);
+			sslsock->ctx = NULL;
+		}
+#ifdef PHP_WIN32
+		if (sslsock->s.socket == -1)
+			sslsock->s.socket = SOCK_ERR;
+#endif
+		if (sslsock->s.socket != SOCK_ERR) {
+#ifdef PHP_WIN32
+			/* prevent more data from coming in */
+			shutdown(sslsock->s.socket, SHUT_RD);
+
+			/* try to make sure that the OS sends all data before we close the connection.
+			 * Essentially, we are waiting for the socket to become writeable, which means
+			 * that all pending data has been sent.
+			 * We use a small timeout which should encourage the OS to send the data,
+			 * but at the same time avoid hanging indefinitely.
+			 * */
+			do {
+				n = php_pollfd_for_ms(sslsock->s.socket, POLLOUT, 500);
+			} while (n == -1 && php_socket_errno() == EINTR);
+#endif
+			closesocket(sslsock->s.socket);
+			sslsock->s.socket = SOCK_ERR;
+		}
+	}
+
+	if (sslsock->sni_certs) {
+		for (i = 0; i < sslsock->sni_cert_count; i++) {
+			if (sslsock->sni_certs[i].ctx) {
+				SSL_CTX_free(sslsock->sni_certs[i].ctx);
+				pefree(sslsock->sni_certs[i].name, php_stream_is_persistent(stream));
+			}
+		}
+		pefree(sslsock->sni_certs, php_stream_is_persistent(stream));
+		sslsock->sni_certs = NULL;
+	}
+
+	if (sslsock->url_name) {
+		pefree(sslsock->url_name, php_stream_is_persistent(stream));
+	}
+
+	if (sslsock->reneg) {
+		pefree(sslsock->reneg, php_stream_is_persistent(stream));
+	}
+
+	pefree(sslsock, php_stream_is_persistent(stream));
+
+	return 0;
+}
+/* }}} */
+
+static int php_openssl_sockop_flush(php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	return php_stream_socket_ops.flush(stream TSRMLS_CC);
+}
+/* }}} */
+
+static int php_openssl_sockop_stat(php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC) /* {{{ */
+{
+	return php_stream_socket_ops.stat(stream, ssb TSRMLS_CC);
+}
+/* }}} */
+
+static inline int php_openssl_tcp_sockop_accept(php_stream *stream, php_openssl_netstream_data_t *sock,
+		php_stream_xport_param *xparam STREAMS_DC TSRMLS_DC)
+{
+	int clisock;
+
+	xparam->outputs.client = NULL;
+
+	clisock = php_network_accept_incoming(sock->s.socket,
+			xparam->want_textaddr ? &xparam->outputs.textaddr : NULL,
+			xparam->want_textaddr ? &xparam->outputs.textaddrlen : NULL,
+			xparam->want_addr ? &xparam->outputs.addr : NULL,
+			xparam->want_addr ? &xparam->outputs.addrlen : NULL,
+			xparam->inputs.timeout,
+			xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+			&xparam->outputs.error_code
+			TSRMLS_CC);
+
+	if (clisock >= 0) {
+		php_openssl_netstream_data_t *clisockdata;
+
+		clisockdata = emalloc(sizeof(*clisockdata));
+
+		if (clisockdata == NULL) {
+			closesocket(clisock);
+			/* technically a fatal error */
+		} else {
+			/* copy underlying tcp fields */
+			memset(clisockdata, 0, sizeof(*clisockdata));
+			memcpy(clisockdata, sock, sizeof(clisockdata->s));
+
+			clisockdata->s.socket = clisock;
+			
+			xparam->outputs.client = php_stream_alloc_rel(stream->ops, clisockdata, NULL, "r+");
+			if (xparam->outputs.client) {
+				xparam->outputs.client->context = stream->context;
+				if (stream->context) {
+					zend_list_addref(stream->context->rsrc_id);
+				}
+			}
+		}
+
+		if (xparam->outputs.client && sock->enable_on_connect) {
+			/* remove the client bit */
+			if (sock->method & STREAM_CRYPTO_IS_CLIENT) {
+				sock->method = ((sock->method >> 1) << 1);
+			}
+
+			clisockdata->method = sock->method;
+
+			if (php_stream_xport_crypto_setup(xparam->outputs.client, clisockdata->method,
+					NULL TSRMLS_CC) < 0 || php_stream_xport_crypto_enable(
+					xparam->outputs.client, 1 TSRMLS_CC) < 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to enable crypto");
+
+				php_stream_close(xparam->outputs.client);
+				xparam->outputs.client = NULL;
+				xparam->outputs.returncode = -1;
+			}
+		}
+	}
+	
+	return xparam->outputs.client == NULL ? -1 : 0;
+}
+
+static int php_openssl_sockop_set_option(php_stream *stream, int option, int value, void *ptrparam TSRMLS_DC)
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	php_stream_xport_crypto_param *cparam = (php_stream_xport_crypto_param *)ptrparam;
+	php_stream_xport_param *xparam = (php_stream_xport_param *)ptrparam;
+
+	switch (option) {
+		case PHP_STREAM_OPTION_CHECK_LIVENESS:
+			{
+				struct timeval tv;
+				char buf;
+				int alive = 1;
+
+				if (value == -1) {
+					if (sslsock->s.timeout.tv_sec == -1) {
+						tv.tv_sec = FG(default_socket_timeout);
+						tv.tv_usec = 0;
+					} else {
+						tv = sslsock->connect_timeout;
+					}
+				} else {
+					tv.tv_sec = value;
+					tv.tv_usec = 0;
+				}
+
+				if (sslsock->s.socket == -1) {
+					alive = 0;
+				} else if (php_pollfd_for(sslsock->s.socket, PHP_POLLREADABLE|POLLPRI, &tv) > 0) {
+					if (sslsock->ssl_active) {
+						int n;
+
+						do {
+							n = SSL_peek(sslsock->ssl_handle, &buf, sizeof(buf));
+							if (n <= 0) {
+								int err = SSL_get_error(sslsock->ssl_handle, n);
+
+								if (err == SSL_ERROR_SYSCALL) {
+									alive = php_socket_errno() == EAGAIN;
+									break;
+								}
+
+								if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+									/* re-negotiate */
+									continue;
+								}
+
+								/* any other problem is a fatal error */
+								alive = 0;
+							}
+							/* either peek succeeded or there was an error; we
+							 * have set the alive flag appropriately */
+							break;
+						} while (1);
+					} else if (0 == recv(sslsock->s.socket, &buf, sizeof(buf), MSG_PEEK) && php_socket_errno() != EAGAIN) {
+						alive = 0;
+					}
+				}
+				return alive ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;
+			}
+			
+		case PHP_STREAM_OPTION_CRYPTO_API:
+
+			switch(cparam->op) {
+
+				case STREAM_XPORT_CRYPTO_OP_SETUP:
+					cparam->outputs.returncode = php_openssl_setup_crypto(stream, sslsock, cparam TSRMLS_CC);
+					return PHP_STREAM_OPTION_RETURN_OK;
+					break;
+				case STREAM_XPORT_CRYPTO_OP_ENABLE:
+					cparam->outputs.returncode = php_openssl_enable_crypto(stream, sslsock, cparam TSRMLS_CC);
+					return PHP_STREAM_OPTION_RETURN_OK;
+					break;
+				default:
+					/* fall through */
+					break;
+			}
+
+			break;
+
+		case PHP_STREAM_OPTION_XPORT_API:
+			switch(xparam->op) {
+
+				case STREAM_XPORT_OP_CONNECT:
+				case STREAM_XPORT_OP_CONNECT_ASYNC:
+					/* TODO: Async connects need to check the enable_on_connect option when
+					 * we notice that the connect has actually been established */
+					php_stream_socket_ops.set_option(stream, option, value, ptrparam TSRMLS_CC);
+
+					if ((sslsock->enable_on_connect) &&
+						((xparam->outputs.returncode == 0) ||
+						(xparam->op == STREAM_XPORT_OP_CONNECT_ASYNC && 
+						xparam->outputs.returncode == 1 && xparam->outputs.error_code == EINPROGRESS)))
+					{
+						if (php_stream_xport_crypto_setup(stream, sslsock->method, NULL TSRMLS_CC) < 0 ||
+								php_stream_xport_crypto_enable(stream, 1 TSRMLS_CC) < 0) {
+							php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to enable crypto");
+							xparam->outputs.returncode = -1;
+						}
+					}
+					return PHP_STREAM_OPTION_RETURN_OK;
+
+				case STREAM_XPORT_OP_ACCEPT:
+					/* we need to copy the additional fields that the underlying tcp transport
+					 * doesn't know about */
+					xparam->outputs.returncode = php_openssl_tcp_sockop_accept(stream, sslsock, xparam STREAMS_CC TSRMLS_CC);
+
+					
+					return PHP_STREAM_OPTION_RETURN_OK;
+
+				default:
+					/* fall through */
+					break;
+			}
+	}
+
+	return php_stream_socket_ops.set_option(stream, option, value, ptrparam TSRMLS_CC);
+}
+
+static int php_openssl_sockop_cast(php_stream *stream, int castas, void **ret TSRMLS_DC)
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	switch(castas)	{
+		case PHP_STREAM_AS_STDIO:
+			if (sslsock->ssl_active) {
+				return FAILURE;
+			}
+			if (ret)	{
+				*ret = fdopen(sslsock->s.socket, stream->mode);
+				if (*ret) {
+					return SUCCESS;
+				}
+				return FAILURE;
+			}
+			return SUCCESS;
+
+		case PHP_STREAM_AS_FD_FOR_SELECT:
+			if (ret) {
+				size_t pending;
+				if (stream->writepos == stream->readpos
+					&& sslsock->ssl_active
+					&& (pending = (size_t)SSL_pending(sslsock->ssl_handle)) > 0) {
+						php_stream_fill_read_buffer(stream, pending < stream->chunk_size
+							? pending
+							: stream->chunk_size);
+				}
+
+				*(php_socket_t *)ret = sslsock->s.socket;
+			}
+			return SUCCESS;
+
+		case PHP_STREAM_AS_FD:
+		case PHP_STREAM_AS_SOCKETD:
+			if (sslsock->ssl_active) {
+				return FAILURE;
+			}
+			if (ret) {
+				*(php_socket_t *)ret = sslsock->s.socket;
+			}
+			return SUCCESS;
+		default:
+			return FAILURE;
+	}
+}
+
+php_stream_ops php_openssl_socket_ops = {
+	php_openssl_sockop_write, php_openssl_sockop_read,
+	php_openssl_sockop_close, php_openssl_sockop_flush,
+	"tcp_socket/ssl",
+	NULL, /* seek */
+	php_openssl_sockop_cast,
+	php_openssl_sockop_stat,
+	php_openssl_sockop_set_option,
+};
+
+static long get_crypto_method(php_stream_context *ctx, long crypto_method)
+{
+	zval **val;
+
+	if (ctx && php_stream_context_get_option(ctx, "ssl", "crypto_method", &val) == SUCCESS) {
+		convert_to_long_ex(val);
+		crypto_method = (long)Z_LVAL_PP(val);
+		crypto_method |= STREAM_CRYPTO_IS_CLIENT;
+	}
+
+	return crypto_method;
+}
+
+static char *get_url_name(const char *resourcename, size_t resourcenamelen, int is_persistent TSRMLS_DC)
+{
+	php_url *url;
+
+	if (!resourcename) {
+		return NULL;
+	}
+
+	url = php_url_parse_ex(resourcename, resourcenamelen);
+	if (!url) {
+		return NULL;
+	}
+
+	if (url->host) {
+		const char * host = url->host;
+		char * url_name = NULL;
+		size_t len = strlen(host);
+
+		/* skip trailing dots */
+		while (len && host[len-1] == '.') {
+			--len;
+		}
+
+		if (len) {
+			url_name = pestrndup(host, len, is_persistent);
+		}
+
+		php_url_free(url);
+		return url_name;
+	}
+
+	php_url_free(url);
+	return NULL;
+}
+
+php_stream *php_openssl_ssl_socket_factory(const char *proto, size_t protolen,
+		const char *resourcename, size_t resourcenamelen,
+		const char *persistent_id, int options, int flags,
+		struct timeval *timeout,
+		php_stream_context *context STREAMS_DC TSRMLS_DC)
+{
+	php_stream *stream = NULL;
+	php_openssl_netstream_data_t *sslsock = NULL;
+
+	sslsock = pemalloc(sizeof(php_openssl_netstream_data_t), persistent_id ? 1 : 0);
+	memset(sslsock, 0, sizeof(*sslsock));
+
+	sslsock->s.is_blocked = 1;
+	/* this timeout is used by standard stream funcs, therefor it should use the default value */
+	sslsock->s.timeout.tv_sec = FG(default_socket_timeout);
+	sslsock->s.timeout.tv_usec = 0;
+
+	/* use separate timeout for our private funcs */
+	sslsock->connect_timeout.tv_sec = timeout->tv_sec;
+	sslsock->connect_timeout.tv_usec = timeout->tv_usec;
+
+	/* we don't know the socket until we have determined if we are binding or
+	 * connecting */
+	sslsock->s.socket = -1;
+
+	/* Initialize context as NULL */
+	sslsock->ctx = NULL;	
+
+	stream = php_stream_alloc_rel(&php_openssl_socket_ops, sslsock, persistent_id, "r+");
+
+	if (stream == NULL)	{
+		pefree(sslsock, persistent_id ? 1 : 0);
+		return NULL;
+	}
+
+	if (strncmp(proto, "ssl", protolen) == 0) {
+		sslsock->enable_on_connect = 1;
+		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_ANY_CLIENT);
+	} else if (strncmp(proto, "sslv2", protolen) == 0) {
+#ifdef OPENSSL_NO_SSL2
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSLv2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#else
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_SSLv2_CLIENT;
+#endif
+	} else if (strncmp(proto, "sslv3", protolen) == 0) {
+#ifdef OPENSSL_NO_SSL3
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSLv3 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#else
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_SSLv3_CLIENT;
+#endif
+	} else if (strncmp(proto, "tls", protolen) == 0) {
+		sslsock->enable_on_connect = 1;
+		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+	} else if (strncmp(proto, "tlsv1.0", protolen) == 0) {
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+	} else if (strncmp(proto, "tlsv1.1", protolen) == 0) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "TLSv1.1 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (strncmp(proto, "tlsv1.2", protolen) == 0) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "TLSv1.2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	}
+
+	sslsock->url_name = get_url_name(resourcename, resourcenamelen, !!persistent_id TSRMLS_CC);
+
+	return stream;
+}
+
+
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/tests/expected/php/5.6.40-php56-openssl11-patch/ext/phar/util.c
+++ b/tests/expected/php/5.6.40-php56-openssl11-patch/ext/phar/util.c
@@ -1,0 +1,2143 @@
+/*
+  +----------------------------------------------------------------------+
+  | phar php single-file executable PHP extension                        |
+  | utility functions                                                    |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2005-2016 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Gregory Beaver <cellog@php.net>                             |
+  |          Marcus Boerger <helly@php.net>                              |
+  +----------------------------------------------------------------------+
+*/
+
+/* $Id$ */
+
+#include "phar_internal.h"
+#ifdef PHAR_HASH_OK
+#include "ext/hash/php_hash_sha.h"
+#endif
+
+#ifdef PHAR_HAVE_OPENSSL
+/* OpenSSL includes */
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/crypto.h>
+#include <openssl/pem.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+#include <openssl/pkcs12.h>
+#else
+static int phar_call_openssl_signverify(int is_sign, php_stream *fp, off_t end, char *key, int key_len, char **signature, int *signature_len TSRMLS_DC);
+#endif
+
+/* for links to relative location, prepend cwd of the entry */
+static char *phar_get_link_location(phar_entry_info *entry TSRMLS_DC) /* {{{ */
+{
+	char *p, *ret = NULL;
+	if (!entry->link) {
+		return NULL;
+	}
+	if (entry->link[0] == '/') {
+		return estrdup(entry->link + 1);
+	}
+	p = strrchr(entry->filename, '/');
+	if (p) {
+		*p = '\0';
+		spprintf(&ret, 0, "%s/%s", entry->filename, entry->link);
+		return ret;
+	}
+	return entry->link;
+}
+/* }}} */
+
+phar_entry_info *phar_get_link_source(phar_entry_info *entry TSRMLS_DC) /* {{{ */
+{
+	phar_entry_info *link_entry;
+	char *link;
+
+	if (!entry->link) {
+		return entry;
+	}
+
+	link = phar_get_link_location(entry TSRMLS_CC);
+	if (SUCCESS == zend_hash_find(&(entry->phar->manifest), entry->link, strlen(entry->link), (void **)&link_entry) ||
+		SUCCESS == zend_hash_find(&(entry->phar->manifest), link, strlen(link), (void **)&link_entry)) {
+		if (link != entry->link) {
+			efree(link);
+		}
+		return phar_get_link_source(link_entry TSRMLS_CC);
+	} else {
+		if (link != entry->link) {
+			efree(link);
+		}
+		return NULL;
+	}
+}
+/* }}} */
+
+/* retrieve a phar_entry_info's current file pointer for reading contents */
+php_stream *phar_get_efp(phar_entry_info *entry, int follow_links TSRMLS_DC) /* {{{ */
+{
+	if (follow_links && entry->link) {
+		phar_entry_info *link_entry = phar_get_link_source(entry TSRMLS_CC);
+
+		if (link_entry && link_entry != entry) {
+			return phar_get_efp(link_entry, 1 TSRMLS_CC);
+		}
+	}
+
+	if (phar_get_fp_type(entry TSRMLS_CC) == PHAR_FP) {
+		if (!phar_get_entrypfp(entry TSRMLS_CC)) {
+			/* re-open just in time for cases where our refcount reached 0 on the phar archive */
+			phar_open_archive_fp(entry->phar TSRMLS_CC);
+		}
+		return phar_get_entrypfp(entry TSRMLS_CC);
+	} else if (phar_get_fp_type(entry TSRMLS_CC) == PHAR_UFP) {
+		return phar_get_entrypufp(entry TSRMLS_CC);
+	} else if (entry->fp_type == PHAR_MOD) {
+		return entry->fp;
+	} else {
+		/* temporary manifest entry */
+		if (!entry->fp) {
+			entry->fp = php_stream_open_wrapper(entry->tmp, "rb", STREAM_MUST_SEEK|0, NULL);
+		}
+		return entry->fp;
+	}
+}
+/* }}} */
+
+int phar_seek_efp(phar_entry_info *entry, off_t offset, int whence, off_t position, int follow_links TSRMLS_DC) /* {{{ */
+{
+	php_stream *fp = phar_get_efp(entry, follow_links TSRMLS_CC);
+	off_t temp, eoffset;
+
+	if (!fp) {
+		return -1;
+	}
+
+	if (follow_links) {
+		phar_entry_info *t;
+		t = phar_get_link_source(entry TSRMLS_CC);
+		if (t) {
+			entry = t;
+		}
+	}
+
+	if (entry->is_dir) {
+		return 0;
+	}
+
+	eoffset = phar_get_fp_offset(entry TSRMLS_CC);
+
+	switch (whence) {
+		case SEEK_END:
+			temp = eoffset + entry->uncompressed_filesize + offset;
+			break;
+		case SEEK_CUR:
+			temp = eoffset + position + offset;
+			break;
+		case SEEK_SET:
+			temp = eoffset + offset;
+			break;
+		default:
+			temp = 0;
+	}
+
+	if (temp > eoffset + (off_t) entry->uncompressed_filesize) {
+		return -1;
+	}
+
+	if (temp < eoffset) {
+		return -1;
+	}
+
+	return php_stream_seek(fp, temp, SEEK_SET);
+}
+/* }}} */
+
+/* mount an absolute path or uri to a path internal to the phar archive */
+int phar_mount_entry(phar_archive_data *phar, char *filename, int filename_len, char *path, int path_len TSRMLS_DC) /* {{{ */
+{
+	phar_entry_info entry = {0};
+	php_stream_statbuf ssb;
+	int is_phar;
+	const char *err;
+
+	if (phar_path_check(&path, &path_len, &err) > pcr_is_ok) {
+		return FAILURE;
+	}
+
+	if (path_len >= sizeof(".phar")-1 && !memcmp(path, ".phar", sizeof(".phar")-1)) {
+		/* no creating magic phar files by mounting them */
+		return FAILURE;
+	}
+
+	is_phar = (filename_len > 7 && !memcmp(filename, "phar://", 7));
+
+	entry.phar = phar;
+	entry.filename = estrndup(path, path_len);
+#ifdef PHP_WIN32
+	phar_unixify_path_separators(entry.filename, path_len);
+#endif
+	entry.filename_len = path_len;
+	if (is_phar) {
+		entry.tmp = estrndup(filename, filename_len);
+	} else {
+		entry.tmp = expand_filepath(filename, NULL TSRMLS_CC);
+		if (!entry.tmp) {
+			entry.tmp = estrndup(filename, filename_len);
+		}
+	}
+#if PHP_API_VERSION < 20100412
+	if (PG(safe_mode) && !is_phar && (!php_checkuid(entry.tmp, NULL, CHECKUID_CHECK_FILE_AND_DIR))) {
+		efree(entry.tmp);
+		efree(entry.filename);
+		return FAILURE;
+	}
+#endif
+	filename = entry.tmp;
+
+	/* only check openbasedir for files, not for phar streams */
+	if (!is_phar && php_check_open_basedir(filename TSRMLS_CC)) {
+		efree(entry.tmp);
+		efree(entry.filename);
+		return FAILURE;
+	}
+
+	entry.is_mounted = 1;
+	entry.is_crc_checked = 1;
+	entry.fp_type = PHAR_TMP;
+
+	if (SUCCESS != php_stream_stat_path(filename, &ssb)) {
+		efree(entry.tmp);
+		efree(entry.filename);
+		return FAILURE;
+	}
+
+	if (ssb.sb.st_mode & S_IFDIR) {
+		entry.is_dir = 1;
+		if (SUCCESS != zend_hash_add(&phar->mounted_dirs, entry.filename, path_len, (void *)&(entry.filename), sizeof(char *), NULL)) {
+			/* directory already mounted */
+			efree(entry.tmp);
+			efree(entry.filename);
+			return FAILURE;
+		}
+	} else {
+		entry.is_dir = 0;
+		entry.uncompressed_filesize = entry.compressed_filesize = ssb.sb.st_size;
+	}
+
+	entry.flags = ssb.sb.st_mode;
+
+	if (SUCCESS == zend_hash_add(&phar->manifest, entry.filename, path_len, (void*)&entry, sizeof(phar_entry_info), NULL)) {
+		return SUCCESS;
+	}
+
+	efree(entry.tmp);
+	efree(entry.filename);
+	return FAILURE;
+}
+/* }}} */
+
+char *phar_find_in_include_path(char *filename, int filename_len, phar_archive_data **pphar TSRMLS_DC) /* {{{ */
+{
+	char *path, *fname, *arch, *entry, *ret, *test;
+	int arch_len, entry_len, fname_len, ret_len;
+	phar_archive_data *phar;
+
+	if (pphar) {
+		*pphar = NULL;
+	} else {
+		pphar = &phar;
+	}
+
+	if (!zend_is_executing(TSRMLS_C) || !PHAR_G(cwd)) {
+		return phar_save_resolve_path(filename, filename_len TSRMLS_CC);
+	}
+
+	fname = (char*)zend_get_executed_filename(TSRMLS_C);
+	fname_len = strlen(fname);
+
+	if (PHAR_G(last_phar) && !memcmp(fname, "phar://", 7) && fname_len - 7 >= PHAR_G(last_phar_name_len) && !memcmp(fname + 7, PHAR_G(last_phar_name), PHAR_G(last_phar_name_len))) {
+		arch = estrndup(PHAR_G(last_phar_name), PHAR_G(last_phar_name_len));
+		arch_len = PHAR_G(last_phar_name_len);
+		phar = PHAR_G(last_phar);
+		goto splitted;
+	}
+
+	if (fname_len < 7 || memcmp(fname, "phar://", 7) || SUCCESS != phar_split_fname(fname, strlen(fname), &arch, &arch_len, &entry, &entry_len, 1, 0 TSRMLS_CC)) {
+		return phar_save_resolve_path(filename, filename_len TSRMLS_CC);
+	}
+
+	efree(entry);
+
+	if (*filename == '.') {
+		int try_len;
+
+		if (FAILURE == phar_get_archive(&phar, arch, arch_len, NULL, 0, NULL TSRMLS_CC)) {
+			efree(arch);
+			return phar_save_resolve_path(filename, filename_len TSRMLS_CC);
+		}
+splitted:
+		if (pphar) {
+			*pphar = phar;
+		}
+
+		try_len = filename_len;
+		test = phar_fix_filepath(estrndup(filename, filename_len), &try_len, 1 TSRMLS_CC);
+
+		if (*test == '/') {
+			if (zend_hash_exists(&(phar->manifest), test + 1, try_len - 1)) {
+				spprintf(&ret, 0, "phar://%s%s", arch, test);
+				efree(arch);
+				efree(test);
+				return ret;
+			}
+		} else {
+			if (zend_hash_exists(&(phar->manifest), test, try_len)) {
+				spprintf(&ret, 0, "phar://%s/%s", arch, test);
+				efree(arch);
+				efree(test);
+				return ret;
+			}
+		}
+		efree(test);
+	}
+
+	spprintf(&path, MAXPATHLEN, "phar://%s/%s%c%s", arch, PHAR_G(cwd), DEFAULT_DIR_SEPARATOR, PG(include_path));
+	efree(arch);
+	ret = php_resolve_path(filename, filename_len, path TSRMLS_CC);
+	efree(path);
+
+	if (ret && strlen(ret) > 8 && !strncmp(ret, "phar://", 7)) {
+		ret_len = strlen(ret);
+		/* found phar:// */
+
+		if (SUCCESS != phar_split_fname(ret, ret_len, &arch, &arch_len, &entry, &entry_len, 1, 0 TSRMLS_CC)) {
+			return ret;
+		}
+
+		zend_hash_find(&(PHAR_GLOBALS->phar_fname_map), arch, arch_len, (void **) &pphar);
+
+		if (!pphar && PHAR_G(manifest_cached)) {
+			zend_hash_find(&cached_phars, arch, arch_len, (void **) &pphar);
+		}
+
+		efree(arch);
+		efree(entry);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/**
+ * Retrieve a copy of the file information on a single file within a phar, or null.
+ * This also transfers the open file pointer, if any, to the entry.
+ *
+ * If the file does not already exist, this will fail.  Pre-existing files can be
+ * appended, truncated, or read.  For read, if the entry is marked unmodified, it is
+ * assumed that the file pointer, if present, is opened for reading
+ */
+int phar_get_entry_data(phar_entry_data **ret, char *fname, int fname_len, char *path, int path_len, const char *mode, char allow_dir, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *phar;
+	phar_entry_info *entry;
+	int for_write  = mode[0] != 'r' || mode[1] == '+';
+	int for_append = mode[0] == 'a';
+	int for_create = mode[0] != 'r';
+	int for_trunc  = mode[0] == 'w';
+
+	if (!ret) {
+		return FAILURE;
+	}
+
+	*ret = NULL;
+
+	if (error) {
+		*error = NULL;
+	}
+
+	if (FAILURE == phar_get_archive(&phar, fname, fname_len, NULL, 0, error TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (for_write && PHAR_G(readonly) && !phar->is_data) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for writing, disabled by ini setting", path, fname);
+		}
+		return FAILURE;
+	}
+
+	if (!path_len) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"\" in phar \"%s\" cannot be empty", fname);
+		}
+		return FAILURE;
+	}
+really_get_entry:
+	if (allow_dir) {
+		if ((entry = phar_get_entry_info_dir(phar, path, path_len, allow_dir, for_create && !PHAR_G(readonly) && !phar->is_data ? NULL : error, security TSRMLS_CC)) == NULL) {
+			if (for_create && (!PHAR_G(readonly) || phar->is_data)) {
+				return SUCCESS;
+			}
+			return FAILURE;
+		}
+	} else {
+		if ((entry = phar_get_entry_info(phar, path, path_len, for_create && !PHAR_G(readonly) && !phar->is_data ? NULL : error, security TSRMLS_CC)) == NULL) {
+			if (for_create && (!PHAR_G(readonly) || phar->is_data)) {
+				return SUCCESS;
+			}
+			return FAILURE;
+		}
+	}
+
+	if (for_write && phar->is_persistent) {
+		if (FAILURE == phar_copy_on_write(&phar TSRMLS_CC)) {
+			if (error) {
+				spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for writing, could not make cached phar writeable", path, fname);
+			}
+			return FAILURE;
+		} else {
+			goto really_get_entry;
+		}
+	}
+
+	if (entry->is_modified && !for_write) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for reading, writable file pointers are open", path, fname);
+		}
+		return FAILURE;
+	}
+
+	if (entry->fp_refcount && for_write) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for writing, readable file pointers are open", path, fname);
+		}
+		return FAILURE;
+	}
+
+	if (entry->is_deleted) {
+		if (!for_create) {
+			return FAILURE;
+		}
+		entry->is_deleted = 0;
+	}
+
+	if (entry->is_dir) {
+		*ret = (phar_entry_data *) emalloc(sizeof(phar_entry_data));
+		(*ret)->position = 0;
+		(*ret)->fp = NULL;
+		(*ret)->phar = phar;
+		(*ret)->for_write = for_write;
+		(*ret)->internal_file = entry;
+		(*ret)->is_zip = entry->is_zip;
+		(*ret)->is_tar = entry->is_tar;
+
+		if (!phar->is_persistent) {
+			++(entry->phar->refcount);
+			++(entry->fp_refcount);
+		}
+
+		return SUCCESS;
+	}
+
+	if (entry->fp_type == PHAR_MOD) {
+		if (for_trunc) {
+			if (FAILURE == phar_create_writeable_entry(phar, entry, error TSRMLS_CC)) {
+				return FAILURE;
+			}
+		} else if (for_append) {
+			phar_seek_efp(entry, 0, SEEK_END, 0, 0 TSRMLS_CC);
+		}
+	} else {
+		if (for_write) {
+			if (entry->link) {
+				efree(entry->link);
+				entry->link = NULL;
+				entry->tar_type = (entry->is_tar ? TAR_FILE : '\0');
+			}
+
+			if (for_trunc) {
+				if (FAILURE == phar_create_writeable_entry(phar, entry, error TSRMLS_CC)) {
+					return FAILURE;
+				}
+			} else {
+				if (FAILURE == phar_separate_entry_fp(entry, error TSRMLS_CC)) {
+					return FAILURE;
+				}
+			}
+		} else {
+			if (FAILURE == phar_open_entry_fp(entry, error, 1 TSRMLS_CC)) {
+				return FAILURE;
+			}
+		}
+	}
+
+	*ret = (phar_entry_data *) emalloc(sizeof(phar_entry_data));
+	(*ret)->position = 0;
+	(*ret)->phar = phar;
+	(*ret)->for_write = for_write;
+	(*ret)->internal_file = entry;
+	(*ret)->is_zip = entry->is_zip;
+	(*ret)->is_tar = entry->is_tar;
+	(*ret)->fp = phar_get_efp(entry, 1 TSRMLS_CC);
+	if (entry->link) {
+		phar_entry_info *link = phar_get_link_source(entry TSRMLS_CC);
+		if(!link) {
+			efree(*ret);
+			return FAILURE;
+		}
+		(*ret)->zero = phar_get_fp_offset(link TSRMLS_CC);
+	} else {
+		(*ret)->zero = phar_get_fp_offset(entry TSRMLS_CC);
+	}
+
+	if (!phar->is_persistent) {
+		++(entry->fp_refcount);
+		++(entry->phar->refcount);
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/**
+ * Create a new dummy file slot within a writeable phar for a newly created file
+ */
+phar_entry_data *phar_get_or_create_entry_data(char *fname, int fname_len, char *path, int path_len, const char *mode, char allow_dir, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *phar;
+	phar_entry_info *entry, etemp;
+	phar_entry_data *ret;
+	const char *pcr_error;
+	char is_dir;
+
+#ifdef PHP_WIN32
+	phar_unixify_path_separators(path, path_len);
+#endif
+
+	is_dir = (path_len && path[path_len - 1] == '/') ? 1 : 0;
+
+	if (FAILURE == phar_get_archive(&phar, fname, fname_len, NULL, 0, error TSRMLS_CC)) {
+		return NULL;
+	}
+
+	if (FAILURE == phar_get_entry_data(&ret, fname, fname_len, path, path_len, mode, allow_dir, error, security TSRMLS_CC)) {
+		return NULL;
+	} else if (ret) {
+		return ret;
+	}
+
+	if (phar_path_check(&path, &path_len, &pcr_error) > pcr_is_ok) {
+		if (error) {
+			spprintf(error, 0, "phar error: invalid path \"%s\" contains %s", path, pcr_error);
+		}
+		return NULL;
+	}
+
+	if (phar->is_persistent && FAILURE == phar_copy_on_write(&phar TSRMLS_CC)) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be created, could not make cached phar writeable", path, fname);
+		}
+		return NULL;
+	}
+
+	/* create a new phar data holder */
+	ret = (phar_entry_data *) emalloc(sizeof(phar_entry_data));
+
+	/* create an entry, this is a new file */
+	memset(&etemp, 0, sizeof(phar_entry_info));
+	etemp.filename_len = path_len;
+	etemp.fp_type = PHAR_MOD;
+	etemp.fp = php_stream_fopen_tmpfile();
+
+	if (!etemp.fp) {
+		if (error) {
+			spprintf(error, 0, "phar error: unable to create temporary file");
+		}
+		efree(ret);
+		return NULL;
+	}
+
+	etemp.fp_refcount = 1;
+
+	if (allow_dir == 2) {
+		etemp.is_dir = 1;
+		etemp.flags = etemp.old_flags = PHAR_ENT_PERM_DEF_DIR;
+	} else {
+		etemp.flags = etemp.old_flags = PHAR_ENT_PERM_DEF_FILE;
+	}
+	if (is_dir) {
+		etemp.filename_len--; /* strip trailing / */
+		path_len--;
+	}
+
+	phar_add_virtual_dirs(phar, path, path_len TSRMLS_CC);
+	etemp.is_modified = 1;
+	etemp.timestamp = time(0);
+	etemp.is_crc_checked = 1;
+	etemp.phar = phar;
+	etemp.filename = estrndup(path, path_len);
+	etemp.is_zip = phar->is_zip;
+
+	if (phar->is_tar) {
+		etemp.is_tar = phar->is_tar;
+		etemp.tar_type = etemp.is_dir ? TAR_DIR : TAR_FILE;
+	}
+
+	if (FAILURE == zend_hash_add(&phar->manifest, etemp.filename, path_len, (void*)&etemp, sizeof(phar_entry_info), (void **) &entry)) {
+		php_stream_close(etemp.fp);
+		if (error) {
+			spprintf(error, 0, "phar error: unable to add new entry \"%s\" to phar \"%s\"", etemp.filename, phar->fname);
+		}
+		efree(ret);
+		efree(etemp.filename);
+		return NULL;
+	}
+
+	if (!entry) {
+		php_stream_close(etemp.fp);
+		efree(etemp.filename);
+		efree(ret);
+		return NULL;
+	}
+
+	++(phar->refcount);
+	ret->phar = phar;
+	ret->fp = entry->fp;
+	ret->position = ret->zero = 0;
+	ret->for_write = 1;
+	ret->is_zip = entry->is_zip;
+	ret->is_tar = entry->is_tar;
+	ret->internal_file = entry;
+
+	return ret;
+}
+/* }}} */
+
+/* initialize a phar_archive_data's read-only fp for existing phar data */
+int phar_open_archive_fp(phar_archive_data *phar TSRMLS_DC) /* {{{ */
+{
+	if (phar_get_pharfp(phar TSRMLS_CC)) {
+		return SUCCESS;
+	}
+
+	if (php_check_open_basedir(phar->fname TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	phar_set_pharfp(phar, php_stream_open_wrapper(phar->fname, "rb", IGNORE_URL|STREAM_MUST_SEEK|0, NULL) TSRMLS_CC);
+
+	if (!phar_get_pharfp(phar TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* copy file data from an existing to a new phar_entry_info that is not in the manifest */
+int phar_copy_entry_fp(phar_entry_info *source, phar_entry_info *dest, char **error TSRMLS_DC) /* {{{ */
+{
+	phar_entry_info *link;
+
+	if (FAILURE == phar_open_entry_fp(source, error, 1 TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (dest->link) {
+		efree(dest->link);
+		dest->link = NULL;
+		dest->tar_type = (dest->is_tar ? TAR_FILE : '\0');
+	}
+
+	dest->fp_type = PHAR_MOD;
+	dest->offset = 0;
+	dest->is_modified = 1;
+	dest->fp = php_stream_fopen_tmpfile();
+	if (dest->fp == NULL) {
+		spprintf(error, 0, "phar error: unable to create temporary file");
+		return EOF;
+	}
+	phar_seek_efp(source, 0, SEEK_SET, 0, 1 TSRMLS_CC);
+	link = phar_get_link_source(source TSRMLS_CC);
+
+	if (!link) {
+		link = source;
+	}
+
+	if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(link, 0 TSRMLS_CC), dest->fp, link->uncompressed_filesize, NULL)) {
+		php_stream_close(dest->fp);
+		dest->fp_type = PHAR_FP;
+		if (error) {
+			spprintf(error, 4096, "phar error: unable to copy contents of file \"%s\" to \"%s\" in phar archive \"%s\"", source->filename, dest->filename, source->phar->fname);
+		}
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* open and decompress a compressed phar entry
+ */
+int phar_open_entry_fp(phar_entry_info *entry, char **error, int follow_links TSRMLS_DC) /* {{{ */
+{
+	php_stream_filter *filter;
+	phar_archive_data *phar = entry->phar;
+	char *filtername;
+	off_t loc;
+	php_stream *ufp;
+	phar_entry_data dummy;
+
+	if (follow_links && entry->link) {
+		phar_entry_info *link_entry = phar_get_link_source(entry TSRMLS_CC);
+		if (link_entry && link_entry != entry) {
+			return phar_open_entry_fp(link_entry, error, 1 TSRMLS_CC);
+		}
+	}
+
+	if (entry->is_modified) {
+		return SUCCESS;
+	}
+
+	if (entry->fp_type == PHAR_TMP) {
+		if (!entry->fp) {
+			entry->fp = php_stream_open_wrapper(entry->tmp, "rb", STREAM_MUST_SEEK|0, NULL);
+		}
+		return SUCCESS;
+	}
+
+	if (entry->fp_type != PHAR_FP) {
+		/* either newly created or already modified */
+		return SUCCESS;
+	}
+
+	if (!phar_get_pharfp(phar TSRMLS_CC)) {
+		if (FAILURE == phar_open_archive_fp(phar TSRMLS_CC)) {
+			spprintf(error, 4096, "phar error: Cannot open phar archive \"%s\" for reading", phar->fname);
+			return FAILURE;
+		}
+	}
+
+	if ((entry->old_flags && !(entry->old_flags & PHAR_ENT_COMPRESSION_MASK)) || !(entry->flags & PHAR_ENT_COMPRESSION_MASK)) {
+		dummy.internal_file = entry;
+		dummy.phar = phar;
+		dummy.zero = entry->offset;
+		dummy.fp = phar_get_pharfp(phar TSRMLS_CC);
+		if (FAILURE == phar_postprocess_file(&dummy, entry->crc32, error, 1 TSRMLS_CC)) {
+			return FAILURE;
+		}
+		return SUCCESS;
+	}
+
+	if (!phar_get_entrypufp(entry TSRMLS_CC)) {
+		phar_set_entrypufp(entry, php_stream_fopen_tmpfile() TSRMLS_CC);
+		if (!phar_get_entrypufp(entry TSRMLS_CC)) {
+			spprintf(error, 4096, "phar error: Cannot open temporary file for decompressing phar archive \"%s\" file \"%s\"", phar->fname, entry->filename);
+			return FAILURE;
+		}
+	}
+
+	dummy.internal_file = entry;
+	dummy.phar = phar;
+	dummy.zero = entry->offset;
+	dummy.fp = phar_get_pharfp(phar TSRMLS_CC);
+	if (FAILURE == phar_postprocess_file(&dummy, entry->crc32, error, 1 TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	ufp = phar_get_entrypufp(entry TSRMLS_CC);
+
+	if ((filtername = phar_decompress_filter(entry, 0)) != NULL) {
+		filter = php_stream_filter_create(filtername, NULL, 0 TSRMLS_CC);
+	} else {
+		filter = NULL;
+	}
+
+	if (!filter) {
+		spprintf(error, 4096, "phar error: unable to read phar \"%s\" (cannot create %s filter while decompressing file \"%s\")", phar->fname, phar_decompress_filter(entry, 1), entry->filename);
+		return FAILURE;
+	}
+
+	/* now we can safely use proper decompression */
+	/* save the new offset location within ufp */
+	php_stream_seek(ufp, 0, SEEK_END);
+	loc = php_stream_tell(ufp);
+	php_stream_filter_append(&ufp->writefilters, filter);
+	php_stream_seek(phar_get_entrypfp(entry TSRMLS_CC), phar_get_fp_offset(entry TSRMLS_CC), SEEK_SET);
+
+	if (entry->uncompressed_filesize) {
+		if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_entrypfp(entry TSRMLS_CC), ufp, entry->compressed_filesize, NULL)) {
+			spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", phar->fname, entry->filename);
+			php_stream_filter_remove(filter, 1 TSRMLS_CC);
+			return FAILURE;
+		}
+	}
+
+	php_stream_filter_flush(filter, 1);
+	php_stream_flush(ufp);
+	php_stream_filter_remove(filter, 1 TSRMLS_CC);
+
+	if (php_stream_tell(ufp) - loc != (off_t) entry->uncompressed_filesize) {
+		spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", phar->fname, entry->filename);
+		return FAILURE;
+	}
+
+	entry->old_flags = entry->flags;
+
+	/* this is now the new location of the file contents within this fp */
+	phar_set_fp_type(entry, PHAR_UFP, loc TSRMLS_CC);
+	dummy.zero = entry->offset;
+	dummy.fp = ufp;
+	if (FAILURE == phar_postprocess_file(&dummy, entry->crc32, error, 0 TSRMLS_CC)) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+int phar_create_writeable_entry(phar_archive_data *phar, phar_entry_info *entry, char **error TSRMLS_DC) /* {{{ */
+{
+	if (entry->fp_type == PHAR_MOD) {
+		/* already newly created, truncate */
+		php_stream_truncate_set_size(entry->fp, 0);
+
+		entry->old_flags = entry->flags;
+		entry->is_modified = 1;
+		phar->is_modified = 1;
+		/* reset file size */
+		entry->uncompressed_filesize = 0;
+		entry->compressed_filesize = 0;
+		entry->crc32 = 0;
+		entry->flags = PHAR_ENT_PERM_DEF_FILE;
+		entry->fp_type = PHAR_MOD;
+		entry->offset = 0;
+		return SUCCESS;
+	}
+
+	if (error) {
+		*error = NULL;
+	}
+
+	/* open a new temp file for writing */
+	if (entry->link) {
+		efree(entry->link);
+		entry->link = NULL;
+		entry->tar_type = (entry->is_tar ? TAR_FILE : '\0');
+	}
+
+	entry->fp = php_stream_fopen_tmpfile();
+
+	if (!entry->fp) {
+		if (error) {
+			spprintf(error, 0, "phar error: unable to create temporary file");
+		}
+		return FAILURE;
+	}
+
+	entry->old_flags = entry->flags;
+	entry->is_modified = 1;
+	phar->is_modified = 1;
+	/* reset file size */
+	entry->uncompressed_filesize = 0;
+	entry->compressed_filesize = 0;
+	entry->crc32 = 0;
+	entry->flags = PHAR_ENT_PERM_DEF_FILE;
+	entry->fp_type = PHAR_MOD;
+	entry->offset = 0;
+	return SUCCESS;
+}
+/* }}} */
+
+int phar_separate_entry_fp(phar_entry_info *entry, char **error TSRMLS_DC) /* {{{ */
+{
+	php_stream *fp;
+	phar_entry_info *link;
+
+	if (FAILURE == phar_open_entry_fp(entry, error, 1 TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (entry->fp_type == PHAR_MOD) {
+		return SUCCESS;
+	}
+
+	fp = php_stream_fopen_tmpfile();
+	if (fp == NULL) {
+		spprintf(error, 0, "phar error: unable to create temporary file");
+		return FAILURE;
+	}
+	phar_seek_efp(entry, 0, SEEK_SET, 0, 1 TSRMLS_CC);
+	link = phar_get_link_source(entry TSRMLS_CC);
+
+	if (!link) {
+		link = entry;
+	}
+
+	if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(link, 0 TSRMLS_CC), fp, link->uncompressed_filesize, NULL)) {
+		if (error) {
+			spprintf(error, 4096, "phar error: cannot separate entry file \"%s\" contents in phar archive \"%s\" for write access", entry->filename, entry->phar->fname);
+		}
+		return FAILURE;
+	}
+
+	if (entry->link) {
+		efree(entry->link);
+		entry->link = NULL;
+		entry->tar_type = (entry->is_tar ? TAR_FILE : '\0');
+	}
+
+	entry->offset = 0;
+	entry->fp = fp;
+	entry->fp_type = PHAR_MOD;
+	entry->is_modified = 1;
+	return SUCCESS;
+}
+/* }}} */
+
+/**
+ * helper function to open an internal file's fp just-in-time
+ */
+phar_entry_info * phar_open_jit(phar_archive_data *phar, phar_entry_info *entry, char **error TSRMLS_DC) /* {{{ */
+{
+	if (error) {
+		*error = NULL;
+	}
+	/* seek to start of internal file and read it */
+	if (FAILURE == phar_open_entry_fp(entry, error, 1 TSRMLS_CC)) {
+		return NULL;
+	}
+	if (-1 == phar_seek_efp(entry, 0, SEEK_SET, 0, 1 TSRMLS_CC)) {
+		spprintf(error, 4096, "phar error: cannot seek to start of file \"%s\" in phar \"%s\"", entry->filename, phar->fname);
+		return NULL;
+	}
+	return entry;
+}
+/* }}} */
+
+PHP_PHAR_API int phar_resolve_alias(char *alias, int alias_len, char **filename, int *filename_len TSRMLS_DC) /* {{{ */ {
+	phar_archive_data **fd_ptr;
+	if (PHAR_GLOBALS->phar_alias_map.arBuckets
+			&& SUCCESS == zend_hash_find(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, (void**)&fd_ptr)) {
+		*filename = (*fd_ptr)->fname;
+		*filename_len = (*fd_ptr)->fname_len;
+		return SUCCESS;
+	}
+	return FAILURE;
+}
+/* }}} */
+
+int phar_free_alias(phar_archive_data *phar, char *alias, int alias_len TSRMLS_DC) /* {{{ */
+{
+	if (phar->refcount || phar->is_persistent) {
+		return FAILURE;
+	}
+
+	/* this archive has no open references, so emit an E_STRICT and remove it */
+	if (zend_hash_del(&(PHAR_GLOBALS->phar_fname_map), phar->fname, phar->fname_len) != SUCCESS) {
+		return FAILURE;
+	}
+
+	/* invalidate phar cache */
+	PHAR_G(last_phar) = NULL;
+	PHAR_G(last_phar_name) = PHAR_G(last_alias) = NULL;
+
+	return SUCCESS;
+}
+/* }}} */
+
+/**
+ * Looks up a phar archive in the filename map, connecting it to the alias
+ * (if any) or returns null
+ */
+int phar_get_archive(phar_archive_data **archive, char *fname, int fname_len, char *alias, int alias_len, char **error TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *fd, **fd_ptr;
+	char *my_realpath, *save;
+	int save_len;
+	ulong fhash, ahash = 0;
+
+	phar_request_initialize(TSRMLS_C);
+
+	if (error) {
+		*error = NULL;
+	}
+
+	*archive = NULL;
+
+	if (PHAR_G(last_phar) && fname_len == PHAR_G(last_phar_name_len) && !memcmp(fname, PHAR_G(last_phar_name), fname_len)) {
+		*archive = PHAR_G(last_phar);
+		if (alias && alias_len) {
+
+			if (!PHAR_G(last_phar)->is_temporary_alias && (alias_len != PHAR_G(last_phar)->alias_len || memcmp(PHAR_G(last_phar)->alias, alias, alias_len))) {
+				if (error) {
+					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, PHAR_G(last_phar)->fname, fname);
+				}
+				*archive = NULL;
+				return FAILURE;
+			}
+
+			if (PHAR_G(last_phar)->alias_len && SUCCESS == zend_hash_find(&(PHAR_GLOBALS->phar_alias_map), PHAR_G(last_phar)->alias, PHAR_G(last_phar)->alias_len, (void**)&fd_ptr)) {
+				zend_hash_del(&(PHAR_GLOBALS->phar_alias_map), PHAR_G(last_phar)->alias, PHAR_G(last_phar)->alias_len);
+			}
+
+			zend_hash_add(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, (void*)&(*archive), sizeof(phar_archive_data*), NULL);
+			PHAR_G(last_alias) = alias;
+			PHAR_G(last_alias_len) = alias_len;
+		}
+
+		return SUCCESS;
+	}
+
+	if (alias && alias_len && PHAR_G(last_phar) && alias_len == PHAR_G(last_alias_len) && !memcmp(alias, PHAR_G(last_alias), alias_len)) {
+		fd = PHAR_G(last_phar);
+		fd_ptr = &fd;
+		goto alias_success;
+	}
+
+	if (alias && alias_len) {
+		ahash = zend_inline_hash_func(alias, alias_len);
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, ahash, (void**)&fd_ptr)) {
+alias_success:
+			if (fname && (fname_len != (*fd_ptr)->fname_len || strncmp(fname, (*fd_ptr)->fname, fname_len))) {
+				if (error) {
+					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, (*fd_ptr)->fname, fname);
+				}
+				if (SUCCESS == phar_free_alias(*fd_ptr, alias, alias_len TSRMLS_CC)) {
+					if (error) {
+						efree(*error);
+						*error = NULL;
+					}
+				}
+				return FAILURE;
+			}
+
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = alias;
+			PHAR_G(last_alias_len) = alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_alias, alias, alias_len, ahash, (void **)&fd_ptr)) {
+			goto alias_success;
+		}
+	}
+
+	fhash = zend_inline_hash_func(fname, fname_len);
+	my_realpath = NULL;
+	save = fname;
+	save_len = fname_len;
+
+	if (fname && fname_len) {
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_fname_map), fname, fname_len, fhash, (void**)&fd_ptr)) {
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+
+			if (alias && alias_len) {
+				if (!fd->is_temporary_alias && (alias_len != fd->alias_len || memcmp(fd->alias, alias, alias_len))) {
+					if (error) {
+						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, (*fd_ptr)->fname, fname);
+					}
+					return FAILURE;
+				}
+
+				if (fd->alias_len && SUCCESS == zend_hash_find(&(PHAR_GLOBALS->phar_alias_map), fd->alias, fd->alias_len, (void**)&fd_ptr)) {
+					zend_hash_del(&(PHAR_GLOBALS->phar_alias_map), fd->alias, fd->alias_len);
+				}
+
+				zend_hash_quick_add(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, ahash, (void*)&fd, sizeof(phar_archive_data*), NULL);
+			}
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_phars, fname, fname_len, fhash, (void**)&fd_ptr)) {
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+
+			/* this could be problematic - alias should never be different from manifest alias
+			   for cached phars */
+			if (!fd->is_temporary_alias && alias && alias_len) {
+				if (alias_len != fd->alias_len || memcmp(fd->alias, alias, alias_len)) {
+					if (error) {
+						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, (*fd_ptr)->fname, fname);
+					}
+					return FAILURE;
+				}
+			}
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_alias_map), save, save_len, fhash, (void**)&fd_ptr)) {
+			fd = *archive = *fd_ptr;
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_alias, save, save_len, fhash, (void**)&fd_ptr)) {
+			fd = *archive = *fd_ptr;
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		/* not found, try converting \ to / */
+		my_realpath = expand_filepath(fname, my_realpath TSRMLS_CC);
+
+		if (my_realpath) {
+			fname_len = strlen(my_realpath);
+			fname = my_realpath;
+		} else {
+			return FAILURE;
+		}
+#ifdef PHP_WIN32
+		phar_unixify_path_separators(fname, fname_len);
+#endif
+		fhash = zend_inline_hash_func(fname, fname_len);
+
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_fname_map), fname, fname_len, fhash, (void**)&fd_ptr)) {
+realpath_success:
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+
+			if (alias && alias_len) {
+				zend_hash_quick_add(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, ahash, (void*)&fd, sizeof(phar_archive_data*), NULL);
+			}
+
+			efree(my_realpath);
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_phars, fname, fname_len, fhash, (void**)&fd_ptr)) {
+			goto realpath_success;
+		}
+
+		efree(my_realpath);
+	}
+
+	return FAILURE;
+}
+/* }}} */
+
+/**
+ * Determine which stream compression filter (if any) we need to read this file
+ */
+char * phar_compress_filter(phar_entry_info * entry, int return_unknown) /* {{{ */
+{
+	switch (entry->flags & PHAR_ENT_COMPRESSION_MASK) {
+	case PHAR_ENT_COMPRESSED_GZ:
+		return "zlib.deflate";
+	case PHAR_ENT_COMPRESSED_BZ2:
+		return "bzip2.compress";
+	default:
+		return return_unknown ? "unknown" : NULL;
+	}
+}
+/* }}} */
+
+/**
+ * Determine which stream decompression filter (if any) we need to read this file
+ */
+char * phar_decompress_filter(phar_entry_info * entry, int return_unknown) /* {{{ */
+{
+	php_uint32 flags;
+
+	if (entry->is_modified) {
+		flags = entry->old_flags;
+	} else {
+		flags = entry->flags;
+	}
+
+	switch (flags & PHAR_ENT_COMPRESSION_MASK) {
+		case PHAR_ENT_COMPRESSED_GZ:
+			return "zlib.inflate";
+		case PHAR_ENT_COMPRESSED_BZ2:
+			return "bzip2.decompress";
+		default:
+			return return_unknown ? "unknown" : NULL;
+	}
+}
+/* }}} */
+
+/**
+ * retrieve information on a file contained within a phar, or null if it ain't there
+ */
+phar_entry_info *phar_get_entry_info(phar_archive_data *phar, char *path, int path_len, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	return phar_get_entry_info_dir(phar, path, path_len, 0, error, security TSRMLS_CC);
+}
+/* }}} */
+/**
+ * retrieve information on a file or directory contained within a phar, or null if none found
+ * allow_dir is 0 for none, 1 for both empty directories in the phar and temp directories, and 2 for only
+ * valid pre-existing empty directory entries
+ */
+phar_entry_info *phar_get_entry_info_dir(phar_archive_data *phar, char *path, int path_len, char dir, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	const char *pcr_error;
+	phar_entry_info *entry;
+	int is_dir;
+
+#ifdef PHP_WIN32
+	phar_unixify_path_separators(path, path_len);
+#endif
+
+	is_dir = (path_len && (path[path_len - 1] == '/')) ? 1 : 0;
+
+	if (error) {
+		*error = NULL;
+	}
+
+	if (security && path_len >= sizeof(".phar")-1 && !memcmp(path, ".phar", sizeof(".phar")-1)) {
+		if (error) {
+			spprintf(error, 4096, "phar error: cannot directly access magic \".phar\" directory or files within it");
+		}
+		return NULL;
+	}
+
+	if (!path_len && !dir) {
+		if (error) {
+			spprintf(error, 4096, "phar error: invalid path \"%s\" must not be empty", path);
+		}
+		return NULL;
+	}
+
+	if (phar_path_check(&path, &path_len, &pcr_error) > pcr_is_ok) {
+		if (error) {
+			spprintf(error, 4096, "phar error: invalid path \"%s\" contains %s", path, pcr_error);
+		}
+		return NULL;
+	}
+
+	if (!phar->manifest.arBuckets) {
+		return NULL;
+	}
+
+	if (is_dir) {
+		if (!path_len || path_len == 1) {
+			return NULL;
+		}
+		path_len--;
+	}
+
+	if (SUCCESS == zend_hash_find(&phar->manifest, path, path_len, (void**)&entry)) {
+		if (entry->is_deleted) {
+			/* entry is deleted, but has not been flushed to disk yet */
+			return NULL;
+		}
+		if (entry->is_dir && !dir) {
+			if (error) {
+				spprintf(error, 4096, "phar error: path \"%s\" is a directory", path);
+			}
+			return NULL;
+		}
+		if (!entry->is_dir && dir == 2) {
+			/* user requested a directory, we must return one */
+			if (error) {
+				spprintf(error, 4096, "phar error: path \"%s\" exists and is a not a directory", path);
+			}
+			return NULL;
+		}
+		return entry;
+	}
+
+	if (dir) {
+		if (zend_hash_exists(&phar->virtual_dirs, path, path_len)) {
+			/* a file or directory exists in a sub-directory of this path */
+			entry = (phar_entry_info *) ecalloc(1, sizeof(phar_entry_info));
+			/* this next line tells PharFileInfo->__destruct() to efree the filename */
+			entry->is_temp_dir = entry->is_dir = 1;
+			entry->filename = (char *) estrndup(path, path_len + 1);
+			entry->filename_len = path_len;
+			entry->phar = phar;
+			return entry;
+		}
+	}
+
+	if (phar->mounted_dirs.arBuckets && zend_hash_num_elements(&phar->mounted_dirs)) {
+		char *str_key;
+		ulong unused;
+		uint keylen;
+
+		zend_hash_internal_pointer_reset(&phar->mounted_dirs);
+		while (FAILURE != zend_hash_has_more_elements(&phar->mounted_dirs)) {
+			if (HASH_KEY_NON_EXISTENT == zend_hash_get_current_key_ex(&phar->mounted_dirs, &str_key, &keylen, &unused, 0, NULL)) {
+				break;
+			}
+
+			if ((int)keylen >= path_len || strncmp(str_key, path, keylen)) {
+				continue;
+			} else {
+				char *test;
+				int test_len;
+				php_stream_statbuf ssb;
+
+				if (SUCCESS != zend_hash_find(&phar->manifest, str_key, keylen, (void **) &entry)) {
+					if (error) {
+						spprintf(error, 4096, "phar internal error: mounted path \"%s\" could not be retrieved from manifest", str_key);
+					}
+					return NULL;
+				}
+
+				if (!entry->tmp || !entry->is_mounted) {
+					if (error) {
+						spprintf(error, 4096, "phar internal error: mounted path \"%s\" is not properly initialized as a mounted path", str_key);
+					}
+					return NULL;
+				}
+
+				test_len = spprintf(&test, MAXPATHLEN, "%s%s", entry->tmp, path + keylen);
+
+				if (SUCCESS != php_stream_stat_path(test, &ssb)) {
+					efree(test);
+					return NULL;
+				}
+
+				if (ssb.sb.st_mode & S_IFDIR && !dir) {
+					efree(test);
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" is a directory", path);
+					}
+					return NULL;
+				}
+
+				if ((ssb.sb.st_mode & S_IFDIR) == 0 && dir) {
+					efree(test);
+					/* user requested a directory, we must return one */
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" exists and is a not a directory", path);
+					}
+					return NULL;
+				}
+
+				/* mount the file just in time */
+				if (SUCCESS != phar_mount_entry(phar, test, test_len, path, path_len TSRMLS_CC)) {
+					efree(test);
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" exists as file \"%s\" and could not be mounted", path, test);
+					}
+					return NULL;
+				}
+
+				efree(test);
+
+				if (SUCCESS != zend_hash_find(&phar->manifest, path, path_len, (void**)&entry)) {
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" exists as file \"%s\" and could not be retrieved after being mounted", path, test);
+					}
+					return NULL;
+				}
+				return entry;
+			}
+		}
+	}
+
+	return NULL;
+}
+/* }}} */
+
+static const char hexChars[] = "0123456789ABCDEF";
+
+static int phar_hex_str(const char *digest, size_t digest_len, char **signature TSRMLS_DC) /* {{{ */
+{
+	int pos = -1;
+	size_t len = 0;
+
+	*signature = (char*)safe_pemalloc(digest_len, 2, 1, PHAR_G(persist));
+
+	for (; len < digest_len; ++len) {
+		(*signature)[++pos] = hexChars[((const unsigned char *)digest)[len] >> 4];
+		(*signature)[++pos] = hexChars[((const unsigned char *)digest)[len] & 0x0F];
+	}
+	(*signature)[++pos] = '\0';
+	return pos;
+}
+/* }}} */
+
+#ifndef PHAR_HAVE_OPENSSL
+static int phar_call_openssl_signverify(int is_sign, php_stream *fp, off_t end, char *key, int key_len, char **signature, int *signature_len TSRMLS_DC) /* {{{ */
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+	zval *zdata, *zsig, *zkey, *retval_ptr, **zp[3], *openssl;
+
+	MAKE_STD_ZVAL(zdata);
+	MAKE_STD_ZVAL(openssl);
+	ZVAL_STRINGL(openssl, is_sign ? "openssl_sign" : "openssl_verify", is_sign ? sizeof("openssl_sign")-1 : sizeof("openssl_verify")-1, 1);
+	MAKE_STD_ZVAL(zsig);
+	ZVAL_STRINGL(zsig, *signature, *signature_len, 1);
+	MAKE_STD_ZVAL(zkey);
+	ZVAL_STRINGL(zkey, key, key_len, 1);
+	zp[0] = &zdata;
+	zp[1] = &zsig;
+	zp[2] = &zkey;
+
+	php_stream_rewind(fp);
+	Z_TYPE_P(zdata) = IS_STRING;
+	Z_STRLEN_P(zdata) = end;
+
+	if (end != (off_t) php_stream_copy_to_mem(fp, &(Z_STRVAL_P(zdata)), (size_t) end, 0)) {
+		zval_dtor(zdata);
+		zval_dtor(zsig);
+		zval_dtor(zkey);
+		zval_dtor(openssl);
+		efree(openssl);
+		efree(zdata);
+		efree(zkey);
+		efree(zsig);
+		return FAILURE;
+	}
+
+	if (FAILURE == zend_fcall_info_init(openssl, 0, &fci, &fcc, NULL, NULL TSRMLS_CC)) {
+		zval_dtor(zdata);
+		zval_dtor(zsig);
+		zval_dtor(zkey);
+		zval_dtor(openssl);
+		efree(openssl);
+		efree(zdata);
+		efree(zkey);
+		efree(zsig);
+		return FAILURE;
+	}
+
+	fci.param_count = 3;
+	fci.params = zp;
+	Z_ADDREF_P(zdata);
+	if (is_sign) {
+		Z_SET_ISREF_P(zsig);
+	} else {
+		Z_ADDREF_P(zsig);
+	}
+	Z_ADDREF_P(zkey);
+
+	fci.retval_ptr_ptr = &retval_ptr;
+
+	if (FAILURE == zend_call_function(&fci, &fcc TSRMLS_CC)) {
+		zval_dtor(zdata);
+		zval_dtor(zsig);
+		zval_dtor(zkey);
+		zval_dtor(openssl);
+		efree(openssl);
+		efree(zdata);
+		efree(zkey);
+		efree(zsig);
+		return FAILURE;
+	}
+
+	zval_dtor(openssl);
+	efree(openssl);
+	Z_DELREF_P(zdata);
+
+	if (is_sign) {
+		Z_UNSET_ISREF_P(zsig);
+	} else {
+		Z_DELREF_P(zsig);
+	}
+	Z_DELREF_P(zkey);
+
+	zval_dtor(zdata);
+	efree(zdata);
+	zval_dtor(zkey);
+	efree(zkey);
+
+	switch (Z_TYPE_P(retval_ptr)) {
+		default:
+		case IS_LONG:
+			zval_dtor(zsig);
+			efree(zsig);
+			if (1 == Z_LVAL_P(retval_ptr)) {
+				efree(retval_ptr);
+				return SUCCESS;
+			}
+			efree(retval_ptr);
+			return FAILURE;
+		case IS_BOOL:
+			efree(retval_ptr);
+			if (Z_BVAL_P(retval_ptr)) {
+				*signature = estrndup(Z_STRVAL_P(zsig), Z_STRLEN_P(zsig));
+				*signature_len = Z_STRLEN_P(zsig);
+				zval_dtor(zsig);
+				efree(zsig);
+				return SUCCESS;
+			}
+			zval_dtor(zsig);
+			efree(zsig);
+			return FAILURE;
+	}
+}
+/* }}} */
+#endif /* #ifndef PHAR_HAVE_OPENSSL */
+
+int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_type, char *sig, int sig_len, char *fname, char **signature, int *signature_len, char **error TSRMLS_DC) /* {{{ */
+{
+	int read_size, len;
+	off_t read_len;
+	unsigned char buf[1024];
+
+	php_stream_rewind(fp);
+
+	switch (sig_type) {
+		case PHAR_SIG_OPENSSL: {
+#ifdef PHAR_HAVE_OPENSSL
+			BIO *in;
+			EVP_PKEY *key;
+			EVP_MD *mdtype = (EVP_MD *) EVP_sha1();
+			EVP_MD_CTX *md_ctx;
+#else
+			int tempsig;
+#endif
+			php_uint32 pubkey_len;
+			char *pubkey = NULL, *pfile;
+			php_stream *pfp;
+#ifndef PHAR_HAVE_OPENSSL
+			if (!zend_hash_exists(&module_registry, "openssl", sizeof("openssl"))) {
+				if (error) {
+					spprintf(error, 0, "openssl not loaded");
+				}
+				return FAILURE;
+			}
+#endif
+			/* use __FILE__ . '.pubkey' for public key file */
+			spprintf(&pfile, 0, "%s.pubkey", fname);
+			pfp = php_stream_open_wrapper(pfile, "rb", 0, NULL);
+			efree(pfile);
+
+#if PHP_MAJOR_VERSION > 5
+			if (!pfp || !(pubkey_len = php_stream_copy_to_mem(pfp, (void **) &pubkey, PHP_STREAM_COPY_ALL, 0)) || !pubkey) {
+#else
+			if (!pfp || !(pubkey_len = php_stream_copy_to_mem(pfp, &pubkey, PHP_STREAM_COPY_ALL, 0)) || !pubkey) {
+#endif
+				if (pfp) {
+					php_stream_close(pfp);
+				}
+				if (error) {
+					spprintf(error, 0, "openssl public key could not be read");
+				}
+				return FAILURE;
+			}
+
+			php_stream_close(pfp);
+#ifndef PHAR_HAVE_OPENSSL
+			tempsig = sig_len;
+
+			if (FAILURE == phar_call_openssl_signverify(0, fp, end_of_phar, pubkey, pubkey_len, &sig, &tempsig TSRMLS_CC)) {
+				if (pubkey) {
+					efree(pubkey);
+				}
+
+				if (error) {
+					spprintf(error, 0, "openssl signature could not be verified");
+				}
+
+				return FAILURE;
+			}
+
+			if (pubkey) {
+				efree(pubkey);
+			}
+
+			sig_len = tempsig;
+#else
+			in = BIO_new_mem_buf(pubkey, pubkey_len);
+
+			if (NULL == in) {
+				efree(pubkey);
+				if (error) {
+					spprintf(error, 0, "openssl signature could not be processed");
+				}
+				return FAILURE;
+			}
+
+			key = PEM_read_bio_PUBKEY(in, NULL,NULL, NULL);
+			BIO_free(in);
+			efree(pubkey);
+
+			if (NULL == key) {
+				if (error) {
+					spprintf(error, 0, "openssl signature could not be processed");
+				}
+				return FAILURE;
+			}
+
+			md_ctx = EVP_MD_CTX_create();
+			EVP_VerifyInit(md_ctx, mdtype);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			php_stream_seek(fp, 0, SEEK_SET);
+
+			while (read_size && (len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				EVP_VerifyUpdate (md_ctx, buf, len);
+				read_len -= (off_t)len;
+
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			if (EVP_VerifyFinal(md_ctx, (unsigned char *)sig, sig_len, key) != 1) {
+				/* 1: signature verified, 0: signature does not match, -1: failed signature operation */
+				EVP_MD_CTX_destroy(md_ctx);
+
+				if (error) {
+					spprintf(error, 0, "broken openssl signature");
+				}
+
+				return FAILURE;
+			}
+
+			EVP_MD_CTX_destroy(md_ctx);
+#endif
+
+			*signature_len = phar_hex_str((const char*)sig, sig_len, signature TSRMLS_CC);
+		}
+		break;
+#ifdef PHAR_HASH_OK
+		case PHAR_SIG_SHA512: {
+			unsigned char digest[64];
+			PHP_SHA512_CTX context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_SHA512Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_SHA512Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_SHA512Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+		case PHAR_SIG_SHA256: {
+			unsigned char digest[32];
+			PHP_SHA256_CTX context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_SHA256Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_SHA256Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_SHA256Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+#else
+		case PHAR_SIG_SHA512:
+		case PHAR_SIG_SHA256:
+			if (error) {
+				spprintf(error, 0, "unsupported signature");
+			}
+			return FAILURE;
+#endif
+		case PHAR_SIG_SHA1: {
+			unsigned char digest[20];
+			PHP_SHA1_CTX  context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_SHA1Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_SHA1Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_SHA1Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+		case PHAR_SIG_MD5: {
+			unsigned char digest[16];
+			PHP_MD5_CTX   context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_MD5Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_MD5Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_MD5Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+		default:
+			if (error) {
+				spprintf(error, 0, "broken or unsupported signature");
+			}
+			return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signature, int *signature_length, char **error TSRMLS_DC) /* {{{ */
+{
+	unsigned char buf[1024];
+	int sig_len;
+
+	php_stream_rewind(fp);
+
+	if (phar->signature) {
+		efree(phar->signature);
+		phar->signature = NULL;
+	}
+
+	switch(phar->sig_flags) {
+#ifdef PHAR_HASH_OK
+		case PHAR_SIG_SHA512: {
+			unsigned char digest[64];
+			PHP_SHA512_CTX context;
+
+			PHP_SHA512Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_SHA512Update(&context, buf, sig_len);
+			}
+
+			PHP_SHA512Final(digest, &context);
+			*signature = estrndup((char *) digest, 64);
+			*signature_length = 64;
+			break;
+		}
+		case PHAR_SIG_SHA256: {
+			unsigned char digest[32];
+			PHP_SHA256_CTX  context;
+
+			PHP_SHA256Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_SHA256Update(&context, buf, sig_len);
+			}
+
+			PHP_SHA256Final(digest, &context);
+			*signature = estrndup((char *) digest, 32);
+			*signature_length = 32;
+			break;
+		}
+#else
+		case PHAR_SIG_SHA512:
+		case PHAR_SIG_SHA256:
+			if (error) {
+				spprintf(error, 0, "unable to write to phar \"%s\" with requested hash type", phar->fname);
+			}
+
+			return FAILURE;
+#endif
+		case PHAR_SIG_OPENSSL: {
+			int siglen;
+			unsigned char *sigbuf;
+#ifdef PHAR_HAVE_OPENSSL
+			BIO *in;
+			EVP_PKEY *key;
+			EVP_MD_CTX *md_ctx;
+
+			in = BIO_new_mem_buf(PHAR_G(openssl_privatekey), PHAR_G(openssl_privatekey_len));
+
+			if (in == NULL) {
+				if (error) {
+					spprintf(error, 0, "unable to write to phar \"%s\" with requested openssl signature", phar->fname);
+				}
+				return FAILURE;
+			}
+
+			key = PEM_read_bio_PrivateKey(in, NULL,NULL, "");
+			BIO_free(in);
+
+			if (!key) {
+				if (error) {
+					spprintf(error, 0, "unable to process private key");
+				}
+				return FAILURE;
+			}
+
+			md_ctx = EVP_MD_CTX_create();
+
+			siglen = EVP_PKEY_size(key);
+			sigbuf = emalloc(siglen + 1);
+
+			if (!EVP_SignInit(md_ctx, EVP_sha1())) {
+				efree(sigbuf);
+				if (error) {
+					spprintf(error, 0, "unable to initialize openssl signature for phar \"%s\"", phar->fname);
+				}
+				return FAILURE;
+			}
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				if (!EVP_SignUpdate(md_ctx, buf, sig_len)) {
+					efree(sigbuf);
+					if (error) {
+						spprintf(error, 0, "unable to update the openssl signature for phar \"%s\"", phar->fname);
+					}
+					return FAILURE;
+				}
+			}
+
+			if (!EVP_SignFinal (md_ctx, sigbuf,(unsigned int *)&siglen, key)) {
+				efree(sigbuf);
+				if (error) {
+					spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", phar->fname);
+				}
+				return FAILURE;
+			}
+
+			sigbuf[siglen] = '\0';
+			EVP_MD_CTX_destroy(md_ctx);
+#else
+			sigbuf = NULL;
+			siglen = 0;
+			php_stream_seek(fp, 0, SEEK_END);
+
+			if (FAILURE == phar_call_openssl_signverify(1, fp, php_stream_tell(fp), PHAR_G(openssl_privatekey), PHAR_G(openssl_privatekey_len), (char **)&sigbuf, &siglen TSRMLS_CC)) {
+				if (error) {
+					spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", phar->fname);
+				}
+				return FAILURE;
+			}
+#endif
+			*signature = (char *) sigbuf;
+			*signature_length = siglen;
+		}
+		break;
+		default:
+			phar->sig_flags = PHAR_SIG_SHA1;
+		case PHAR_SIG_SHA1: {
+			unsigned char digest[20];
+			PHP_SHA1_CTX  context;
+
+			PHP_SHA1Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_SHA1Update(&context, buf, sig_len);
+			}
+
+			PHP_SHA1Final(digest, &context);
+			*signature = estrndup((char *) digest, 20);
+			*signature_length = 20;
+			break;
+		}
+		case PHAR_SIG_MD5: {
+			unsigned char digest[16];
+			PHP_MD5_CTX   context;
+
+			PHP_MD5Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_MD5Update(&context, buf, sig_len);
+			}
+
+			PHP_MD5Final(digest, &context);
+			*signature = estrndup((char *) digest, 16);
+			*signature_length = 16;
+			break;
+		}
+	}
+
+	phar->sig_len = phar_hex_str((const char *)*signature, *signature_length, &phar->signature TSRMLS_CC);
+	return SUCCESS;
+}
+/* }}} */
+
+void phar_add_virtual_dirs(phar_archive_data *phar, char *filename, int filename_len TSRMLS_DC) /* {{{ */
+{
+	const char *s;
+
+	while ((s = zend_memrchr(filename, '/', filename_len))) {
+		filename_len = s - filename;
+		if (!filename_len || FAILURE == zend_hash_add_empty_element(&phar->virtual_dirs, filename, filename_len)) {
+			break;
+		}
+	}
+}
+/* }}} */
+
+static int phar_update_cached_entry(void *data, void *argument) /* {{{ */
+{
+	phar_entry_info *entry = (phar_entry_info *)data;
+	TSRMLS_FETCH();
+
+	entry->phar = (phar_archive_data *)argument;
+
+	if (entry->link) {
+		entry->link = estrdup(entry->link);
+	}
+
+	if (entry->tmp) {
+		entry->tmp = estrdup(entry->tmp);
+	}
+
+	entry->metadata_str.c = 0;
+	entry->filename = estrndup(entry->filename, entry->filename_len);
+	entry->is_persistent = 0;
+
+	if (entry->metadata) {
+		if (entry->metadata_len) {
+			char *buf = estrndup((char *) entry->metadata, entry->metadata_len);
+			/* assume success, we would have failed before */
+			phar_parse_metadata((char **) &buf, &entry->metadata, entry->metadata_len TSRMLS_CC);
+			efree(buf);
+		} else {
+			zval *t;
+
+			t = entry->metadata;
+			ALLOC_ZVAL(entry->metadata);
+			*entry->metadata = *t;
+			zval_copy_ctor(entry->metadata);
+			Z_SET_REFCOUNT_P(entry->metadata, 1);
+			entry->metadata_str.c = NULL;
+			entry->metadata_str.len = 0;
+		}
+	}
+	return ZEND_HASH_APPLY_KEEP;
+}
+/* }}} */
+
+static void phar_copy_cached_phar(phar_archive_data **pphar TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *phar;
+	HashTable newmanifest;
+	char *fname;
+	phar_archive_object **objphar;
+
+	phar = (phar_archive_data *) emalloc(sizeof(phar_archive_data));
+	*phar = **pphar;
+	phar->is_persistent = 0;
+	fname = phar->fname;
+	phar->fname = estrndup(phar->fname, phar->fname_len);
+	phar->ext = phar->fname + (phar->ext - fname);
+
+	if (phar->alias) {
+		phar->alias = estrndup(phar->alias, phar->alias_len);
+	}
+
+	if (phar->signature) {
+		phar->signature = estrdup(phar->signature);
+	}
+
+	if (phar->metadata) {
+		/* assume success, we would have failed before */
+		if (phar->metadata_len) {
+			char *buf = estrndup((char *) phar->metadata, phar->metadata_len);
+			phar_parse_metadata(&buf, &phar->metadata, phar->metadata_len TSRMLS_CC);
+			efree(buf);
+		} else {
+			zval *t;
+
+			t = phar->metadata;
+			ALLOC_ZVAL(phar->metadata);
+			*phar->metadata = *t;
+			zval_copy_ctor(phar->metadata);
+			Z_SET_REFCOUNT_P(phar->metadata, 1);
+		}
+	}
+
+	zend_hash_init(&newmanifest, sizeof(phar_entry_info),
+		zend_get_hash_value, destroy_phar_manifest_entry, 0);
+	zend_hash_copy(&newmanifest, &(*pphar)->manifest, NULL, NULL, sizeof(phar_entry_info));
+	zend_hash_apply_with_argument(&newmanifest, (apply_func_arg_t) phar_update_cached_entry, (void *)phar TSRMLS_CC);
+	phar->manifest = newmanifest;
+	zend_hash_init(&phar->mounted_dirs, sizeof(char *),
+		zend_get_hash_value, NULL, 0);
+	zend_hash_init(&phar->virtual_dirs, sizeof(char *),
+		zend_get_hash_value, NULL, 0);
+	zend_hash_copy(&phar->virtual_dirs, &(*pphar)->virtual_dirs, NULL, NULL, sizeof(void *));
+	*pphar = phar;
+
+	/* now, scan the list of persistent Phar objects referencing this phar and update the pointers */
+	for (zend_hash_internal_pointer_reset(&PHAR_GLOBALS->phar_persist_map);
+	SUCCESS == zend_hash_get_current_data(&PHAR_GLOBALS->phar_persist_map, (void **) &objphar);
+	zend_hash_move_forward(&PHAR_GLOBALS->phar_persist_map)) {
+		if (objphar[0]->arc.archive->fname_len == phar->fname_len && !memcmp(objphar[0]->arc.archive->fname, phar->fname, phar->fname_len)) {
+			objphar[0]->arc.archive = phar;
+		}
+	}
+}
+/* }}} */
+
+int phar_copy_on_write(phar_archive_data **pphar TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data **newpphar, *newphar = NULL;
+
+	if (SUCCESS != zend_hash_add(&(PHAR_GLOBALS->phar_fname_map), (*pphar)->fname, (*pphar)->fname_len, (void *)&newphar, sizeof(phar_archive_data *), (void **)&newpphar)) {
+		return FAILURE;
+	}
+
+	*newpphar = *pphar;
+	phar_copy_cached_phar(newpphar TSRMLS_CC);
+	/* invalidate phar cache */
+	PHAR_G(last_phar) = NULL;
+	PHAR_G(last_phar_name) = PHAR_G(last_alias) = NULL;
+
+	if (newpphar[0]->alias_len && FAILURE == zend_hash_add(&(PHAR_GLOBALS->phar_alias_map), newpphar[0]->alias, newpphar[0]->alias_len, (void*)newpphar, sizeof(phar_archive_data*), NULL)) {
+		zend_hash_del(&(PHAR_GLOBALS->phar_fname_map), (*pphar)->fname, (*pphar)->fname_len);
+		return FAILURE;
+	}
+
+	*pphar = *newpphar;
+	return SUCCESS;
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/tests/fixtures/php/5.6.40/ext/openssl/openssl.c
+++ b/tests/fixtures/php/5.6.40/ext/openssl/openssl.c
@@ -1,0 +1,5517 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 5                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2016 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Stig Venaas <venaas@php.net>                                |
+   |          Wez Furlong <wez@thebrainroom.com>                          |
+   |          Sascha Kettler <kettler@gmx.net>                            |
+   |          Pierre-Alain Joye <pierre@php.net>                          |
+   |          Marc Delling <delling@silpion.de> (PKCS12 functions)        |		
+   +----------------------------------------------------------------------+
+ */
+
+/* $Id$ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_ini.h"
+#include "php_openssl.h"
+
+/* PHP Includes */
+#include "ext/standard/file.h"
+#include "ext/standard/info.h"
+#include "ext/standard/php_fopen_wrappers.h"
+#include "ext/standard/md5.h"
+#include "ext/standard/base64.h"
+#ifdef PHP_WIN32
+# include "win32/winutil.h"
+#endif
+
+/* OpenSSL includes */
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/crypto.h>
+#include <openssl/pem.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+#include <openssl/pkcs12.h>
+
+/* Common */
+#include <time.h>
+
+#ifdef NETWARE
+#define timezone _timezone	/* timezone is called _timezone in LibC */
+#endif
+
+#define DEFAULT_KEY_LENGTH	512
+#define MIN_KEY_LENGTH		384
+
+#define OPENSSL_ALGO_SHA1 	1
+#define OPENSSL_ALGO_MD5	2
+#define OPENSSL_ALGO_MD4	3
+#ifdef HAVE_OPENSSL_MD2_H
+#define OPENSSL_ALGO_MD2	4
+#endif
+#define OPENSSL_ALGO_DSS1	5
+#if OPENSSL_VERSION_NUMBER >= 0x0090708fL
+#define OPENSSL_ALGO_SHA224 6
+#define OPENSSL_ALGO_SHA256 7
+#define OPENSSL_ALGO_SHA384 8
+#define OPENSSL_ALGO_SHA512 9
+#define OPENSSL_ALGO_RMD160 10
+#endif
+#define DEBUG_SMIME	0
+
+#if !defined(OPENSSL_NO_EC) && defined(EVP_PKEY_EC)
+#define HAVE_EVP_PKEY_EC 1
+#endif
+
+/* FIXME: Use the openssl constants instead of
+ * enum. It is now impossible to match real values
+ * against php constants. Also sorry to break the
+ * enum principles here, BC...
+ */
+enum php_openssl_key_type {
+	OPENSSL_KEYTYPE_RSA,
+	OPENSSL_KEYTYPE_DSA,
+	OPENSSL_KEYTYPE_DH,
+	OPENSSL_KEYTYPE_DEFAULT = OPENSSL_KEYTYPE_RSA,
+#ifdef HAVE_EVP_PKEY_EC
+	OPENSSL_KEYTYPE_EC = OPENSSL_KEYTYPE_DH +1
+#endif
+};
+
+enum php_openssl_cipher_type {
+	PHP_OPENSSL_CIPHER_RC2_40,
+	PHP_OPENSSL_CIPHER_RC2_128,
+	PHP_OPENSSL_CIPHER_RC2_64,
+	PHP_OPENSSL_CIPHER_DES,
+	PHP_OPENSSL_CIPHER_3DES,
+	PHP_OPENSSL_CIPHER_AES_128_CBC,
+	PHP_OPENSSL_CIPHER_AES_192_CBC,
+	PHP_OPENSSL_CIPHER_AES_256_CBC,
+
+	PHP_OPENSSL_CIPHER_DEFAULT = PHP_OPENSSL_CIPHER_RC2_40
+};
+
+PHP_FUNCTION(openssl_get_md_methods);
+PHP_FUNCTION(openssl_get_cipher_methods);
+
+PHP_FUNCTION(openssl_digest);
+PHP_FUNCTION(openssl_encrypt);
+PHP_FUNCTION(openssl_decrypt);
+PHP_FUNCTION(openssl_cipher_iv_length);
+
+PHP_FUNCTION(openssl_dh_compute_key);
+PHP_FUNCTION(openssl_random_pseudo_bytes);
+
+/* {{{ arginfo */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 0, 2)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_export, 0, 0, 2)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_fingerprint, 0, 0, 1)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, raw_output)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_check_private_key, 0)
+	ZEND_ARG_INFO(0, cert)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_parse, 0)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, shortname)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_x509_checkpurpose, 0, 0, 3)
+	ZEND_ARG_INFO(0, x509cert)
+	ZEND_ARG_INFO(0, purpose)
+	ZEND_ARG_INFO(0, cainfo) /* array */
+	ZEND_ARG_INFO(0, untrustedfile)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_read, 0)
+	ZEND_ARG_INFO(0, cert)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_x509_free, 0)
+	ZEND_ARG_INFO(0, x509)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs12_export_to_file, 0, 0, 4)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, filename)
+	ZEND_ARG_INFO(0, priv_key)
+	ZEND_ARG_INFO(0, pass)
+	ZEND_ARG_INFO(0, args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkcs12_export, 0)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, priv_key)
+	ZEND_ARG_INFO(0, pass)
+	ZEND_ARG_INFO(0, args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkcs12_read, 0)
+	ZEND_ARG_INFO(0, PKCS12)
+	ZEND_ARG_INFO(1, certs) /* array */
+	ZEND_ARG_INFO(0, pass)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_export_to_file, 0, 0, 2)
+	ZEND_ARG_INFO(0, csr)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_export, 0, 0, 2)
+	ZEND_ARG_INFO(0, csr)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, notext)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_sign, 0, 0, 4)
+	ZEND_ARG_INFO(0, csr)
+	ZEND_ARG_INFO(0, x509)
+	ZEND_ARG_INFO(0, priv_key)
+	ZEND_ARG_INFO(0, days)
+	ZEND_ARG_INFO(0, config_args) /* array */
+	ZEND_ARG_INFO(0, serial)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_csr_new, 0, 0, 2)
+	ZEND_ARG_INFO(0, dn) /* array */
+	ZEND_ARG_INFO(1, privkey)
+	ZEND_ARG_INFO(0, configargs)
+	ZEND_ARG_INFO(0, extraattribs)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_csr_get_subject, 0)
+	ZEND_ARG_INFO(0, csr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_csr_get_public_key, 0)
+	ZEND_ARG_INFO(0, csr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_new, 0, 0, 0)
+	ZEND_ARG_INFO(0, configargs) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_export_to_file, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, passphrase)
+	ZEND_ARG_INFO(0, config_args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_export, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(1, out)
+	ZEND_ARG_INFO(0, passphrase)
+	ZEND_ARG_INFO(0, config_args) /* array */
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkey_get_public, 0)
+	ZEND_ARG_INFO(0, cert)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkey_free, 0)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkey_get_private, 0, 0, 1)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, passphrase)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_pkey_get_details, 0)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pbkdf2, 0, 0, 4)
+	ZEND_ARG_INFO(0, password)
+	ZEND_ARG_INFO(0, salt)
+	ZEND_ARG_INFO(0, key_length)
+	ZEND_ARG_INFO(0, iterations)
+	ZEND_ARG_INFO(0, digest_algorithm)
+ZEND_END_ARG_INFO()
+#endif
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_verify, 0, 0, 2)
+	ZEND_ARG_INFO(0, filename)
+	ZEND_ARG_INFO(0, flags)
+	ZEND_ARG_INFO(0, signerscerts)
+	ZEND_ARG_INFO(0, cainfo) /* array */
+	ZEND_ARG_INFO(0, extracerts)
+	ZEND_ARG_INFO(0, content)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_encrypt, 0, 0, 4)
+	ZEND_ARG_INFO(0, infile)
+	ZEND_ARG_INFO(0, outfile)
+	ZEND_ARG_INFO(0, recipcerts)
+	ZEND_ARG_INFO(0, headers) /* array */
+	ZEND_ARG_INFO(0, flags)
+	ZEND_ARG_INFO(0, cipher)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_sign, 0, 0, 5)
+	ZEND_ARG_INFO(0, infile)
+	ZEND_ARG_INFO(0, outfile)
+	ZEND_ARG_INFO(0, signcert)
+	ZEND_ARG_INFO(0, signkey)
+	ZEND_ARG_INFO(0, headers) /* array */
+	ZEND_ARG_INFO(0, flags)
+	ZEND_ARG_INFO(0, extracertsfilename)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_pkcs7_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, infilename)
+	ZEND_ARG_INFO(0, outfilename)
+	ZEND_ARG_INFO(0, recipcert)
+	ZEND_ARG_INFO(0, recipkey)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_private_encrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_private_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_public_encrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_public_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, crypted)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, padding)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_error_string, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_sign, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, signature)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_verify, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, signature)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_seal, 0, 0, 4)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, sealdata)
+	ZEND_ARG_INFO(1, ekeys) /* arary */
+	ZEND_ARG_INFO(0, pubkeys) /* array */
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_open, 0)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(1, opendata)
+	ZEND_ARG_INFO(0, ekey)
+	ZEND_ARG_INFO(0, privkey)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_get_md_methods, 0, 0, 0)
+	ZEND_ARG_INFO(0, aliases)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_get_cipher_methods, 0, 0, 0)
+	ZEND_ARG_INFO(0, aliases)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_digest, 0, 0, 2)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, raw_output)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_encrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, password)
+	ZEND_ARG_INFO(0, options)
+	ZEND_ARG_INFO(0, iv)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_decrypt, 0, 0, 3)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_INFO(0, method)
+	ZEND_ARG_INFO(0, password)
+	ZEND_ARG_INFO(0, options)
+	ZEND_ARG_INFO(0, iv)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_cipher_iv_length, 0)
+	ZEND_ARG_INFO(0, method)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_dh_compute_key, 0)
+	ZEND_ARG_INFO(0, pub_key)
+	ZEND_ARG_INFO(0, dh_key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_random_pseudo_bytes, 0, 0, 1)
+	ZEND_ARG_INFO(0, length)
+	ZEND_ARG_INFO(1, result_is_strong)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openssl_spki_new, 0, 0, 2)
+	ZEND_ARG_INFO(0, privkey)
+	ZEND_ARG_INFO(0, challenge)
+	ZEND_ARG_INFO(0, algo)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_spki_verify, 0)
+	ZEND_ARG_INFO(0, spki)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_spki_export, 0)
+	ZEND_ARG_INFO(0, spki)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_spki_export_challenge, 0)
+	ZEND_ARG_INFO(0, spki)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_openssl_get_cert_locations, 0)
+ZEND_END_ARG_INFO()
+/* }}} */
+
+/* {{{ openssl_functions[]
+ */
+const zend_function_entry openssl_functions[] = {
+	PHP_FE(openssl_get_cert_locations, arginfo_openssl_get_cert_locations)
+
+/* spki functions */
+	PHP_FE(openssl_spki_new, arginfo_openssl_spki_new)
+	PHP_FE(openssl_spki_verify, arginfo_openssl_spki_verify)
+	PHP_FE(openssl_spki_export, arginfo_openssl_spki_export)
+	PHP_FE(openssl_spki_export_challenge, arginfo_openssl_spki_export_challenge)
+
+/* public/private key functions */
+	PHP_FE(openssl_pkey_free,			arginfo_openssl_pkey_free)
+	PHP_FE(openssl_pkey_new,			arginfo_openssl_pkey_new)
+	PHP_FE(openssl_pkey_export,			arginfo_openssl_pkey_export)
+	PHP_FE(openssl_pkey_export_to_file,	arginfo_openssl_pkey_export_to_file)
+	PHP_FE(openssl_pkey_get_private,	arginfo_openssl_pkey_get_private)
+	PHP_FE(openssl_pkey_get_public,		arginfo_openssl_pkey_get_public)
+	PHP_FE(openssl_pkey_get_details,	arginfo_openssl_pkey_get_details)
+
+	PHP_FALIAS(openssl_free_key,		openssl_pkey_free, 			arginfo_openssl_pkey_free)
+	PHP_FALIAS(openssl_get_privatekey,	openssl_pkey_get_private,	arginfo_openssl_pkey_get_private)
+	PHP_FALIAS(openssl_get_publickey,	openssl_pkey_get_public,	arginfo_openssl_pkey_get_public)
+
+/* x.509 cert funcs */
+	PHP_FE(openssl_x509_read,				arginfo_openssl_x509_read)
+	PHP_FE(openssl_x509_free,          		arginfo_openssl_x509_free)
+	PHP_FE(openssl_x509_parse,			 	arginfo_openssl_x509_parse)
+	PHP_FE(openssl_x509_checkpurpose,		arginfo_openssl_x509_checkpurpose)
+	PHP_FE(openssl_x509_check_private_key,	arginfo_openssl_x509_check_private_key)
+	PHP_FE(openssl_x509_export,				arginfo_openssl_x509_export)
+	PHP_FE(openssl_x509_fingerprint,			arginfo_openssl_x509_fingerprint)
+	PHP_FE(openssl_x509_export_to_file,		arginfo_openssl_x509_export_to_file)
+
+/* PKCS12 funcs */
+	PHP_FE(openssl_pkcs12_export,			arginfo_openssl_pkcs12_export)
+	PHP_FE(openssl_pkcs12_export_to_file,	arginfo_openssl_pkcs12_export_to_file)
+	PHP_FE(openssl_pkcs12_read,				arginfo_openssl_pkcs12_read)
+
+/* CSR funcs */
+	PHP_FE(openssl_csr_new,				arginfo_openssl_csr_new)
+	PHP_FE(openssl_csr_export,			arginfo_openssl_csr_export)
+	PHP_FE(openssl_csr_export_to_file,	arginfo_openssl_csr_export_to_file)
+	PHP_FE(openssl_csr_sign,			arginfo_openssl_csr_sign)
+	PHP_FE(openssl_csr_get_subject,		arginfo_openssl_csr_get_subject)
+	PHP_FE(openssl_csr_get_public_key,	arginfo_openssl_csr_get_public_key)
+
+	PHP_FE(openssl_digest,				arginfo_openssl_digest)
+	PHP_FE(openssl_encrypt,				arginfo_openssl_encrypt)
+	PHP_FE(openssl_decrypt,				arginfo_openssl_decrypt)
+	PHP_FE(openssl_cipher_iv_length,	arginfo_openssl_cipher_iv_length)
+	PHP_FE(openssl_sign,				arginfo_openssl_sign)
+	PHP_FE(openssl_verify,				arginfo_openssl_verify)
+	PHP_FE(openssl_seal,				arginfo_openssl_seal)
+	PHP_FE(openssl_open,				arginfo_openssl_open)
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	PHP_FE(openssl_pbkdf2,	arginfo_openssl_pbkdf2)
+#endif
+
+/* for S/MIME handling */
+	PHP_FE(openssl_pkcs7_verify,		arginfo_openssl_pkcs7_verify)
+	PHP_FE(openssl_pkcs7_decrypt,		arginfo_openssl_pkcs7_decrypt)
+	PHP_FE(openssl_pkcs7_sign,			arginfo_openssl_pkcs7_sign)
+	PHP_FE(openssl_pkcs7_encrypt,		arginfo_openssl_pkcs7_encrypt)
+
+	PHP_FE(openssl_private_encrypt,		arginfo_openssl_private_encrypt)
+	PHP_FE(openssl_private_decrypt,		arginfo_openssl_private_decrypt)
+	PHP_FE(openssl_public_encrypt,		arginfo_openssl_public_encrypt)
+	PHP_FE(openssl_public_decrypt,		arginfo_openssl_public_decrypt)
+
+	PHP_FE(openssl_get_md_methods,		arginfo_openssl_get_md_methods)
+	PHP_FE(openssl_get_cipher_methods,	arginfo_openssl_get_cipher_methods)
+
+	PHP_FE(openssl_dh_compute_key,      arginfo_openssl_dh_compute_key)
+
+	PHP_FE(openssl_random_pseudo_bytes,    arginfo_openssl_random_pseudo_bytes)
+	PHP_FE(openssl_error_string, arginfo_openssl_error_string)
+	PHP_FE_END
+};
+/* }}} */
+
+/* {{{ openssl_module_entry
+ */
+zend_module_entry openssl_module_entry = {
+	STANDARD_MODULE_HEADER,
+	"openssl",
+	openssl_functions,
+	PHP_MINIT(openssl),
+	PHP_MSHUTDOWN(openssl),
+	NULL,
+	NULL,
+	PHP_MINFO(openssl),
+	NO_VERSION_YET,
+	STANDARD_MODULE_PROPERTIES
+};
+/* }}} */
+
+#ifdef COMPILE_DL_OPENSSL
+ZEND_GET_MODULE(openssl)
+#endif
+
+static int le_key;
+static int le_x509;
+static int le_csr;
+static int ssl_stream_data_index;
+
+int php_openssl_get_x509_list_id(void) /* {{{ */
+{
+	return le_x509;
+}
+/* }}} */
+
+/* {{{ resource destructors */
+static void php_pkey_free(zend_rsrc_list_entry *rsrc TSRMLS_DC)
+{
+	EVP_PKEY *pkey = (EVP_PKEY *)rsrc->ptr;
+
+	assert(pkey != NULL);
+
+	EVP_PKEY_free(pkey);
+}
+
+static void php_x509_free(zend_rsrc_list_entry *rsrc TSRMLS_DC)
+{
+	X509 *x509 = (X509 *)rsrc->ptr;
+	X509_free(x509);
+}
+
+static void php_csr_free(zend_rsrc_list_entry *rsrc TSRMLS_DC)
+{
+	X509_REQ * csr = (X509_REQ*)rsrc->ptr;
+	X509_REQ_free(csr);
+}
+/* }}} */
+
+/* {{{ openssl open_basedir check */
+inline static int php_openssl_open_base_dir_chk(char *filename TSRMLS_DC)
+{
+	if (php_check_open_basedir(filename TSRMLS_CC)) {
+		return -1;
+	}
+	
+	return 0;
+}
+/* }}} */
+
+php_stream* php_openssl_get_stream_from_ssl_handle(const SSL *ssl)
+{
+	return (php_stream*)SSL_get_ex_data(ssl, ssl_stream_data_index);
+}
+
+int php_openssl_get_ssl_stream_data_index()
+{
+	return ssl_stream_data_index;
+}
+
+/* openssl -> PHP "bridging" */
+/* true global; readonly after module startup */
+static char default_ssl_conf_filename[MAXPATHLEN];
+
+struct php_x509_request { /* {{{ */
+#if OPENSSL_VERSION_NUMBER >= 0x10000002L
+	LHASH_OF(CONF_VALUE) * global_config;	/* Global SSL config */
+	LHASH_OF(CONF_VALUE) * req_config;		/* SSL config for this request */
+#else
+	LHASH * global_config;  /* Global SSL config */
+	LHASH * req_config;             /* SSL config for this request */
+#endif
+	const EVP_MD * md_alg;
+	const EVP_MD * digest;
+	char	* section_name,
+			* config_filename,
+			* digest_name,
+			* extensions_section,
+			* request_extensions_section;
+	int priv_key_bits;
+	int priv_key_type;
+
+	int priv_key_encrypt;
+
+	EVP_PKEY * priv_key;
+
+    const EVP_CIPHER * priv_key_encrypt_cipher;
+};
+/* }}} */
+
+static X509 * php_openssl_x509_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC);
+static EVP_PKEY * php_openssl_evp_from_zval(zval ** val, int public_key, char * passphrase, int makeresource, long * resourceval TSRMLS_DC);
+static int php_openssl_is_private_key(EVP_PKEY* pkey TSRMLS_DC);
+static X509_STORE * setup_verify(zval * calist TSRMLS_DC);
+static STACK_OF(X509) * load_all_certs_from_file(char *certfile);
+static X509_REQ * php_openssl_csr_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC);
+static EVP_PKEY * php_openssl_generate_private_key(struct php_x509_request * req TSRMLS_DC);
+
+static void add_assoc_name_entry(zval * val, char * key, X509_NAME * name, int shortname TSRMLS_DC) /* {{{ */
+{
+	zval **data;
+	zval *subitem, *subentries;
+	int i;
+	char *sname;
+	int nid;
+	X509_NAME_ENTRY * ne;
+	ASN1_STRING * str = NULL;
+	ASN1_OBJECT * obj;
+
+	if (key != NULL) {
+		MAKE_STD_ZVAL(subitem);
+		array_init(subitem);
+	} else {
+		subitem = val;
+	}
+	
+	for (i = 0; i < X509_NAME_entry_count(name); i++) {
+		unsigned char *to_add;
+		int to_add_len = 0;
+
+
+		ne  = X509_NAME_get_entry(name, i);
+		obj = X509_NAME_ENTRY_get_object(ne);
+		nid = OBJ_obj2nid(obj);
+
+		if (shortname) {
+			sname = (char *) OBJ_nid2sn(nid);
+		} else {
+			sname = (char *) OBJ_nid2ln(nid);
+		}
+
+		str = X509_NAME_ENTRY_get_data(ne);
+		if (ASN1_STRING_type(str) != V_ASN1_UTF8STRING) {
+			to_add_len = ASN1_STRING_to_UTF8(&to_add, str);
+		} else {
+			to_add = ASN1_STRING_data(str);
+			to_add_len = ASN1_STRING_length(str);
+		}
+
+		if (to_add_len != -1) {
+			if (zend_hash_find(Z_ARRVAL_P(subitem), sname, strlen(sname)+1, (void**)&data) == SUCCESS) {
+				if (Z_TYPE_PP(data) == IS_ARRAY) {
+					subentries = *data;
+					add_next_index_stringl(subentries, (char *)to_add, to_add_len, 1);
+				} else if (Z_TYPE_PP(data) == IS_STRING) {
+					MAKE_STD_ZVAL(subentries);
+					array_init(subentries);
+					add_next_index_stringl(subentries, Z_STRVAL_PP(data), Z_STRLEN_PP(data), 1);
+					add_next_index_stringl(subentries, (char *)to_add, to_add_len, 1);
+					zend_hash_update(Z_ARRVAL_P(subitem), sname, strlen(sname)+1, &subentries, sizeof(zval*), NULL);
+				}
+			} else {
+				add_assoc_stringl(subitem, sname, (char *)to_add, to_add_len, 1);
+			}
+		}
+	}
+	if (key != NULL) {
+		zend_hash_update(HASH_OF(val), key, strlen(key) + 1, (void *)&subitem, sizeof(subitem), NULL);
+	}
+}
+/* }}} */
+
+static void add_assoc_asn1_string(zval * val, char * key, ASN1_STRING * str) /* {{{ */
+{
+	add_assoc_stringl(val, key, (char *)str->data, str->length, 1);
+}
+/* }}} */
+
+static time_t asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC) /* {{{ */
+{
+/*
+	This is how the time string is formatted:
+
+   snprintf(p, sizeof(p), "%02d%02d%02d%02d%02d%02dZ",ts->tm_year%100,
+      ts->tm_mon+1,ts->tm_mday,ts->tm_hour,ts->tm_min,ts->tm_sec);
+*/
+
+	time_t ret;
+	struct tm thetime;
+	char * strbuf;
+	char * thestr;
+	long gmadjust = 0;
+
+	if (ASN1_STRING_type(timestr) != V_ASN1_UTCTIME && ASN1_STRING_type(timestr) != V_ASN1_GENERALIZEDTIME) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "illegal ASN1 data type for timestamp");
+		return (time_t)-1;
+	}
+
+	if (ASN1_STRING_length(timestr) != strlen((const char*)ASN1_STRING_data(timestr))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "illegal length in timestamp");
+		return (time_t)-1;
+	}
+
+	if (ASN1_STRING_length(timestr) < 13) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to parse time string %s correctly", timestr->data);
+		return (time_t)-1;
+	}
+
+	if (ASN1_STRING_type(timestr) == V_ASN1_GENERALIZEDTIME && ASN1_STRING_length(timestr) < 15) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to parse time string %s correctly", timestr->data);
+		return (time_t)-1;
+	}
+
+	strbuf = estrdup((char *)ASN1_STRING_data(timestr));
+
+	memset(&thetime, 0, sizeof(thetime));
+
+	/* we work backwards so that we can use atoi more easily */
+
+	thestr = strbuf + ASN1_STRING_length(timestr) - 3;
+
+	thetime.tm_sec = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_min = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_hour = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_mday = atoi(thestr);
+	*thestr = '\0';
+	thestr -= 2;
+	thetime.tm_mon = atoi(thestr)-1;
+
+	*thestr = '\0';
+	if( ASN1_STRING_type(timestr) == V_ASN1_UTCTIME ) {
+		thestr -= 2;
+		thetime.tm_year = atoi(thestr);
+
+		if (thetime.tm_year < 68) {
+			thetime.tm_year += 100;
+		}
+	} else if( ASN1_STRING_type(timestr) == V_ASN1_GENERALIZEDTIME ) {
+		thestr -= 4;
+		thetime.tm_year = atoi(thestr) - 1900;
+	}
+
+
+	thetime.tm_isdst = -1;
+	ret = mktime(&thetime);
+
+#if HAVE_TM_GMTOFF
+	gmadjust = thetime.tm_gmtoff;
+#else
+	/*
+	** If correcting for daylight savings time, we set the adjustment to
+	** the value of timezone - 3600 seconds. Otherwise, we need to overcorrect and
+	** set the adjustment to the main timezone + 3600 seconds.
+	*/
+	gmadjust = -(thetime.tm_isdst ? (long)timezone - 3600 : (long)timezone + 3600);
+#endif
+	ret += gmadjust;
+
+	efree(strbuf);
+
+	return ret;
+}
+/* }}} */
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000002L
+static inline int php_openssl_config_check_syntax(const char * section_label, const char * config_filename, const char * section, LHASH_OF(CONF_VALUE) * config TSRMLS_DC) /* {{{ */
+#else
+static inline int php_openssl_config_check_syntax(const char * section_label, const char * config_filename, const char * section, LHASH * config TSRMLS_DC)
+#endif
+{
+	X509V3_CTX ctx;
+	
+	X509V3_set_ctx_test(&ctx);
+	X509V3_set_conf_lhash(&ctx, config);
+	if (!X509V3_EXT_add_conf(config, &ctx, (char *)section, NULL)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error loading %s section %s of %s",
+				section_label,
+				section,
+				config_filename);
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+static int add_oid_section(struct php_x509_request * req TSRMLS_DC) /* {{{ */
+{
+	char * str;
+	STACK_OF(CONF_VALUE) * sktmp;
+	CONF_VALUE * cnf;
+	int i;
+
+	str = CONF_get_string(req->req_config, NULL, "oid_section");
+	if (str == NULL) {
+		return SUCCESS;
+	}
+	sktmp = CONF_get_section(req->req_config, str);
+	if (sktmp == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "problem loading oid section %s", str);
+		return FAILURE;
+	}
+	for (i = 0; i < sk_CONF_VALUE_num(sktmp); i++) {
+		cnf = sk_CONF_VALUE_value(sktmp, i);
+		if (OBJ_create(cnf->value, cnf->name, cnf->name) == NID_undef) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "problem creating object %s=%s", cnf->name, cnf->value);
+			return FAILURE;
+		}
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+#define PHP_SSL_REQ_INIT(req)		memset(req, 0, sizeof(*req))
+#define PHP_SSL_REQ_DISPOSE(req)	php_openssl_dispose_config(req TSRMLS_CC)
+#define PHP_SSL_REQ_PARSE(req, zval)	php_openssl_parse_config(req, zval TSRMLS_CC)
+
+#define PHP_SSL_CONFIG_SYNTAX_CHECK(var) if (req->var && php_openssl_config_check_syntax(#var, \
+			req->config_filename, req->var, req->req_config TSRMLS_CC) == FAILURE) return FAILURE
+
+#define SET_OPTIONAL_STRING_ARG(key, varname, defval)	\
+	if (optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), key, sizeof(key), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_STRING) \
+		varname = Z_STRVAL_PP(item); \
+	else \
+		varname = defval
+
+#define SET_OPTIONAL_LONG_ARG(key, varname, defval)	\
+	if (optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), key, sizeof(key), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_LONG) \
+		varname = Z_LVAL_PP(item); \
+	else \
+		varname = defval
+
+static const EVP_CIPHER * php_openssl_get_evp_cipher_from_algo(long algo);
+
+int openssl_spki_cleanup(const char *src, char *dest);
+
+static int php_openssl_parse_config(struct php_x509_request * req, zval * optional_args TSRMLS_DC) /* {{{ */
+{
+	char * str;
+	zval ** item;
+
+	SET_OPTIONAL_STRING_ARG("config", req->config_filename, default_ssl_conf_filename);
+	SET_OPTIONAL_STRING_ARG("config_section_name", req->section_name, "req");
+	req->global_config = CONF_load(NULL, default_ssl_conf_filename, NULL);
+	req->req_config = CONF_load(NULL, req->config_filename, NULL);
+
+	if (req->req_config == NULL) {
+		return FAILURE;
+	}
+
+	/* read in the oids */
+	str = CONF_get_string(req->req_config, NULL, "oid_file");
+	if (str && !php_openssl_open_base_dir_chk(str TSRMLS_CC)) {
+		BIO *oid_bio = BIO_new_file(str, "r");
+		if (oid_bio) {
+			OBJ_create_objects(oid_bio);
+			BIO_free(oid_bio);
+		}
+	}
+	if (add_oid_section(req TSRMLS_CC) == FAILURE) {
+		return FAILURE;
+	}
+	SET_OPTIONAL_STRING_ARG("digest_alg", req->digest_name,
+		CONF_get_string(req->req_config, req->section_name, "default_md"));
+	SET_OPTIONAL_STRING_ARG("x509_extensions", req->extensions_section,
+		CONF_get_string(req->req_config, req->section_name, "x509_extensions"));
+	SET_OPTIONAL_STRING_ARG("req_extensions", req->request_extensions_section,
+		CONF_get_string(req->req_config, req->section_name, "req_extensions"));
+	SET_OPTIONAL_LONG_ARG("private_key_bits", req->priv_key_bits,
+		CONF_get_number(req->req_config, req->section_name, "default_bits"));
+
+	SET_OPTIONAL_LONG_ARG("private_key_type", req->priv_key_type, OPENSSL_KEYTYPE_DEFAULT);
+
+	if (optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), "encrypt_key", sizeof("encrypt_key"), (void**)&item) == SUCCESS) {
+		req->priv_key_encrypt = Z_BVAL_PP(item);
+	} else {
+		str = CONF_get_string(req->req_config, req->section_name, "encrypt_rsa_key");
+		if (str == NULL) {
+			str = CONF_get_string(req->req_config, req->section_name, "encrypt_key");
+		}
+		if (str && strcmp(str, "no") == 0) {
+			req->priv_key_encrypt = 0;
+		} else {
+			req->priv_key_encrypt = 1;
+		}
+	}
+
+	if (req->priv_key_encrypt && optional_args && zend_hash_find(Z_ARRVAL_P(optional_args), "encrypt_key_cipher", sizeof("encrypt_key_cipher"), (void**)&item) == SUCCESS 
+		&& Z_TYPE_PP(item) == IS_LONG) {
+		long cipher_algo = Z_LVAL_PP(item);
+		const EVP_CIPHER* cipher = php_openssl_get_evp_cipher_from_algo(cipher_algo);
+		if (cipher == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm for private key.");
+			return FAILURE;
+		} else  {
+			req->priv_key_encrypt_cipher = cipher;
+		}
+	} else {
+		req->priv_key_encrypt_cipher = NULL;
+	}
+
+
+	
+	/* digest alg */
+	if (req->digest_name == NULL) {
+		req->digest_name = CONF_get_string(req->req_config, req->section_name, "default_md");
+	}
+	if (req->digest_name) {
+		req->digest = req->md_alg = EVP_get_digestbyname(req->digest_name);
+	}
+	if (req->md_alg == NULL) {
+		req->md_alg = req->digest = EVP_sha1();
+	}
+
+	PHP_SSL_CONFIG_SYNTAX_CHECK(extensions_section);
+
+	/* set the string mask */
+	str = CONF_get_string(req->req_config, req->section_name, "string_mask");
+	if (str && !ASN1_STRING_set_default_mask_asc(str)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid global string mask setting %s", str);
+		return FAILURE;
+	}
+
+	PHP_SSL_CONFIG_SYNTAX_CHECK(request_extensions_section);
+	
+	return SUCCESS;
+}
+/* }}} */
+
+static void php_openssl_dispose_config(struct php_x509_request * req TSRMLS_DC) /* {{{ */
+{
+	if (req->priv_key) {
+		EVP_PKEY_free(req->priv_key);
+		req->priv_key = NULL;
+	}
+	if (req->global_config) {
+		CONF_free(req->global_config);
+		req->global_config = NULL;
+	}
+	if (req->req_config) {
+		CONF_free(req->req_config);
+		req->req_config = NULL;
+	}
+}
+/* }}} */
+
+#ifdef PHP_WIN32
+#define PHP_OPENSSL_RAND_ADD_TIME() ((void) 0)
+#else
+#define PHP_OPENSSL_RAND_ADD_TIME() php_openssl_rand_add_timeval()
+
+static inline void php_openssl_rand_add_timeval()  /* {{{ */
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	RAND_add(&tv, sizeof(tv), 0.0);
+}
+/* }}} */
+
+#endif
+
+static int php_openssl_load_rand_file(const char * file, int *egdsocket, int *seeded TSRMLS_DC) /* {{{ */
+{
+	char buffer[MAXPATHLEN];
+
+	*egdsocket = 0;
+	*seeded = 0;
+
+	if (file == NULL) {
+		file = RAND_file_name(buffer, sizeof(buffer));
+#ifdef HAVE_RAND_EGD
+	} else if (RAND_egd(file) > 0) {
+		/* if the given filename is an EGD socket, don't
+		 * write anything back to it */
+		*egdsocket = 1;
+		return SUCCESS;
+#endif
+	}
+	if (file == NULL || !RAND_load_file(file, -1)) {
+		if (RAND_status() == 0) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to load random state; not enough random data!");
+			return FAILURE;
+		}
+		return FAILURE;
+	}
+	*seeded = 1;
+	return SUCCESS;
+}
+/* }}} */
+
+static int php_openssl_write_rand_file(const char * file, int egdsocket, int seeded) /* {{{ */
+{
+	char buffer[MAXPATHLEN];
+
+	TSRMLS_FETCH();
+
+	if (egdsocket || !seeded) {
+		/* if we did not manage to read the seed file, we should not write
+		 * a low-entropy seed file back */
+		return FAILURE;
+	}
+	if (file == NULL) {
+		file = RAND_file_name(buffer, sizeof(buffer));
+	}
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (file == NULL || !RAND_write_file(file)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to write random state");
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+static EVP_MD * php_openssl_get_evp_md_from_algo(long algo) { /* {{{ */
+	EVP_MD *mdtype;
+
+	switch (algo) {
+		case OPENSSL_ALGO_SHA1:
+			mdtype = (EVP_MD *) EVP_sha1();
+			break;
+		case OPENSSL_ALGO_MD5:
+			mdtype = (EVP_MD *) EVP_md5();
+			break;
+		case OPENSSL_ALGO_MD4:
+			mdtype = (EVP_MD *) EVP_md4();
+			break;
+#ifdef HAVE_OPENSSL_MD2_H
+		case OPENSSL_ALGO_MD2:
+			mdtype = (EVP_MD *) EVP_md2();
+			break;
+#endif
+		case OPENSSL_ALGO_DSS1:
+			mdtype = (EVP_MD *) EVP_dss1();
+			break;
+#if OPENSSL_VERSION_NUMBER >= 0x0090708fL
+		case OPENSSL_ALGO_SHA224:
+			mdtype = (EVP_MD *) EVP_sha224();
+			break;
+		case OPENSSL_ALGO_SHA256:
+			mdtype = (EVP_MD *) EVP_sha256();
+			break;
+		case OPENSSL_ALGO_SHA384:
+			mdtype = (EVP_MD *) EVP_sha384();
+			break;
+		case OPENSSL_ALGO_SHA512:
+			mdtype = (EVP_MD *) EVP_sha512();
+			break;
+		case OPENSSL_ALGO_RMD160:
+			mdtype = (EVP_MD *) EVP_ripemd160();
+			break;
+#endif
+		default:
+			return NULL;
+			break;
+	}
+	return mdtype;
+}
+/* }}} */
+
+static const EVP_CIPHER * php_openssl_get_evp_cipher_from_algo(long algo) { /* {{{ */
+	switch (algo) {
+#ifndef OPENSSL_NO_RC2
+		case PHP_OPENSSL_CIPHER_RC2_40:
+			return EVP_rc2_40_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_RC2_64:
+			return EVP_rc2_64_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_RC2_128:
+			return EVP_rc2_cbc();
+			break;
+#endif
+
+#ifndef OPENSSL_NO_DES
+		case PHP_OPENSSL_CIPHER_DES:
+			return EVP_des_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_3DES:
+			return EVP_des_ede3_cbc();
+			break;
+#endif
+
+#ifndef OPENSSL_NO_AES
+		case PHP_OPENSSL_CIPHER_AES_128_CBC:
+			return EVP_aes_128_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_AES_192_CBC:
+			return EVP_aes_192_cbc();
+			break;
+		case PHP_OPENSSL_CIPHER_AES_256_CBC:
+			return EVP_aes_256_cbc();
+			break;
+#endif
+
+
+		default:
+			return NULL;
+			break;
+	}
+}
+/* }}} */
+
+/* {{{ INI Settings */
+PHP_INI_BEGIN()
+	PHP_INI_ENTRY("openssl.cafile", NULL, PHP_INI_PERDIR, NULL)
+	PHP_INI_ENTRY("openssl.capath", NULL, PHP_INI_PERDIR, NULL)
+PHP_INI_END()
+/* }}} */
+ 
+/* {{{ PHP_MINIT_FUNCTION
+ */
+PHP_MINIT_FUNCTION(openssl)
+{
+	char * config_filename;
+
+	le_key = zend_register_list_destructors_ex(php_pkey_free, NULL, "OpenSSL key", module_number);
+	le_x509 = zend_register_list_destructors_ex(php_x509_free, NULL, "OpenSSL X.509", module_number);
+	le_csr = zend_register_list_destructors_ex(php_csr_free, NULL, "OpenSSL X.509 CSR", module_number);
+
+	SSL_library_init();
+	OpenSSL_add_all_ciphers();
+	OpenSSL_add_all_digests();
+	OpenSSL_add_all_algorithms();
+
+	SSL_load_error_strings();
+
+	/* register a resource id number with OpenSSL so that we can map SSL -> stream structures in
+	 * OpenSSL callbacks */
+	ssl_stream_data_index = SSL_get_ex_new_index(0, "PHP stream index", NULL, NULL, NULL);
+	
+	REGISTER_STRING_CONSTANT("OPENSSL_VERSION_TEXT", OPENSSL_VERSION_TEXT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_VERSION_NUMBER", OPENSSL_VERSION_NUMBER, CONST_CS|CONST_PERSISTENT);
+	
+	/* purposes for cert purpose checking */
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SSL_CLIENT", X509_PURPOSE_SSL_CLIENT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SSL_SERVER", X509_PURPOSE_SSL_SERVER, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_NS_SSL_SERVER", X509_PURPOSE_NS_SSL_SERVER, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SMIME_SIGN", X509_PURPOSE_SMIME_SIGN, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_SMIME_ENCRYPT", X509_PURPOSE_SMIME_ENCRYPT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_CRL_SIGN", X509_PURPOSE_CRL_SIGN, CONST_CS|CONST_PERSISTENT);
+#ifdef X509_PURPOSE_ANY
+	REGISTER_LONG_CONSTANT("X509_PURPOSE_ANY", X509_PURPOSE_ANY, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	/* signature algorithm constants */
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA1", OPENSSL_ALGO_SHA1, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_MD5", OPENSSL_ALGO_MD5, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_MD4", OPENSSL_ALGO_MD4, CONST_CS|CONST_PERSISTENT);
+#ifdef HAVE_OPENSSL_MD2_H
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_MD2", OPENSSL_ALGO_MD2, CONST_CS|CONST_PERSISTENT);
+#endif
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_DSS1", OPENSSL_ALGO_DSS1, CONST_CS|CONST_PERSISTENT);
+#if OPENSSL_VERSION_NUMBER >= 0x0090708fL
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA224", OPENSSL_ALGO_SHA224, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA256", OPENSSL_ALGO_SHA256, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA384", OPENSSL_ALGO_SHA384, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_SHA512", OPENSSL_ALGO_SHA512, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ALGO_RMD160", OPENSSL_ALGO_RMD160, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	/* flags for S/MIME */
+	REGISTER_LONG_CONSTANT("PKCS7_DETACHED", PKCS7_DETACHED, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_TEXT", PKCS7_TEXT, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOINTERN", PKCS7_NOINTERN, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOVERIFY", PKCS7_NOVERIFY, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOCHAIN", PKCS7_NOCHAIN, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOCERTS", PKCS7_NOCERTS, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOATTR", PKCS7_NOATTR, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_BINARY", PKCS7_BINARY, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PKCS7_NOSIGS", PKCS7_NOSIGS, CONST_CS|CONST_PERSISTENT);
+
+	REGISTER_LONG_CONSTANT("OPENSSL_PKCS1_PADDING", RSA_PKCS1_PADDING, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_SSLV23_PADDING", RSA_SSLV23_PADDING, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_NO_PADDING", RSA_NO_PADDING, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_PKCS1_OAEP_PADDING", RSA_PKCS1_OAEP_PADDING, CONST_CS|CONST_PERSISTENT);
+
+	/* Informational stream wrapper constants */
+	REGISTER_STRING_CONSTANT("OPENSSL_DEFAULT_STREAM_CIPHERS", OPENSSL_DEFAULT_STREAM_CIPHERS, CONST_CS|CONST_PERSISTENT);
+
+	/* Ciphers */
+#ifndef OPENSSL_NO_RC2
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_RC2_40", PHP_OPENSSL_CIPHER_RC2_40, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_RC2_128", PHP_OPENSSL_CIPHER_RC2_128, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_RC2_64", PHP_OPENSSL_CIPHER_RC2_64, CONST_CS|CONST_PERSISTENT);
+#endif
+#ifndef OPENSSL_NO_DES
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_DES", PHP_OPENSSL_CIPHER_DES, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_3DES", PHP_OPENSSL_CIPHER_3DES, CONST_CS|CONST_PERSISTENT);
+#endif
+#ifndef OPENSSL_NO_AES
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_AES_128_CBC", PHP_OPENSSL_CIPHER_AES_128_CBC, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_AES_192_CBC", PHP_OPENSSL_CIPHER_AES_192_CBC, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_CIPHER_AES_256_CBC", PHP_OPENSSL_CIPHER_AES_256_CBC, CONST_CS|CONST_PERSISTENT);
+#endif
+ 
+	/* Values for key types */
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_RSA", OPENSSL_KEYTYPE_RSA, CONST_CS|CONST_PERSISTENT);
+#ifndef NO_DSA
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_DSA", OPENSSL_KEYTYPE_DSA, CONST_CS|CONST_PERSISTENT);
+#endif
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_DH", OPENSSL_KEYTYPE_DH, CONST_CS|CONST_PERSISTENT);
+#ifdef HAVE_EVP_PKEY_EC
+	REGISTER_LONG_CONSTANT("OPENSSL_KEYTYPE_EC", OPENSSL_KEYTYPE_EC, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	REGISTER_LONG_CONSTANT("OPENSSL_RAW_DATA", OPENSSL_RAW_DATA, CONST_CS|CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("OPENSSL_ZERO_PADDING", OPENSSL_ZERO_PADDING, CONST_CS|CONST_PERSISTENT);
+
+#if OPENSSL_VERSION_NUMBER >= 0x0090806fL && !defined(OPENSSL_NO_TLSEXT)
+	/* SNI support included in OpenSSL >= 0.9.8j */
+	REGISTER_LONG_CONSTANT("OPENSSL_TLSEXT_SERVER_NAME", 1, CONST_CS|CONST_PERSISTENT);
+#endif
+
+	/* Determine default SSL configuration file */
+	config_filename = getenv("OPENSSL_CONF");
+	if (config_filename == NULL) {
+		config_filename = getenv("SSLEAY_CONF");
+	}
+
+	/* default to 'openssl.cnf' if no environment variable is set */
+	if (config_filename == NULL) {
+		snprintf(default_ssl_conf_filename, sizeof(default_ssl_conf_filename), "%s/%s",
+				X509_get_default_cert_area(),
+				"openssl.cnf");
+	} else {
+		strlcpy(default_ssl_conf_filename, config_filename, sizeof(default_ssl_conf_filename));
+	}
+
+	php_stream_xport_register("ssl", php_openssl_ssl_socket_factory TSRMLS_CC);
+	php_stream_xport_register("sslv3", php_openssl_ssl_socket_factory TSRMLS_CC);
+#ifndef OPENSSL_NO_SSL2
+	php_stream_xport_register("sslv2", php_openssl_ssl_socket_factory TSRMLS_CC);
+#endif
+	php_stream_xport_register("tls", php_openssl_ssl_socket_factory TSRMLS_CC);
+	php_stream_xport_register("tlsv1.0", php_openssl_ssl_socket_factory TSRMLS_CC);
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	php_stream_xport_register("tlsv1.1", php_openssl_ssl_socket_factory TSRMLS_CC);
+	php_stream_xport_register("tlsv1.2", php_openssl_ssl_socket_factory TSRMLS_CC);
+#endif
+
+	/* override the default tcp socket provider */
+	php_stream_xport_register("tcp", php_openssl_ssl_socket_factory TSRMLS_CC);
+
+	php_register_url_stream_wrapper("https", &php_stream_http_wrapper TSRMLS_CC);
+	php_register_url_stream_wrapper("ftps", &php_stream_ftp_wrapper TSRMLS_CC);
+
+	REGISTER_INI_ENTRIES();
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_MINFO_FUNCTION
+ */
+PHP_MINFO_FUNCTION(openssl)
+{
+	php_info_print_table_start();
+	php_info_print_table_row(2, "OpenSSL support", "enabled");
+	php_info_print_table_row(2, "OpenSSL Library Version", SSLeay_version(SSLEAY_VERSION));
+	php_info_print_table_row(2, "OpenSSL Header Version", OPENSSL_VERSION_TEXT);
+	php_info_print_table_row(2, "Openssl default config", default_ssl_conf_filename);
+	php_info_print_table_end();
+	DISPLAY_INI_ENTRIES();
+}
+/* }}} */
+
+/* {{{ PHP_MSHUTDOWN_FUNCTION
+ */
+PHP_MSHUTDOWN_FUNCTION(openssl)
+{
+	EVP_cleanup();
+
+#if OPENSSL_VERSION_NUMBER >= 0x00090805f
+	/* prevent accessing locking callback from unloaded extension */
+	CRYPTO_set_locking_callback(NULL);
+	/* free allocated error strings */
+	ERR_free_strings();
+#endif
+
+	php_unregister_url_stream_wrapper("https" TSRMLS_CC);
+	php_unregister_url_stream_wrapper("ftps" TSRMLS_CC);
+
+	php_stream_xport_unregister("ssl" TSRMLS_CC);
+#ifndef OPENSSL_NO_SSL2
+	php_stream_xport_unregister("sslv2" TSRMLS_CC);
+#endif
+	php_stream_xport_unregister("sslv3" TSRMLS_CC);
+	php_stream_xport_unregister("tls" TSRMLS_CC);
+	php_stream_xport_unregister("tlsv1.0" TSRMLS_CC);
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	php_stream_xport_unregister("tlsv1.1" TSRMLS_CC);
+	php_stream_xport_unregister("tlsv1.2" TSRMLS_CC);
+#endif
+
+	/* reinstate the default tcp handler */
+	php_stream_xport_register("tcp", php_stream_generic_socket_factory TSRMLS_CC);
+
+	UNREGISTER_INI_ENTRIES();
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ x509 cert functions */
+
+/* {{{ proto array openssl_get_cert_locations(void)
+   Retrieve an array mapping available certificate locations */
+PHP_FUNCTION(openssl_get_cert_locations)
+{
+	array_init(return_value);
+
+	add_assoc_string(return_value, "default_cert_file", (char *) X509_get_default_cert_file(), 1);
+	add_assoc_string(return_value, "default_cert_file_env", (char *) X509_get_default_cert_file_env(), 1);
+	add_assoc_string(return_value, "default_cert_dir", (char *) X509_get_default_cert_dir(), 1);
+	add_assoc_string(return_value, "default_cert_dir_env", (char *) X509_get_default_cert_dir_env(), 1);
+	add_assoc_string(return_value, "default_private_dir", (char *) X509_get_default_private_dir(), 1);
+	add_assoc_string(return_value, "default_default_cert_area", (char *) X509_get_default_cert_area(), 1);
+	add_assoc_string(return_value, "ini_cafile",
+		zend_ini_string("openssl.cafile", sizeof("openssl.cafile"), 0), 1);
+	add_assoc_string(return_value, "ini_capath",
+		zend_ini_string("openssl.capath", sizeof("openssl.capath"), 0), 1);
+}
+/* }}} */
+
+
+/* {{{ php_openssl_x509_from_zval
+	Given a zval, coerce it into an X509 object.
+	The zval can be:
+		. X509 resource created using openssl_read_x509()
+		. if it starts with file:// then it will be interpreted as the path to that cert
+		. it will be interpreted as the cert data
+	If you supply makeresource, the result will be registered as an x509 resource and
+	it's value returned in makeresource.
+*/
+static X509 * php_openssl_x509_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC)
+{
+	X509 *cert = NULL;
+
+	if (resourceval) {
+		*resourceval = -1;
+	}
+	if (Z_TYPE_PP(val) == IS_RESOURCE) {
+		/* is it an x509 resource ? */
+		void * what;
+		int type;
+
+		what = zend_fetch_resource(val TSRMLS_CC, -1, "OpenSSL X.509", &type, 1, le_x509);
+		if (!what) {
+			return NULL;
+		}
+		/* this is so callers can decide if they should free the X509 */
+		if (resourceval) {
+			*resourceval = Z_LVAL_PP(val);
+		}
+		if (type == le_x509) {
+			return (X509*)what;
+		}
+		/* other types could be used here - eg: file pointers and read in the data from them */
+
+		return NULL;
+	}
+
+	if (!(Z_TYPE_PP(val) == IS_STRING || Z_TYPE_PP(val) == IS_OBJECT)) {
+		return NULL;
+	}
+
+	/* force it to be a string and check if it refers to a file */
+	convert_to_string_ex(val);
+
+	if (Z_STRLEN_PP(val) > 7 && memcmp(Z_STRVAL_PP(val), "file://", sizeof("file://") - 1) == 0) {
+		/* read cert from the named file */
+		BIO *in;
+
+		if (php_openssl_open_base_dir_chk(Z_STRVAL_PP(val) + (sizeof("file://") - 1) TSRMLS_CC)) {
+			return NULL;
+		}
+
+		in = BIO_new_file(Z_STRVAL_PP(val) + (sizeof("file://") - 1), "r");
+		if (in == NULL) {
+			return NULL;
+		}
+		cert = PEM_read_bio_X509(in, NULL, NULL, NULL);
+		BIO_free(in);
+	} else {
+		BIO *in;
+
+		in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+		if (in == NULL) {
+			return NULL;
+		}
+#ifdef TYPEDEF_D2I_OF
+		cert = (X509 *) PEM_ASN1_read_bio((d2i_of_void *)d2i_X509, PEM_STRING_X509, in, NULL, NULL, NULL);
+#else
+		cert = (X509 *) PEM_ASN1_read_bio((char *(*)())d2i_X509, PEM_STRING_X509, in, NULL, NULL, NULL);
+#endif
+		BIO_free(in);
+	}
+
+	if (cert && makeresource && resourceval) {
+		*resourceval = zend_list_insert(cert, le_x509 TSRMLS_CC);
+	}
+	return cert;
+}
+
+/* }}} */
+
+/* {{{ proto bool openssl_x509_export_to_file(mixed x509, string outfilename [, bool notext = true])
+   Exports a CERT to file or a var */
+PHP_FUNCTION(openssl_x509_export_to_file)
+{
+	X509 * cert;
+	zval ** zcert;
+	zend_bool notext = 1;
+	BIO * bio_out;
+	long certresource;
+	char * filename;
+	int filename_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zp|b", &zcert, &filename, &filename_len, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		return;
+	}
+
+	bio_out = BIO_new_file(filename, "w");
+	if (bio_out) {
+		if (!notext) {
+			X509_print(bio_out, cert);
+		}
+		PEM_write_bio_X509(bio_out, cert);
+
+		RETVAL_TRUE;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening file %s", filename);
+	}
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+/* {{{ proto string openssl_spki_new(mixed zpkey, string challenge [, mixed method])
+   Creates new private key (or uses existing) and creates a new spki cert
+   outputting results to var */
+PHP_FUNCTION(openssl_spki_new)
+{
+	int challenge_len;
+	char * challenge = NULL, * spkstr = NULL, * s = NULL;
+	long keyresource = -1;
+	const char *spkac = "SPKAC=";
+	long algo = OPENSSL_ALGO_MD5;
+
+	zval *method = NULL;
+	zval * zpkey = NULL;
+	EVP_PKEY * pkey = NULL;
+	NETSCAPE_SPKI *spki=NULL;
+	const EVP_MD *mdtype;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs|z", &zpkey, &challenge, &challenge_len, &method) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	pkey = php_openssl_evp_from_zval(&zpkey, 0, challenge, 1, &keyresource TSRMLS_CC);
+
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied private key");
+		goto cleanup;
+	}
+
+	if (method != NULL) {
+		if (Z_TYPE_P(method) == IS_LONG) {
+			algo = Z_LVAL_P(method);
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Algorithm must be of supported type");
+			goto cleanup;
+		}
+	}
+	mdtype = php_openssl_get_evp_md_from_algo(algo);
+
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		goto cleanup;
+	}
+
+	if ((spki = NETSCAPE_SPKI_new()) == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to create new SPKAC");
+		goto cleanup;
+	}
+
+	if (challenge) {
+		ASN1_STRING_set(spki->spkac->challenge, challenge, challenge_len);
+	}
+
+	if (!NETSCAPE_SPKI_set_pubkey(spki, pkey)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to embed public key");
+		goto cleanup;
+	}
+
+	if (!NETSCAPE_SPKI_sign(spki, pkey, mdtype)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to sign with specified algorithm");
+		goto cleanup;
+	}
+
+	spkstr = NETSCAPE_SPKI_b64_encode(spki);
+	if (!spkstr){
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to encode SPKAC");
+		goto cleanup;
+	}
+
+	s = emalloc(strlen(spkac) + strlen(spkstr) + 1);
+	sprintf(s, "%s%s", spkac, spkstr);
+
+	RETVAL_STRINGL(s, strlen(s), 0);
+	goto cleanup;
+
+cleanup:
+
+	if (keyresource == -1 && spki != NULL) {
+		NETSCAPE_SPKI_free(spki);
+	}
+	if (keyresource == -1 && pkey != NULL) {
+		EVP_PKEY_free(pkey);
+	}
+	if (keyresource == -1 && spkstr != NULL) {
+		efree(spkstr);
+	}
+
+	if (s && strlen(s) <= 0) {
+		RETVAL_FALSE;
+	}
+
+	if (keyresource == -1 && s != NULL) {
+		efree(s);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_spki_verify(string spki)
+   Verifies spki returns boolean */
+PHP_FUNCTION(openssl_spki_verify)
+{
+	int spkstr_len, i = 0;
+	char *spkstr = NULL, * spkstr_cleaned = NULL;
+
+	EVP_PKEY *pkey = NULL;
+	NETSCAPE_SPKI *spki = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &spkstr, &spkstr_len) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (spkstr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied SPKAC");
+		goto cleanup;
+	}
+
+	spkstr_cleaned = emalloc(spkstr_len + 1);
+	openssl_spki_cleanup(spkstr, spkstr_cleaned);
+
+	if (strlen(spkstr_cleaned)<=0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid SPKAC");
+		goto cleanup;
+	}
+
+	spki = NETSCAPE_SPKI_b64_decode(spkstr_cleaned, strlen(spkstr_cleaned));
+	if (spki == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to decode supplied SPKAC");
+		goto cleanup;
+	}
+
+	pkey = X509_PUBKEY_get(spki->spkac->pubkey);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to acquire signed public key");
+		goto cleanup;
+	}
+
+	i = NETSCAPE_SPKI_verify(spki, pkey);
+	goto cleanup;
+
+cleanup:
+	if (spki != NULL) {
+		NETSCAPE_SPKI_free(spki);
+	}
+	if (pkey != NULL) {
+		EVP_PKEY_free(pkey);
+	}
+	if (spkstr_cleaned != NULL) {
+		efree(spkstr_cleaned);
+	}
+
+	if (i > 0) {
+		RETVAL_TRUE;
+	}
+}
+/* }}} */
+
+/* {{{ proto string openssl_spki_export(string spki)
+   Exports public key from existing spki to var */
+PHP_FUNCTION(openssl_spki_export)
+{
+	int spkstr_len;
+	char *spkstr = NULL, * spkstr_cleaned = NULL, * s = NULL;
+
+	EVP_PKEY *pkey = NULL;
+	NETSCAPE_SPKI *spki = NULL;
+	BIO *out = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &spkstr, &spkstr_len) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (spkstr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied SPKAC");
+		goto cleanup;
+	}
+
+	spkstr_cleaned = emalloc(spkstr_len + 1);
+	openssl_spki_cleanup(spkstr, spkstr_cleaned);
+
+	spki = NETSCAPE_SPKI_b64_decode(spkstr_cleaned, strlen(spkstr_cleaned));
+	if (spki == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to decode supplied SPKAC");
+		goto cleanup;
+	}
+
+	pkey = X509_PUBKEY_get(spki->spkac->pubkey);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to acquire signed public key");
+		goto cleanup;
+	}
+
+	out = BIO_new(BIO_s_mem());
+	if (out && PEM_write_bio_PUBKEY(out, pkey))  {
+		BUF_MEM *bio_buf;
+
+		BIO_get_mem_ptr(out, &bio_buf);
+		RETVAL_STRINGL((char *)bio_buf->data, bio_buf->length, 1);
+	}
+	goto cleanup;
+
+cleanup:
+
+	if (spki != NULL) {
+		NETSCAPE_SPKI_free(spki);
+	}
+	if (out != NULL) {
+		BIO_free_all(out);
+	}
+	if (pkey != NULL) {
+		EVP_PKEY_free(pkey);
+	}
+	if (spkstr_cleaned != NULL) {
+		efree(spkstr_cleaned);
+	}
+	if (s != NULL) {
+		efree(s);
+	}
+}
+/* }}} */
+
+/* {{{ proto string openssl_spki_export_challenge(string spki)
+   Exports spkac challenge from existing spki to var */
+PHP_FUNCTION(openssl_spki_export_challenge)
+{
+	int spkstr_len;
+	char *spkstr = NULL, * spkstr_cleaned = NULL;
+
+	NETSCAPE_SPKI *spki = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &spkstr, &spkstr_len) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (spkstr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to use supplied SPKAC");
+		goto cleanup;
+	}
+
+	spkstr_cleaned = emalloc(spkstr_len + 1);
+	openssl_spki_cleanup(spkstr, spkstr_cleaned);
+
+	spki = NETSCAPE_SPKI_b64_decode(spkstr_cleaned, strlen(spkstr_cleaned));
+	if (spki == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to decode SPKAC");
+		goto cleanup;
+	}
+
+	RETVAL_STRING((char *) ASN1_STRING_data(spki->spkac->challenge), 1);
+	goto cleanup;
+
+cleanup:
+	if (spkstr_cleaned != NULL) {
+		efree(spkstr_cleaned);
+	}
+}
+/* }}} */
+
+/* {{{ strip line endings from spkac */
+int openssl_spki_cleanup(const char *src, char *dest)
+{
+    int removed=0;
+
+    while (*src) {
+        if (*src!='\n'&&*src!='\r') {
+            *dest++=*src;
+        } else {
+            ++removed;
+        }
+        ++src;
+    }
+    *dest=0;
+    return removed;
+}
+/* }}} */
+
+/* {{{ proto bool openssl_x509_export(mixed x509, string &out [, bool notext = true])
+   Exports a CERT to file or a var */
+PHP_FUNCTION(openssl_x509_export)
+{
+	X509 * cert;
+	zval ** zcert, *zout;
+	zend_bool notext = 1;
+	BIO * bio_out;
+	long certresource;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zz|b", &zcert, &zout, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+
+	bio_out = BIO_new(BIO_s_mem());
+	if (!notext) {
+		X509_print(bio_out, cert);
+	}
+	if (PEM_write_bio_X509(bio_out, cert))  {
+		BUF_MEM *bio_buf;
+
+		zval_dtor(zout);
+		BIO_get_mem_ptr(bio_out, &bio_buf);
+		ZVAL_STRINGL(zout, bio_buf->data, bio_buf->length, 1);
+
+		RETVAL_TRUE;
+	}
+
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+int php_openssl_x509_fingerprint(X509 *peer, const char *method, zend_bool raw, char **out, int *out_len TSRMLS_DC)
+{
+	unsigned char md[EVP_MAX_MD_SIZE];
+	const EVP_MD *mdtype;
+	unsigned int n;
+
+	if (!(mdtype = EVP_get_digestbyname(method))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		return FAILURE;
+	} else if (!X509_digest(peer, mdtype, md, &n)) {
+		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Could not generate signature");
+		return FAILURE;
+	}
+
+	if (raw) {
+		*out_len = n;
+		*out = estrndup((char *) md, n);
+	} else {
+		*out_len = n * 2;
+		*out = emalloc(*out_len + 1);
+
+		make_digest_ex(*out, md, n);
+	}
+
+	return SUCCESS;
+}
+
+PHP_FUNCTION(openssl_x509_fingerprint)
+{
+	X509 *cert;
+	zval **zcert;
+	long certresource;
+	zend_bool raw_output = 0;
+	char *method = "sha1";
+	int method_len;
+
+	char *fingerprint;
+	int fingerprint_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|sb", &zcert, &method, &method_len, &raw_output) == FAILURE) {
+		return;
+	}
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		RETURN_FALSE;
+	}
+
+	if (php_openssl_x509_fingerprint(cert, method, raw_output, &fingerprint, &fingerprint_len TSRMLS_CC) == SUCCESS) {
+		RETVAL_STRINGL(fingerprint, fingerprint_len, 0);
+	} else {
+		RETVAL_FALSE;
+	}
+
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+}
+
+/* {{{ proto bool openssl_x509_check_private_key(mixed cert, mixed key)
+   Checks if a private key corresponds to a CERT */
+PHP_FUNCTION(openssl_x509_check_private_key)
+{
+	zval ** zcert, **zkey;
+	X509 * cert = NULL;
+	EVP_PKEY * key = NULL;
+	long certresource = -1, keyresource = -1;
+
+	RETVAL_FALSE;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ZZ", &zcert, &zkey) == FAILURE) {
+		return;
+	}
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		RETURN_FALSE;
+	}	
+	key = php_openssl_evp_from_zval(zkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (key) {
+		RETVAL_BOOL(X509_check_private_key(cert, key));
+	}
+
+	if (keyresource == -1 && key) {
+		EVP_PKEY_free(key);
+	}
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* Special handling of subjectAltName, see CVE-2013-4073
+ * Christian Heimes
+ */
+
+static int openssl_x509v3_subjectAltName(BIO *bio, X509_EXTENSION *extension)
+{
+	GENERAL_NAMES *names;
+	const X509V3_EXT_METHOD *method = NULL;
+	long i, length, num;
+	const unsigned char *p;
+
+	method = X509V3_EXT_get(extension);
+	if (method == NULL) {
+		return -1;
+	}
+
+	p = extension->value->data;
+	length = extension->value->length;
+	if (method->it) {
+		names = (GENERAL_NAMES*)(ASN1_item_d2i(NULL, &p, length,
+						       ASN1_ITEM_ptr(method->it)));
+	} else {
+		names = (GENERAL_NAMES*)(method->d2i(NULL, &p, length));
+	}
+	if (names == NULL) {
+		return -1;
+	}
+
+	num = sk_GENERAL_NAME_num(names);
+	for (i = 0; i < num; i++) {
+			GENERAL_NAME *name;
+			ASN1_STRING *as;
+			name = sk_GENERAL_NAME_value(names, i);
+			switch (name->type) {
+				case GEN_EMAIL:
+					BIO_puts(bio, "email:");
+					as = name->d.rfc822Name;
+					BIO_write(bio, ASN1_STRING_data(as),
+						  ASN1_STRING_length(as));
+					break;
+				case GEN_DNS:
+					BIO_puts(bio, "DNS:");
+					as = name->d.dNSName;
+					BIO_write(bio, ASN1_STRING_data(as),
+						  ASN1_STRING_length(as));
+					break;
+				case GEN_URI:
+					BIO_puts(bio, "URI:");
+					as = name->d.uniformResourceIdentifier;
+					BIO_write(bio, ASN1_STRING_data(as),
+						  ASN1_STRING_length(as));
+					break;
+				default:
+					/* use builtin print for GEN_OTHERNAME, GEN_X400,
+					 * GEN_EDIPARTY, GEN_DIRNAME, GEN_IPADD and GEN_RID
+					 */
+					GENERAL_NAME_print(bio, name);
+			}
+			/* trailing ', ' except for last element */
+			if (i < (num - 1)) {
+				BIO_puts(bio, ", ");
+			}
+	}
+	sk_GENERAL_NAME_pop_free(names, GENERAL_NAME_free);
+
+	return 0;
+}
+
+/* {{{ proto array openssl_x509_parse(mixed x509 [, bool shortnames=true])
+   Returns an array of the fields/values of the CERT */
+PHP_FUNCTION(openssl_x509_parse)
+{
+	zval ** zcert;
+	X509 * cert = NULL;
+	long certresource = -1;
+	int i, sig_nid;
+	zend_bool useshortnames = 1;
+	char * tmpstr;
+	zval * subitem;
+	X509_EXTENSION *extension;
+	char *extname;
+	BIO  *bio_out;
+	BUF_MEM *bio_buf;
+	char buf[256];
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|b", &zcert, &useshortnames) == FAILURE) {
+		return;
+	}
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		RETURN_FALSE;
+	}
+	array_init(return_value);
+
+	if (cert->name) {
+		add_assoc_string(return_value, "name", cert->name, 1);
+	}
+/*	add_assoc_bool(return_value, "valid", cert->valid); */
+
+	add_assoc_name_entry(return_value, "subject", 		X509_get_subject_name(cert), useshortnames TSRMLS_CC);
+	/* hash as used in CA directories to lookup cert by subject name */
+	{
+		char buf[32];
+		snprintf(buf, sizeof(buf), "%08lx", X509_subject_name_hash(cert));
+		add_assoc_string(return_value, "hash", buf, 1);
+	}
+	
+	add_assoc_name_entry(return_value, "issuer", 		X509_get_issuer_name(cert), useshortnames TSRMLS_CC);
+	add_assoc_long(return_value, "version", 			X509_get_version(cert));
+
+	add_assoc_string(return_value, "serialNumber", i2s_ASN1_INTEGER(NULL, X509_get_serialNumber(cert)), 1); 
+
+	add_assoc_asn1_string(return_value, "validFrom", 	X509_get_notBefore(cert));
+	add_assoc_asn1_string(return_value, "validTo", 		X509_get_notAfter(cert));
+
+	add_assoc_long(return_value, "validFrom_time_t", 	asn1_time_to_time_t(X509_get_notBefore(cert) TSRMLS_CC));
+	add_assoc_long(return_value, "validTo_time_t", 		asn1_time_to_time_t(X509_get_notAfter(cert) TSRMLS_CC));
+
+	tmpstr = (char *)X509_alias_get0(cert, NULL);
+	if (tmpstr) {
+		add_assoc_string(return_value, "alias", tmpstr, 1);
+	}
+
+	sig_nid = OBJ_obj2nid((cert)->sig_alg->algorithm);
+	add_assoc_string(return_value, "signatureTypeSN", (char*)OBJ_nid2sn(sig_nid), 1);
+	add_assoc_string(return_value, "signatureTypeLN", (char*)OBJ_nid2ln(sig_nid), 1);
+	add_assoc_long(return_value, "signatureTypeNID", sig_nid);
+
+	MAKE_STD_ZVAL(subitem);
+	array_init(subitem);
+
+	/* NOTE: the purposes are added as integer keys - the keys match up to the X509_PURPOSE_SSL_XXX defines
+	   in x509v3.h */
+	for (i = 0; i < X509_PURPOSE_get_count(); i++) {
+		int id, purpset;
+		char * pname;
+		X509_PURPOSE * purp;
+		zval * subsub;
+
+		MAKE_STD_ZVAL(subsub);
+		array_init(subsub);
+
+		purp = X509_PURPOSE_get0(i);
+		id = X509_PURPOSE_get_id(purp);
+
+		purpset = X509_check_purpose(cert, id, 0);
+		add_index_bool(subsub, 0, purpset);
+
+		purpset = X509_check_purpose(cert, id, 1);
+		add_index_bool(subsub, 1, purpset);
+
+		pname = useshortnames ? X509_PURPOSE_get0_sname(purp) : X509_PURPOSE_get0_name(purp);
+		add_index_string(subsub, 2, pname, 1);
+
+		/* NOTE: if purpset > 1 then it's a warning - we should mention it ? */
+
+		add_index_zval(subitem, id, subsub);
+	}
+	add_assoc_zval(return_value, "purposes", subitem);
+
+	MAKE_STD_ZVAL(subitem);
+	array_init(subitem);
+
+
+	for (i = 0; i < X509_get_ext_count(cert); i++) {
+		int nid;
+		extension = X509_get_ext(cert, i);
+		nid = OBJ_obj2nid(X509_EXTENSION_get_object(extension));
+		if (nid != NID_undef) {
+			extname = (char *)OBJ_nid2sn(OBJ_obj2nid(X509_EXTENSION_get_object(extension)));
+		} else {
+			OBJ_obj2txt(buf, sizeof(buf)-1, X509_EXTENSION_get_object(extension), 1);
+			extname = buf;
+		}
+		bio_out = BIO_new(BIO_s_mem());
+		if (nid == NID_subject_alt_name) {
+			if (openssl_x509v3_subjectAltName(bio_out, extension) == 0) {
+				BIO_get_mem_ptr(bio_out, &bio_buf);
+				add_assoc_stringl(subitem, extname, bio_buf->data, bio_buf->length, 1);
+			} else {
+				zval_dtor(return_value);
+				if (certresource == -1 && cert) {
+					X509_free(cert);
+				}
+				BIO_free(bio_out);
+				RETURN_FALSE;
+			}
+		}
+		else if (X509V3_EXT_print(bio_out, extension, 0, 0)) {
+			BIO_get_mem_ptr(bio_out, &bio_buf);
+			add_assoc_stringl(subitem, extname, bio_buf->data, bio_buf->length, 1);
+		} else {
+			add_assoc_asn1_string(subitem, extname, X509_EXTENSION_get_data(extension));
+		}
+		BIO_free(bio_out);
+	}
+	add_assoc_zval(return_value, "extensions", subitem);
+
+	if (certresource == -1 && cert) {
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ load_all_certs_from_file */
+static STACK_OF(X509) * load_all_certs_from_file(char *certfile)
+{
+	STACK_OF(X509_INFO) *sk=NULL;
+	STACK_OF(X509) *stack=NULL, *ret=NULL;
+	BIO *in=NULL;
+	X509_INFO *xi;
+	TSRMLS_FETCH();
+
+	if(!(stack = sk_X509_new_null())) {
+		php_error_docref(NULL TSRMLS_CC, E_ERROR, "memory allocation failure");
+		goto end;
+	}
+
+	if (php_openssl_open_base_dir_chk(certfile TSRMLS_CC)) {
+		sk_X509_free(stack);
+		goto end;
+	}
+
+	if(!(in=BIO_new_file(certfile, "r"))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening the file, %s", certfile);
+		sk_X509_free(stack);
+		goto end;
+	}
+
+	/* This loads from a file, a stack of x509/crl/pkey sets */
+	if(!(sk=PEM_X509_INFO_read_bio(in, NULL, NULL, NULL))) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error reading the file, %s", certfile);
+		sk_X509_free(stack);
+		goto end;
+	}
+
+	/* scan over it and pull out the certs */
+	while (sk_X509_INFO_num(sk)) {
+		xi=sk_X509_INFO_shift(sk);
+		if (xi->x509 != NULL) {
+			sk_X509_push(stack,xi->x509);
+			xi->x509=NULL;
+		}
+		X509_INFO_free(xi);
+	}
+	if(!sk_X509_num(stack)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "no certificates in file, %s", certfile);
+		sk_X509_free(stack);
+		goto end;
+	}
+	ret=stack;
+end:
+	BIO_free(in);
+	sk_X509_INFO_free(sk);
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ check_cert */
+static int check_cert(X509_STORE *ctx, X509 *x, STACK_OF(X509) *untrustedchain, int purpose)
+{
+	int ret=0;
+	X509_STORE_CTX *csc;
+	TSRMLS_FETCH();
+
+	csc = X509_STORE_CTX_new();
+	if (csc == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_ERROR, "memory allocation failure");
+		return 0;
+	}
+	X509_STORE_CTX_init(csc, ctx, x, untrustedchain);
+	if(purpose >= 0) {
+		X509_STORE_CTX_set_purpose(csc, purpose);
+	}
+	ret = X509_verify_cert(csc);
+	X509_STORE_CTX_free(csc);
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ proto int openssl_x509_checkpurpose(mixed x509cert, int purpose, array cainfo [, string untrustedfile])
+   Checks the CERT to see if it can be used for the purpose in purpose. cainfo holds information about trusted CAs */
+PHP_FUNCTION(openssl_x509_checkpurpose)
+{
+	zval ** zcert, * zcainfo = NULL;
+	X509_STORE * cainfo = NULL;
+	X509 * cert = NULL;
+	long certresource = -1;
+	STACK_OF(X509) * untrustedchain = NULL;
+	long purpose;
+	char * untrusted = NULL;
+	int untrusted_len = 0, ret;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zl|a!s", &zcert, &purpose, &zcainfo, &untrusted, &untrusted_len) == FAILURE) {
+		return;
+	}
+
+	RETVAL_LONG(-1);
+
+	if (untrusted) {
+		untrustedchain = load_all_certs_from_file(untrusted);
+		if (untrustedchain == NULL) {
+			goto clean_exit;
+		}
+	}
+
+	cainfo = setup_verify(zcainfo TSRMLS_CC);
+	if (cainfo == NULL) {
+		goto clean_exit;
+	}
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		goto clean_exit;
+	}
+
+	ret = check_cert(cainfo, cert, untrustedchain, purpose);
+	if (ret != 0 && ret != 1) {
+		RETVAL_LONG(ret);
+	} else {
+		RETVAL_BOOL(ret);
+	}
+
+clean_exit:
+	if (certresource == 1 && cert) {
+		X509_free(cert);
+	}
+	if (cainfo) { 
+		X509_STORE_free(cainfo); 
+	}
+	if (untrustedchain) {
+		sk_X509_pop_free(untrustedchain, X509_free);
+	}
+}
+/* }}} */
+
+/* {{{ setup_verify
+ * calist is an array containing file and directory names.  create a
+ * certificate store and add those certs to it for use in verification.
+*/
+static X509_STORE * setup_verify(zval * calist TSRMLS_DC)
+{
+	X509_STORE *store;
+	X509_LOOKUP * dir_lookup, * file_lookup;
+	HashPosition pos;
+	int ndirs = 0, nfiles = 0;
+
+	store = X509_STORE_new();
+
+	if (store == NULL) {
+		return NULL;
+	}
+
+	if (calist && (Z_TYPE_P(calist) == IS_ARRAY)) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(calist), &pos);
+		for (;; zend_hash_move_forward_ex(HASH_OF(calist), &pos)) {
+			zval ** item;
+			struct stat sb;
+
+			if (zend_hash_get_current_data_ex(HASH_OF(calist), (void**)&item, &pos) == FAILURE) {
+				break;
+			}
+			convert_to_string_ex(item);
+
+			if (VCWD_STAT(Z_STRVAL_PP(item), &sb) == -1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to stat %s", Z_STRVAL_PP(item));
+				continue;
+			}
+
+			if ((sb.st_mode & S_IFREG) == S_IFREG) {
+				file_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
+				if (file_lookup == NULL || !X509_LOOKUP_load_file(file_lookup, Z_STRVAL_PP(item), X509_FILETYPE_PEM)) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "error loading file %s", Z_STRVAL_PP(item));
+				} else {
+					nfiles++;
+				}
+				file_lookup = NULL;
+			} else {
+				dir_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_hash_dir());
+				if (dir_lookup == NULL || !X509_LOOKUP_add_dir(dir_lookup, Z_STRVAL_PP(item), X509_FILETYPE_PEM)) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "error loading directory %s", Z_STRVAL_PP(item));
+				} else { 
+					ndirs++;
+				}
+				dir_lookup = NULL;
+			}
+		}
+	}
+	if (nfiles == 0) {
+		file_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
+		if (file_lookup) {
+			X509_LOOKUP_load_file(file_lookup, NULL, X509_FILETYPE_DEFAULT);
+		}
+	}
+	if (ndirs == 0) {
+		dir_lookup = X509_STORE_add_lookup(store, X509_LOOKUP_hash_dir());
+		if (dir_lookup) {
+			X509_LOOKUP_add_dir(dir_lookup, NULL, X509_FILETYPE_DEFAULT);
+		}
+	}
+	return store;
+}
+/* }}} */
+
+/* {{{ proto resource openssl_x509_read(mixed cert)
+   Reads X.509 certificates */
+PHP_FUNCTION(openssl_x509_read)
+{
+	zval **cert;
+	X509 *x509;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z", &cert) == FAILURE) {
+		return;
+	}
+	Z_TYPE_P(return_value) = IS_RESOURCE;
+	x509 = php_openssl_x509_from_zval(cert, 1, &Z_LVAL_P(return_value) TSRMLS_CC);
+
+	if (x509 == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied parameter cannot be coerced into an X509 certificate!");
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+/* {{{ proto void openssl_x509_free(resource x509)
+   Frees X.509 certificates */
+PHP_FUNCTION(openssl_x509_free)
+{
+	zval *x509;
+	X509 *cert;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &x509) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(cert, X509 *, &x509, -1, "OpenSSL X.509", le_x509);
+	zend_list_delete(Z_LVAL_P(x509));
+}
+/* }}} */
+
+/* }}} */
+
+/* Pop all X509 from Stack and free them, free the stack afterwards */
+static void php_sk_X509_free(STACK_OF(X509) * sk) /* {{{ */
+{
+	for (;;) {
+		X509* x = sk_X509_pop(sk);
+		if (!x) break;
+		X509_free(x);
+	}
+	sk_X509_free(sk);
+}
+/* }}} */
+
+static STACK_OF(X509) * php_array_to_X509_sk(zval ** zcerts TSRMLS_DC) /* {{{ */
+{
+	HashPosition hpos;
+	zval ** zcertval;
+	STACK_OF(X509) * sk = NULL;
+    X509 * cert;
+    long certresource;
+
+	sk = sk_X509_new_null();
+
+	/* get certs */
+	if (Z_TYPE_PP(zcerts) == IS_ARRAY) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(*zcerts), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(*zcerts), (void**)&zcertval, &hpos) == SUCCESS) {
+
+			cert = php_openssl_x509_from_zval(zcertval, 0, &certresource TSRMLS_CC);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+
+			if (certresource != -1) {
+				cert = X509_dup(cert);
+				
+				if (cert == NULL) {
+					goto clean_exit;
+				}
+				
+			}
+			sk_X509_push(sk, cert);
+
+			zend_hash_move_forward_ex(HASH_OF(*zcerts), &hpos);
+		}
+	} else {
+		/* a single certificate */
+		cert = php_openssl_x509_from_zval(zcerts, 0, &certresource TSRMLS_CC);
+		
+		if (cert == NULL) {
+			goto clean_exit;
+		}
+
+		if (certresource != -1) {
+			cert = X509_dup(cert);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+		}
+		sk_X509_push(sk, cert);
+	}
+
+  clean_exit:
+    return sk;
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs12_export_to_file(mixed x509, string filename, mixed priv_key, string pass[, array args])
+   Creates and exports a PKCS to file */
+PHP_FUNCTION(openssl_pkcs12_export_to_file)
+{
+	X509 * cert = NULL;
+	BIO * bio_out = NULL;
+	PKCS12 * p12 = NULL;
+	char * filename;
+	char * friendly_name = NULL;
+	int filename_len;
+	char * pass;
+	int pass_len;
+	zval **zcert = NULL, *zpkey = NULL, *args = NULL;
+	EVP_PKEY *priv_key = NULL;
+	long certresource, keyresource;
+	zval ** item;
+	STACK_OF(X509) *ca = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zpzs|a", &zcert, &filename, &filename_len, &zpkey, &pass, &pass_len, &args) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+	priv_key = php_openssl_evp_from_zval(&zpkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (priv_key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get private key from parameter 3");
+		goto cleanup;
+	}
+	if (cert && !X509_check_private_key(cert, priv_key)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key does not correspond to cert");
+		goto cleanup;
+	}
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		goto cleanup;
+	}
+
+	/* parse extra config from args array, promote this to an extra function */
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "friendly_name", sizeof("friendly_name"), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_STRING)
+		friendly_name = Z_STRVAL_PP(item);
+	/* certpbe (default RC2-40)
+	   keypbe (default 3DES)
+	   friendly_caname
+	*/
+
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "extracerts", sizeof("extracerts"), (void**)&item) == SUCCESS)
+		ca = php_array_to_X509_sk(item TSRMLS_CC);
+	/* end parse extra config */
+
+	/*PKCS12 *PKCS12_create(char *pass, char *name, EVP_PKEY *pkey, X509 *cert, STACK_OF(X509) *ca,
+                                       int nid_key, int nid_cert, int iter, int mac_iter, int keytype);*/
+
+	p12 = PKCS12_create(pass, friendly_name, priv_key, cert, ca, 0, 0, 0, 0, 0);
+
+	bio_out = BIO_new_file(filename, "w"); 
+	if (bio_out) {
+		
+		i2d_PKCS12_bio(bio_out, p12);
+
+		RETVAL_TRUE;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening file %s", filename);
+	}
+
+	BIO_free(bio_out);
+	PKCS12_free(p12);
+	php_sk_X509_free(ca);
+	
+cleanup:
+
+	if (keyresource == -1 && priv_key) {
+		EVP_PKEY_free(priv_key);
+	}
+	if (certresource == -1 && cert) { 
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs12_export(mixed x509, string &out, mixed priv_key, string pass[, array args])
+   Creates and exports a PKCS12 to a var */
+PHP_FUNCTION(openssl_pkcs12_export)
+{
+	X509 * cert = NULL;
+	BIO * bio_out;
+	PKCS12 * p12 = NULL;
+	zval * zcert = NULL, *zout = NULL, *zpkey, *args = NULL;
+	EVP_PKEY *priv_key = NULL;
+	long certresource, keyresource;
+	char * pass;
+	int pass_len;
+	char * friendly_name = NULL;
+	zval ** item;
+	STACK_OF(X509) *ca = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zzzs|a", &zcert, &zout, &zpkey, &pass, &pass_len, &args) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	cert = php_openssl_x509_from_zval(&zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 1");
+		return;
+	}
+	priv_key = php_openssl_evp_from_zval(&zpkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (priv_key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get private key from parameter 3");
+		goto cleanup;
+	}
+	if (cert && !X509_check_private_key(cert, priv_key)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key does not correspond to cert");
+		goto cleanup;
+	}
+
+	/* parse extra config from args array, promote this to an extra function */
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "friendly_name", sizeof("friendly_name"), (void**)&item) == SUCCESS && Z_TYPE_PP(item) == IS_STRING)
+		friendly_name = Z_STRVAL_PP(item);
+
+	if (args && zend_hash_find(Z_ARRVAL_P(args), "extracerts", sizeof("extracerts"), (void**)&item) == SUCCESS)
+		ca = php_array_to_X509_sk(item TSRMLS_CC);
+	/* end parse extra config */
+	
+	p12 = PKCS12_create(pass, friendly_name, priv_key, cert, ca, 0, 0, 0, 0, 0);
+
+	bio_out = BIO_new(BIO_s_mem());
+	if (i2d_PKCS12_bio(bio_out, p12))  {
+		BUF_MEM *bio_buf;
+
+		zval_dtor(zout);
+		BIO_get_mem_ptr(bio_out, &bio_buf);
+		ZVAL_STRINGL(zout, bio_buf->data, bio_buf->length, 1);
+
+		RETVAL_TRUE;
+	}
+
+	BIO_free(bio_out);
+	PKCS12_free(p12);
+	php_sk_X509_free(ca);
+	
+cleanup:
+
+	if (keyresource == -1 && priv_key) {
+		EVP_PKEY_free(priv_key);
+	}
+	if (certresource == -1 && cert) { 
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs12_read(string PKCS12, array &certs, string pass)
+   Parses a PKCS12 to an array */
+PHP_FUNCTION(openssl_pkcs12_read)
+{
+	zval *zout = NULL, *zextracerts, *zcert, *zpkey;
+	char *pass, *zp12;
+	int pass_len, zp12_len;
+	PKCS12 * p12 = NULL;
+	EVP_PKEY * pkey = NULL;
+	X509 * cert = NULL;
+	STACK_OF(X509) * ca = NULL;
+	BIO * bio_in = NULL;
+	int i;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szs", &zp12, &zp12_len, &zout, &pass, &pass_len) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	bio_in = BIO_new(BIO_s_mem());
+	
+	if(!BIO_write(bio_in, zp12, zp12_len))
+		goto cleanup;
+	
+	if(d2i_PKCS12_bio(bio_in, &p12)) {
+		if(PKCS12_parse(p12, pass, &pkey, &cert, &ca)) {
+			BIO * bio_out;
+
+			zval_dtor(zout);
+			array_init(zout);
+
+			bio_out = BIO_new(BIO_s_mem());
+			if (PEM_write_bio_X509(bio_out, cert)) {
+				BUF_MEM *bio_buf;
+				BIO_get_mem_ptr(bio_out, &bio_buf);
+				MAKE_STD_ZVAL(zcert);
+				ZVAL_STRINGL(zcert, bio_buf->data, bio_buf->length, 1);
+				add_assoc_zval(zout, "cert", zcert);
+			}
+			BIO_free(bio_out);
+
+			bio_out = BIO_new(BIO_s_mem());
+			if (PEM_write_bio_PrivateKey(bio_out, pkey, NULL, NULL, 0, 0, NULL)) {
+				BUF_MEM *bio_buf;
+				BIO_get_mem_ptr(bio_out, &bio_buf);
+				MAKE_STD_ZVAL(zpkey);
+				ZVAL_STRINGL(zpkey, bio_buf->data, bio_buf->length, 1);
+				add_assoc_zval(zout, "pkey", zpkey);
+			}
+			BIO_free(bio_out);
+
+			MAKE_STD_ZVAL(zextracerts);
+			array_init(zextracerts);
+			
+			for (i=0;;i++) {
+				zval * zextracert;
+				X509* aCA = sk_X509_pop(ca);
+				if (!aCA) break;
+
+				/* fix for bug 69882 */
+				{
+					int err = ERR_peek_error();
+					if (err == OPENSSL_ERROR_X509_PRIVATE_KEY_VALUES_MISMATCH) {
+						ERR_get_error();
+					}
+				}
+
+				bio_out = BIO_new(BIO_s_mem());
+				if (PEM_write_bio_X509(bio_out, aCA)) {
+					BUF_MEM *bio_buf;
+					BIO_get_mem_ptr(bio_out, &bio_buf);
+					MAKE_STD_ZVAL(zextracert);
+					ZVAL_STRINGL(zextracert, bio_buf->data, bio_buf->length, 1);
+					add_index_zval(zextracerts, i, zextracert);
+					
+				}
+				BIO_free(bio_out);
+
+				X509_free(aCA);
+			}
+			if(ca) {
+				sk_X509_free(ca);
+				add_assoc_zval(zout, "extracerts", zextracerts);
+			} else {
+				zval_dtor(zextracerts);
+			}
+			
+			RETVAL_TRUE;
+			
+			PKCS12_free(p12);
+		}
+	}
+	
+  cleanup:
+	if (bio_in) {
+		BIO_free(bio_in);
+	}
+	if (pkey) {
+		EVP_PKEY_free(pkey);
+	}
+	if (cert) { 
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ x509 CSR functions */
+
+/* {{{ php_openssl_make_REQ */
+static int php_openssl_make_REQ(struct php_x509_request * req, X509_REQ * csr, zval * dn, zval * attribs TSRMLS_DC)
+{
+	STACK_OF(CONF_VALUE) * dn_sk, *attr_sk = NULL;
+	char * str, *dn_sect, *attr_sect;
+
+	dn_sect = CONF_get_string(req->req_config, req->section_name, "distinguished_name");
+	if (dn_sect == NULL) {
+		return FAILURE;
+	}
+	dn_sk = CONF_get_section(req->req_config, dn_sect);
+	if (dn_sk == NULL) { 
+		return FAILURE;
+	}
+	attr_sect = CONF_get_string(req->req_config, req->section_name, "attributes");
+	if (attr_sect == NULL) {
+		attr_sk = NULL;
+	} else {
+		attr_sk = CONF_get_section(req->req_config, attr_sect);
+		if (attr_sk == NULL) {
+			return FAILURE;
+		}
+	}
+	/* setup the version number: version 1 */
+	if (X509_REQ_set_version(csr, 0L)) {
+		int i, nid;
+		char * type;
+		CONF_VALUE * v;
+		X509_NAME * subj;
+		HashPosition hpos;
+		zval ** item;
+		
+		subj = X509_REQ_get_subject_name(csr);
+		/* apply values from the dn hash */
+		zend_hash_internal_pointer_reset_ex(HASH_OF(dn), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(dn), (void**)&item, &hpos) == SUCCESS) {
+			char * strindex = NULL; 
+			uint strindexlen = 0;
+			ulong intindex;
+			
+			zend_hash_get_current_key_ex(HASH_OF(dn), &strindex, &strindexlen, &intindex, 0, &hpos);
+
+			convert_to_string_ex(item);
+
+			if (strindex) {
+				int nid;
+
+				nid = OBJ_txt2nid(strindex);
+				if (nid != NID_undef) {
+					if (!X509_NAME_add_entry_by_NID(subj, nid, MBSTRING_UTF8, 
+								(unsigned char*)Z_STRVAL_PP(item), -1, -1, 0))
+					{
+						php_error_docref(NULL TSRMLS_CC, E_WARNING,
+							"dn: add_entry_by_NID %d -> %s (failed; check error"
+							" queue and value of string_mask OpenSSL option "
+							"if illegal characters are reported)",
+							nid, Z_STRVAL_PP(item));
+						return FAILURE;
+					}
+				} else {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "dn: %s is not a recognized name", strindex);
+				}
+			}
+			zend_hash_move_forward_ex(HASH_OF(dn), &hpos);
+		}
+
+		/* Finally apply defaults from config file */
+		for(i = 0; i < sk_CONF_VALUE_num(dn_sk); i++) {
+			int len;
+			char buffer[200 + 1]; /*200 + \0 !*/
+			
+			v = sk_CONF_VALUE_value(dn_sk, i);
+			type = v->name;
+			
+			len = strlen(type);
+			if (len < sizeof("_default")) {
+				continue;
+			}
+			len -= sizeof("_default") - 1;
+			if (strcmp("_default", type + len) != 0) {
+				continue;
+			}
+			if (len > 200) {
+				len = 200;
+			}
+			memcpy(buffer, type, len);
+			buffer[len] = '\0';
+			type = buffer;
+		
+			/* Skip past any leading X. X: X, etc to allow for multiple
+			 * instances */
+			for (str = type; *str; str++) {
+				if (*str == ':' || *str == ',' || *str == '.') {
+					str++;
+					if (*str) {
+						type = str;
+					}
+					break;
+				}
+			}
+			/* if it is already set, skip this */
+			nid = OBJ_txt2nid(type);
+			if (X509_NAME_get_index_by_NID(subj, nid, -1) >= 0) {
+				continue;
+			}
+			if (!X509_NAME_add_entry_by_txt(subj, type, MBSTRING_UTF8, (unsigned char*)v->value, -1, -1, 0)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "add_entry_by_txt %s -> %s (failed)", type, v->value);
+				return FAILURE;
+			}
+			if (!X509_NAME_entry_count(subj)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "no objects specified in config file");
+				return FAILURE;
+			}
+		}
+		if (attribs) {
+			zend_hash_internal_pointer_reset_ex(HASH_OF(attribs), &hpos);
+			while(zend_hash_get_current_data_ex(HASH_OF(attribs), (void**)&item, &hpos) == SUCCESS) {
+				char *strindex = NULL;
+				uint strindexlen;
+				ulong intindex;
+
+				zend_hash_get_current_key_ex(HASH_OF(attribs), &strindex, &strindexlen, &intindex, 0, &hpos);
+				convert_to_string_ex(item);
+
+				if (strindex) {
+					int nid;
+
+					nid = OBJ_txt2nid(strindex);
+					if (nid != NID_undef) {
+						if (!X509_NAME_add_entry_by_NID(subj, nid, MBSTRING_UTF8, (unsigned char*)Z_STRVAL_PP(item), -1, -1, 0)) {
+							php_error_docref(NULL TSRMLS_CC, E_WARNING, "attribs: add_entry_by_NID %d -> %s (failed)", nid, Z_STRVAL_PP(item));
+							return FAILURE;
+						}
+					} else {
+						php_error_docref(NULL TSRMLS_CC, E_WARNING, "dn: %s is not a recognized name", strindex);
+					}
+				}
+				zend_hash_move_forward_ex(HASH_OF(attribs), &hpos);
+			}
+			for (i = 0; i < sk_CONF_VALUE_num(attr_sk); i++) {
+				v = sk_CONF_VALUE_value(attr_sk, i);
+				/* if it is already set, skip this */
+				nid = OBJ_txt2nid(v->name);
+				if (X509_REQ_get_attr_by_NID(csr, nid, -1) >= 0) {
+					continue;
+				}
+				if (!X509_REQ_add1_attr_by_txt(csr, v->name, MBSTRING_UTF8, (unsigned char*)v->value, -1)) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+						"add1_attr_by_txt %s -> %s (failed; check error queue "
+						"and value of string_mask OpenSSL option if illegal "
+						"characters are reported)",
+						v->name, v->value);
+					return FAILURE;
+				}
+			}
+		}
+	}
+
+	X509_REQ_set_pubkey(csr, req->priv_key);
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ php_openssl_csr_from_zval */
+static X509_REQ * php_openssl_csr_from_zval(zval ** val, int makeresource, long * resourceval TSRMLS_DC)
+{
+	X509_REQ * csr = NULL;
+	char * filename = NULL;
+	BIO * in;
+	
+	if (resourceval) {
+		*resourceval = -1;
+	}
+	if (Z_TYPE_PP(val) == IS_RESOURCE) {
+		void * what;
+		int type;
+
+		what = zend_fetch_resource(val TSRMLS_CC, -1, "OpenSSL X.509 CSR", &type, 1, le_csr);
+		if (what) {
+			if (resourceval) {
+				*resourceval = Z_LVAL_PP(val);
+			}
+			return (X509_REQ*)what;
+		}
+		return NULL;
+	} else if (Z_TYPE_PP(val) != IS_STRING) {
+		return NULL;
+	}
+
+	if (Z_STRLEN_PP(val) > 7 && memcmp(Z_STRVAL_PP(val), "file://", sizeof("file://") - 1) == 0) {
+		filename = Z_STRVAL_PP(val) + (sizeof("file://") - 1);
+	}
+	if (filename) {
+		if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+			return NULL;
+		}
+		in = BIO_new_file(filename, "r");
+	} else {
+		in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+	}
+	csr = PEM_read_bio_X509_REQ(in, NULL,NULL,NULL);
+	BIO_free(in);
+
+	return csr;
+}
+/* }}} */
+
+/* {{{ proto bool openssl_csr_export_to_file(resource csr, string outfilename [, bool notext=true])
+   Exports a CSR to file */
+PHP_FUNCTION(openssl_csr_export_to_file)
+{
+	X509_REQ * csr;
+	zval * zcsr = NULL;
+	zend_bool notext = 1;
+	char * filename = NULL; int filename_len;
+	BIO * bio_out;
+	long csr_resource;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rp|b", &zcsr, &filename, &filename_len, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	csr = php_openssl_csr_from_zval(&zcsr, 0, &csr_resource TSRMLS_CC);
+	if (csr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get CSR from parameter 1");
+		return;
+	}
+
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		return;
+	}
+
+	bio_out = BIO_new_file(filename, "w");
+	if (bio_out) {
+		if (!notext) {
+			X509_REQ_print(bio_out, csr);
+		}
+		PEM_write_bio_X509_REQ(bio_out, csr);
+		RETVAL_TRUE;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening file %s", filename);
+	}
+
+	if (csr_resource == -1 && csr) {
+		X509_REQ_free(csr);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_csr_export(resource csr, string &out [, bool notext=true])
+   Exports a CSR to file or a var */
+PHP_FUNCTION(openssl_csr_export)
+{
+	X509_REQ * csr;
+	zval * zcsr = NULL, *zout=NULL;
+	zend_bool notext = 1;
+	BIO * bio_out;
+
+	long csr_resource;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz|b", &zcsr, &zout, &notext) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	csr = php_openssl_csr_from_zval(&zcsr, 0, &csr_resource TSRMLS_CC);
+	if (csr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get CSR from parameter 1");
+		return;
+	}
+
+	/* export to a var */
+
+	bio_out = BIO_new(BIO_s_mem());
+	if (!notext) {
+		X509_REQ_print(bio_out, csr);
+	}
+
+	if (PEM_write_bio_X509_REQ(bio_out, csr)) {
+		BUF_MEM *bio_buf;
+
+		BIO_get_mem_ptr(bio_out, &bio_buf);
+		zval_dtor(zout);
+		ZVAL_STRINGL(zout, bio_buf->data, bio_buf->length, 1);
+
+		RETVAL_TRUE;
+	}
+
+	if (csr_resource == -1 && csr) {
+		X509_REQ_free(csr);
+	}
+	BIO_free(bio_out);
+}
+/* }}} */
+
+/* {{{ proto resource openssl_csr_sign(mixed csr, mixed x509, mixed priv_key, long days [, array config_args [, long serial]])
+   Signs a cert with another CERT */
+PHP_FUNCTION(openssl_csr_sign)
+{
+	zval ** zcert = NULL, **zcsr, **zpkey, *args = NULL;
+	long num_days;
+	long serial = 0L;
+	X509 * cert = NULL, *new_cert = NULL;
+	X509_REQ * csr;
+	EVP_PKEY * key = NULL, *priv_key = NULL;
+	long csr_resource, certresource = 0, keyresource = -1;
+	int i;
+	struct php_x509_request req;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ZZ!Zl|a!l", &zcsr, &zcert, &zpkey, &num_days, &args, &serial) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	PHP_SSL_REQ_INIT(&req);
+	
+	csr = php_openssl_csr_from_zval(zcsr, 0, &csr_resource TSRMLS_CC);
+	if (csr == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get CSR from parameter 1");
+		return;
+	}
+	if (zcert) {
+		cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+		if (cert == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get cert from parameter 2");
+			goto cleanup;
+		}
+	}
+	priv_key = php_openssl_evp_from_zval(zpkey, 0, "", 1, &keyresource TSRMLS_CC);
+	if (priv_key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get private key from parameter 3");
+		goto cleanup;
+	}
+	if (cert && !X509_check_private_key(cert, priv_key)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key does not correspond to signing cert");
+		goto cleanup;
+	}
+	
+	if (PHP_SSL_REQ_PARSE(&req, args) == FAILURE) {
+		goto cleanup;
+	}
+	/* Check that the request matches the signature */
+	key = X509_REQ_get_pubkey(csr);
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error unpacking public key");
+		goto cleanup;
+	}
+	i = X509_REQ_verify(csr, key);
+
+	if (i < 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Signature verification problems");
+		goto cleanup;
+	}
+	else if (i == 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Signature did not match the certificate request");
+		goto cleanup;
+	}
+	
+	/* Now we can get on with it */
+	
+	new_cert = X509_new();
+	if (new_cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No memory");
+		goto cleanup;
+	}
+	/* Version 3 cert */
+	if (!X509_set_version(new_cert, 2))
+		goto cleanup;
+
+	ASN1_INTEGER_set(X509_get_serialNumber(new_cert), serial);
+	
+	X509_set_subject_name(new_cert, X509_REQ_get_subject_name(csr));
+
+	if (cert == NULL) {
+		cert = new_cert;
+	}
+	if (!X509_set_issuer_name(new_cert, X509_get_subject_name(cert))) {
+		goto cleanup;
+	}
+	X509_gmtime_adj(X509_get_notBefore(new_cert), 0);
+	X509_gmtime_adj(X509_get_notAfter(new_cert), (long)60*60*24*num_days);
+	i = X509_set_pubkey(new_cert, key);
+	if (!i) {
+		goto cleanup;
+	}
+	if (req.extensions_section) {
+		X509V3_CTX ctx;
+		
+		X509V3_set_ctx(&ctx, cert, new_cert, csr, NULL, 0);
+		X509V3_set_conf_lhash(&ctx, req.req_config);
+		if (!X509V3_EXT_add_conf(req.req_config, &ctx, req.extensions_section, new_cert)) {
+			goto cleanup;
+		}
+	}
+
+	/* Now sign it */
+	if (!X509_sign(new_cert, priv_key, req.digest)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to sign it");
+		goto cleanup;
+	}
+	
+	/* Succeeded; lets return the cert */
+	RETVAL_RESOURCE(zend_list_insert(new_cert, le_x509 TSRMLS_CC));
+	new_cert = NULL;
+	
+cleanup:
+
+	if (cert == new_cert) {
+		cert = NULL;
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+
+	if (keyresource == -1 && priv_key) {
+		EVP_PKEY_free(priv_key);
+	}
+	if (key) {
+		EVP_PKEY_free(key);
+	}
+	if (csr_resource == -1 && csr) {
+		X509_REQ_free(csr);
+	}
+	if (certresource == -1 && cert) { 
+		X509_free(cert);
+	}
+	if (new_cert) {
+		X509_free(new_cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_csr_new(array dn, resource &privkey [, array configargs [, array extraattribs]])
+   Generates a privkey and CSR */
+PHP_FUNCTION(openssl_csr_new)
+{
+	struct php_x509_request req;
+	zval * args = NULL, * dn, *attribs = NULL;
+	zval * out_pkey;
+	X509_REQ * csr = NULL;
+	int we_made_the_key = 1;
+	long key_resource;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "az|a!a!", &dn, &out_pkey, &args, &attribs) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+	
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS) {
+		/* Generate or use a private key */
+		if (Z_TYPE_P(out_pkey) != IS_NULL) {
+			req.priv_key = php_openssl_evp_from_zval(&out_pkey, 0, NULL, 0, &key_resource TSRMLS_CC);
+			if (req.priv_key != NULL) {
+				we_made_the_key = 0;
+			}
+		}
+		if (req.priv_key == NULL) {
+			php_openssl_generate_private_key(&req TSRMLS_CC);
+		}
+		if (req.priv_key == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to generate a private key");
+		} else {
+			csr = X509_REQ_new();
+			if (csr) {
+				if (php_openssl_make_REQ(&req, csr, dn, attribs TSRMLS_CC) == SUCCESS) {
+					X509V3_CTX ext_ctx;
+
+					X509V3_set_ctx(&ext_ctx, NULL, NULL, csr, NULL, 0);
+					X509V3_set_conf_lhash(&ext_ctx, req.req_config);
+
+					/* Add extensions */
+					if (req.request_extensions_section && !X509V3_EXT_REQ_add_conf(req.req_config,
+								&ext_ctx, req.request_extensions_section, csr))
+					{
+						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error loading extension section %s", req.request_extensions_section);
+					} else {
+						RETVAL_TRUE;
+						
+						if (X509_REQ_sign(csr, req.priv_key, req.digest)) {
+							RETVAL_RESOURCE(zend_list_insert(csr, le_csr TSRMLS_CC));
+							csr = NULL;			
+						} else {
+							php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error signing request");
+						}
+
+						if (we_made_the_key) {
+							/* and a resource for the private key */
+							zval_dtor(out_pkey);
+							ZVAL_RESOURCE(out_pkey, zend_list_insert(req.priv_key, le_key TSRMLS_CC));
+							req.priv_key = NULL; /* make sure the cleanup code doesn't zap it! */
+						} else if (key_resource != -1) {
+							req.priv_key = NULL; /* make sure the cleanup code doesn't zap it! */
+						}
+					}
+				}
+				else {
+					if (!we_made_the_key) {
+						/* if we have not made the key we are not supposed to zap it by calling dispose! */
+						req.priv_key = NULL;
+					}
+				}
+			}
+		}
+	}
+	if (csr) {
+		X509_REQ_free(csr);
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+}
+/* }}} */
+
+/* {{{ proto mixed openssl_csr_get_subject(mixed csr)
+   Returns the subject of a CERT or FALSE on error */
+PHP_FUNCTION(openssl_csr_get_subject)
+{
+	zval ** zcsr;
+	zend_bool use_shortnames = 1;
+	long csr_resource;
+	X509_NAME * subject;
+	X509_REQ * csr;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|b", &zcsr, &use_shortnames) == FAILURE) {
+		return;
+	}
+
+	csr = php_openssl_csr_from_zval(zcsr, 0, &csr_resource TSRMLS_CC);
+
+	if (csr == NULL) {
+		RETURN_FALSE;
+	}
+
+	subject = X509_REQ_get_subject_name(csr);
+
+	array_init(return_value);
+	add_assoc_name_entry(return_value, NULL, subject, use_shortnames TSRMLS_CC);
+	return;
+}
+/* }}} */
+
+/* {{{ proto mixed openssl_csr_get_public_key(mixed csr)
+	Returns the subject of a CERT or FALSE on error */
+PHP_FUNCTION(openssl_csr_get_public_key)
+{
+	zval ** zcsr;
+	zend_bool use_shortnames = 1;
+	long csr_resource;
+
+	X509_REQ * csr;
+	EVP_PKEY *tpubkey;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|b", &zcsr, &use_shortnames) == FAILURE) {
+		return;
+	}
+
+	csr = php_openssl_csr_from_zval(zcsr, 0, &csr_resource TSRMLS_CC);
+
+	if (csr == NULL) {
+		RETURN_FALSE;
+	}
+
+	tpubkey=X509_REQ_get_pubkey(csr);
+	RETVAL_RESOURCE(zend_list_insert(tpubkey, le_key TSRMLS_CC));
+	return;
+}
+/* }}} */
+
+/* }}} */
+
+/* {{{ EVP Public/Private key functions */
+
+/* {{{ php_openssl_evp_from_zval
+   Given a zval, coerce it into a EVP_PKEY object.
+	It can be:
+		1. private key resource from openssl_get_privatekey()
+		2. X509 resource -> public key will be extracted from it
+		3. if it starts with file:// interpreted as path to key file
+		4. interpreted as the data from the cert/key file and interpreted in same way as openssl_get_privatekey()
+		5. an array(0 => [items 2..4], 1 => passphrase)
+		6. if val is a string (possibly starting with file:///) and it is not an X509 certificate, then interpret as public key
+	NOTE: If you are requesting a private key but have not specified a passphrase, you should use an
+	empty string rather than NULL for the passphrase - NULL causes a passphrase prompt to be emitted in
+	the Apache error log!
+*/
+static EVP_PKEY * php_openssl_evp_from_zval(zval ** val, int public_key, char * passphrase, int makeresource, long * resourceval TSRMLS_DC)
+{
+	EVP_PKEY * key = NULL;
+	X509 * cert = NULL;
+	int free_cert = 0;
+	long cert_res = -1;
+	char * filename = NULL;
+	zval tmp;
+
+	Z_TYPE(tmp) = IS_NULL;
+
+#define TMP_CLEAN \
+	if (Z_TYPE(tmp) == IS_STRING) {\
+		zval_dtor(&tmp); \
+	} \
+	return NULL;
+
+	if (resourceval) {
+		*resourceval = -1;
+	}
+	if (Z_TYPE_PP(val) == IS_ARRAY) {
+		zval ** zphrase;
+		
+		/* get passphrase */
+
+		if (zend_hash_index_find(HASH_OF(*val), 1, (void **)&zphrase) == FAILURE) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key array must be of the form array(0 => key, 1 => phrase)");
+			return NULL;
+		}
+		
+		if (Z_TYPE_PP(zphrase) == IS_STRING) {
+			passphrase = Z_STRVAL_PP(zphrase);
+		} else {
+			tmp = **zphrase;
+			zval_copy_ctor(&tmp);
+			convert_to_string(&tmp);
+			passphrase = Z_STRVAL(tmp);
+		}
+
+		/* now set val to be the key param and continue */
+		if (zend_hash_index_find(HASH_OF(*val), 0, (void **)&val) == FAILURE) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key array must be of the form array(0 => key, 1 => phrase)");
+			TMP_CLEAN;
+		}
+	}
+
+	if (Z_TYPE_PP(val) == IS_RESOURCE) {
+		void * what;
+		int type;
+
+		what = zend_fetch_resource(val TSRMLS_CC, -1, "OpenSSL X.509/key", &type, 2, le_x509, le_key);
+		if (!what) {
+			TMP_CLEAN;
+		}
+		if (resourceval) { 
+			*resourceval = Z_LVAL_PP(val);
+		}
+		if (type == le_x509) {
+			/* extract key from cert, depending on public_key param */
+			cert = (X509*)what;
+			free_cert = 0;
+		} else if (type == le_key) {
+			int is_priv;
+
+			is_priv = php_openssl_is_private_key((EVP_PKEY*)what TSRMLS_CC);
+
+			/* check whether it is actually a private key if requested */
+			if (!public_key && !is_priv) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied key param is a public key");
+				TMP_CLEAN;
+			}
+
+			if (public_key && is_priv) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Don't know how to get public key from this private key");
+				TMP_CLEAN;
+			} else {
+				if (Z_TYPE(tmp) == IS_STRING) {
+					zval_dtor(&tmp);
+				}
+				/* got the key - return it */
+				return (EVP_PKEY*)what;
+			}
+		} else {
+			/* other types could be used here - eg: file pointers and read in the data from them */
+			TMP_CLEAN;
+		}
+	} else {
+		/* force it to be a string and check if it refers to a file */
+		/* passing non string values leaks, object uses toString, it returns NULL 
+		 * See bug38255.phpt 
+		 */
+		if (!(Z_TYPE_PP(val) == IS_STRING || Z_TYPE_PP(val) == IS_OBJECT)) {
+			TMP_CLEAN;
+		}
+		convert_to_string_ex(val);
+
+		if (Z_STRLEN_PP(val) > 7 && memcmp(Z_STRVAL_PP(val), "file://", sizeof("file://") - 1) == 0) {
+			filename = Z_STRVAL_PP(val) + (sizeof("file://") - 1);
+		}
+		/* it's an X509 file/cert of some kind, and we need to extract the data from that */
+		if (public_key) {
+			cert = php_openssl_x509_from_zval(val, 0, &cert_res TSRMLS_CC);
+			free_cert = (cert_res == -1);
+			/* actual extraction done later */
+			if (!cert) {
+				/* not a X509 certificate, try to retrieve public key */
+				BIO* in;
+				if (filename) {
+					in = BIO_new_file(filename, "r");
+				} else {
+					in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+				}
+				if (in == NULL) {
+					TMP_CLEAN;
+				}
+				key = PEM_read_bio_PUBKEY(in, NULL,NULL, NULL);
+				BIO_free(in);
+			}
+		} else {
+			/* we want the private key */
+			BIO *in;
+
+			if (filename) {
+				if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+					TMP_CLEAN;
+				}
+				in = BIO_new_file(filename, "r");
+			} else {
+				in = BIO_new_mem_buf(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+			}
+
+			if (in == NULL) {
+				TMP_CLEAN;
+			}
+			key = PEM_read_bio_PrivateKey(in, NULL,NULL, passphrase);
+			BIO_free(in);
+		}
+	}
+
+	if (public_key && cert && key == NULL) {
+		/* extract public key from X509 cert */
+		key = (EVP_PKEY *) X509_get_pubkey(cert);
+	}
+
+	if (free_cert && cert) {
+		X509_free(cert);
+	}
+	if (key && makeresource && resourceval) {
+		*resourceval = ZEND_REGISTER_RESOURCE(NULL, key, le_key);
+	}
+	if (Z_TYPE(tmp) == IS_STRING) {
+		zval_dtor(&tmp);
+	}
+	return key;
+}
+/* }}} */
+
+/* {{{ php_openssl_generate_private_key */
+static EVP_PKEY * php_openssl_generate_private_key(struct php_x509_request * req TSRMLS_DC)
+{
+	char * randfile = NULL;
+	int egdsocket, seeded;
+	EVP_PKEY * return_val = NULL;
+	
+	if (req->priv_key_bits < MIN_KEY_LENGTH) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "private key length is too short; it needs to be at least %d bits, not %d",
+				MIN_KEY_LENGTH, req->priv_key_bits);
+		return NULL;
+	}
+
+	randfile = CONF_get_string(req->req_config, req->section_name, "RANDFILE");
+	php_openssl_load_rand_file(randfile, &egdsocket, &seeded TSRMLS_CC);
+	
+	if ((req->priv_key = EVP_PKEY_new()) != NULL) {
+		switch(req->priv_key_type) {
+			case OPENSSL_KEYTYPE_RSA:
+				PHP_OPENSSL_RAND_ADD_TIME();
+				if (EVP_PKEY_assign_RSA(req->priv_key, RSA_generate_key(req->priv_key_bits, 0x10001, NULL, NULL))) {
+					return_val = req->priv_key;
+				}
+				break;
+#if !defined(NO_DSA) && defined(HAVE_DSA_DEFAULT_METHOD)
+			case OPENSSL_KEYTYPE_DSA:
+				PHP_OPENSSL_RAND_ADD_TIME();
+				{
+					DSA *dsapar = DSA_generate_parameters(req->priv_key_bits, NULL, 0, NULL, NULL, NULL, NULL);
+					if (dsapar) {
+						DSA_set_method(dsapar, DSA_get_default_method());
+						if (DSA_generate_key(dsapar)) {
+							if (EVP_PKEY_assign_DSA(req->priv_key, dsapar)) {
+								return_val = req->priv_key;
+							}
+						} else {
+							DSA_free(dsapar);
+						}
+					}
+				}
+				break;
+#endif
+#if !defined(NO_DH)
+			case OPENSSL_KEYTYPE_DH:
+				PHP_OPENSSL_RAND_ADD_TIME();
+				{
+					DH *dhpar = DH_generate_parameters(req->priv_key_bits, 2, NULL, NULL);
+					int codes = 0;
+
+					if (dhpar) {
+						DH_set_method(dhpar, DH_get_default_method());
+						if (DH_check(dhpar, &codes) && codes == 0 && DH_generate_key(dhpar)) {
+							if (EVP_PKEY_assign_DH(req->priv_key, dhpar)) {
+								return_val = req->priv_key;
+							}
+						} else {
+							DH_free(dhpar);
+						}
+					}
+				}
+				break;
+#endif
+			default:
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unsupported private key type");
+		}
+	}
+
+	php_openssl_write_rand_file(randfile, egdsocket, seeded);
+	
+	if (return_val == NULL) {
+		EVP_PKEY_free(req->priv_key);
+		req->priv_key = NULL;
+		return NULL;
+	}
+	
+	return return_val;
+}
+/* }}} */
+
+/* {{{ php_openssl_is_private_key
+	Check whether the supplied key is a private key by checking if the secret prime factors are set */
+static int php_openssl_is_private_key(EVP_PKEY* pkey TSRMLS_DC)
+{
+	assert(pkey != NULL);
+
+	switch (pkey->type) {
+#ifndef NO_RSA
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			assert(pkey->pkey.rsa != NULL);
+			if (pkey->pkey.rsa != NULL && (NULL == pkey->pkey.rsa->p || NULL == pkey->pkey.rsa->q)) {
+				return 0;
+			}
+			break;
+#endif
+#ifndef NO_DSA
+		case EVP_PKEY_DSA:
+		case EVP_PKEY_DSA1:
+		case EVP_PKEY_DSA2:
+		case EVP_PKEY_DSA3:
+		case EVP_PKEY_DSA4:
+			assert(pkey->pkey.dsa != NULL);
+
+			if (NULL == pkey->pkey.dsa->p || NULL == pkey->pkey.dsa->q || NULL == pkey->pkey.dsa->priv_key){ 
+				return 0;
+			}
+			break;
+#endif
+#ifndef NO_DH
+		case EVP_PKEY_DH:
+			assert(pkey->pkey.dh != NULL);
+
+			if (NULL == pkey->pkey.dh->p || NULL == pkey->pkey.dh->priv_key) {
+				return 0;
+			}
+			break;
+#endif
+#ifdef HAVE_EVP_PKEY_EC
+		case EVP_PKEY_EC:
+			assert(pkey->pkey.ec != NULL);
+
+			if ( NULL == EC_KEY_get0_private_key(pkey->pkey.ec)) {
+				return 0;
+			}
+			break;
+#endif
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+			break;
+	}
+	return 1;
+}
+/* }}} */
+
+#define OPENSSL_PKEY_GET_BN(_type, _name) do {							\
+		if (pkey->pkey._type->_name != NULL) {							\
+			int len = BN_num_bytes(pkey->pkey._type->_name);			\
+			char *str = emalloc(len + 1);								\
+			BN_bn2bin(pkey->pkey._type->_name, (unsigned char*)str);	\
+			str[len] = 0;                                           	\
+			add_assoc_stringl(_type, #_name, str, len, 0);				\
+		}																\
+	} while (0)
+
+#define OPENSSL_PKEY_SET_BN(_ht, _type, _name) do {						\
+		zval **bn;														\
+		if (zend_hash_find(_ht, #_name, sizeof(#_name),	(void**)&bn) == SUCCESS && \
+				Z_TYPE_PP(bn) == IS_STRING) {							\
+			_type->_name = BN_bin2bn(									\
+				(unsigned char*)Z_STRVAL_PP(bn),						\
+	 			Z_STRLEN_PP(bn), NULL);									\
+	    }                                                               \
+	} while (0);
+
+/* {{{ php_openssl_pkey_init_dsa */
+zend_bool php_openssl_pkey_init_dsa(DSA *dsa)
+{
+	if (!dsa->p || !dsa->q || !dsa->g) {
+		return 0;
+	}
+	if (dsa->priv_key || dsa->pub_key) {
+		return 1;
+	}
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (!DSA_generate_key(dsa)) {
+		return 0;
+	}
+	/* if BN_mod_exp return -1, then DSA_generate_key succeed for failed key
+	 * so we need to double check that public key is created */
+	if (!dsa->pub_key || BN_is_zero(dsa->pub_key)) {
+		return 0;
+	}
+	/* all good */
+	return 1;
+}
+/* }}} */
+
+/* {{{ php_openssl_pkey_init_dh */
+zend_bool php_openssl_pkey_init_dh(DH *dh)
+{
+	if (!dh->p || !dh->g) {
+		return 0;
+	}
+	if (dh->pub_key) {
+		return 1;
+	}
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (!DH_generate_key(dh)) {
+		return 0;
+	}
+	/* all good */
+	return 1;
+}
+/* }}} */
+
+/* {{{ proto resource openssl_pkey_new([array configargs])
+   Generates a new private key */
+PHP_FUNCTION(openssl_pkey_new)
+{
+	struct php_x509_request req;
+	zval * args = NULL;
+	zval **data;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|a!", &args) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	if (args && Z_TYPE_P(args) == IS_ARRAY) {
+		EVP_PKEY *pkey;
+
+		if (zend_hash_find(Z_ARRVAL_P(args), "rsa", sizeof("rsa"), (void**)&data) == SUCCESS &&
+		    Z_TYPE_PP(data) == IS_ARRAY) {
+		    pkey = EVP_PKEY_new();
+		    if (pkey) {
+				RSA *rsa = RSA_new();
+				if (rsa) {
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, n);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, e);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, d);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, p);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, q);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, dmp1);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, dmq1);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), rsa, iqmp);
+					if (rsa->n && rsa->d) {
+						if (EVP_PKEY_assign_RSA(pkey, rsa)) {
+							RETURN_RESOURCE(zend_list_insert(pkey, le_key TSRMLS_CC));
+						}
+					}
+					RSA_free(rsa);
+				}
+				EVP_PKEY_free(pkey);
+			}
+			RETURN_FALSE;
+		} else if (zend_hash_find(Z_ARRVAL_P(args), "dsa", sizeof("dsa"), (void**)&data) == SUCCESS &&
+		           Z_TYPE_PP(data) == IS_ARRAY) {
+		    pkey = EVP_PKEY_new();
+		    if (pkey) {
+				DSA *dsa = DSA_new();
+				if (dsa) {
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dsa, p);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dsa, q);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dsa, g);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dsa, priv_key);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dsa, pub_key);
+					if (php_openssl_pkey_init_dsa(dsa)) {
+						if (EVP_PKEY_assign_DSA(pkey, dsa)) {
+							RETURN_RESOURCE(zend_list_insert(pkey, le_key TSRMLS_CC));
+						}
+					}
+					DSA_free(dsa);
+				}
+				EVP_PKEY_free(pkey);
+			}
+			RETURN_FALSE;
+		} else if (zend_hash_find(Z_ARRVAL_P(args), "dh", sizeof("dh"), (void**)&data) == SUCCESS &&
+		           Z_TYPE_PP(data) == IS_ARRAY) {
+		    pkey = EVP_PKEY_new();
+		    if (pkey) {
+				DH *dh = DH_new();
+				if (dh) {
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dh, p);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dh, g);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dh, priv_key);
+					OPENSSL_PKEY_SET_BN(Z_ARRVAL_PP(data), dh, pub_key);
+					if (php_openssl_pkey_init_dh(dh)) {
+						if (EVP_PKEY_assign_DH(pkey, dh)) {
+							RETURN_RESOURCE(zend_list_insert(pkey, le_key TSRMLS_CC));
+						}
+					}
+					DH_free(dh);
+				}
+				EVP_PKEY_free(pkey);
+			}
+			RETURN_FALSE;
+		}
+	} 
+
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS)
+	{
+		if (php_openssl_generate_private_key(&req TSRMLS_CC)) {
+			/* pass back a key resource */
+			RETVAL_RESOURCE(zend_list_insert(req.priv_key, le_key TSRMLS_CC));
+			/* make sure the cleanup code doesn't zap it! */
+			req.priv_key = NULL;
+		}
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkey_export_to_file(mixed key, string outfilename [, string passphrase, array config_args)
+   Gets an exportable representation of a key into a file */
+PHP_FUNCTION(openssl_pkey_export_to_file)
+{
+	struct php_x509_request req;
+	zval ** zpkey, * args = NULL;
+	char * passphrase = NULL; 
+	int passphrase_len = 0;
+	char * filename = NULL; 
+	int filename_len = 0;
+	long key_resource = -1;
+	int pem_write = 0;
+	EVP_PKEY * key;
+	BIO * bio_out = NULL;
+	const EVP_CIPHER * cipher;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zp|s!a!", &zpkey, &filename, &filename_len, &passphrase, &passphrase_len, &args) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	key = php_openssl_evp_from_zval(zpkey, 0, passphrase, 0, &key_resource TSRMLS_CC);
+
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get key from parameter 1");
+		RETURN_FALSE;
+	}
+	
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		RETURN_FALSE;
+	}
+	
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS) {
+		bio_out = BIO_new_file(filename, "w");
+
+		if (passphrase && req.priv_key_encrypt) {
+			if (req.priv_key_encrypt_cipher) {
+				cipher = req.priv_key_encrypt_cipher;
+			} else {
+				cipher = (EVP_CIPHER *) EVP_des_ede3_cbc();
+			}
+		} else {
+			cipher = NULL;
+		}
+
+		switch (EVP_PKEY_type(key->type)) {
+#ifdef HAVE_EVP_PKEY_EC
+			case EVP_PKEY_EC:
+				pem_write = PEM_write_bio_ECPrivateKey(bio_out, EVP_PKEY_get1_EC_KEY(key), cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+#endif
+			default:
+				pem_write = PEM_write_bio_PrivateKey(bio_out, key, cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+		}
+
+		if (pem_write) {
+			/* Success!
+			 * If returning the output as a string, do so now */
+			RETVAL_TRUE;
+		}
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+
+	if (key_resource == -1 && key) {
+		EVP_PKEY_free(key);
+	}
+	if (bio_out) {
+		BIO_free(bio_out);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkey_export(mixed key, &mixed out [, string passphrase [, array config_args]])
+   Gets an exportable representation of a key into a string or file */
+PHP_FUNCTION(openssl_pkey_export)
+{
+	struct php_x509_request req;
+	zval ** zpkey, * args = NULL, *out;
+	char * passphrase = NULL; 
+	int passphrase_len = 0;
+	long key_resource = -1;
+	int pem_write = 0;
+	EVP_PKEY * key;
+	BIO * bio_out = NULL;
+	const EVP_CIPHER * cipher;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Zz|s!a!", &zpkey, &out, &passphrase, &passphrase_len, &args) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	key = php_openssl_evp_from_zval(zpkey, 0, passphrase, 0, &key_resource TSRMLS_CC);
+
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "cannot get key from parameter 1");
+		RETURN_FALSE;
+	}
+	
+	PHP_SSL_REQ_INIT(&req);
+
+	if (PHP_SSL_REQ_PARSE(&req, args) == SUCCESS) {
+		bio_out = BIO_new(BIO_s_mem());
+
+		if (passphrase && req.priv_key_encrypt) {
+			if (req.priv_key_encrypt_cipher) {
+				cipher = req.priv_key_encrypt_cipher;
+			} else {
+				cipher = (EVP_CIPHER *) EVP_des_ede3_cbc();
+			}
+		} else {
+			cipher = NULL;
+		}
+
+		switch (EVP_PKEY_type(key->type)) {
+#ifdef HAVE_EVP_PKEY_EC
+			case EVP_PKEY_EC:
+				pem_write = PEM_write_bio_ECPrivateKey(bio_out, EVP_PKEY_get1_EC_KEY(key), cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+#endif
+			default:
+				pem_write = PEM_write_bio_PrivateKey(bio_out, key, cipher, (unsigned char *)passphrase, passphrase_len, NULL, NULL);
+				break;
+		}
+
+		if (pem_write) {
+			/* Success!
+			 * If returning the output as a string, do so now */
+
+			char * bio_mem_ptr;
+			long bio_mem_len;
+			RETVAL_TRUE;
+
+			bio_mem_len = BIO_get_mem_data(bio_out, &bio_mem_ptr);
+			zval_dtor(out);
+			ZVAL_STRINGL(out, bio_mem_ptr, bio_mem_len, 1);
+		}
+	}
+	PHP_SSL_REQ_DISPOSE(&req);
+
+	if (key_resource == -1 && key) {
+		EVP_PKEY_free(key);
+	}
+	if (bio_out) {
+		BIO_free(bio_out);
+	}
+}
+/* }}} */
+
+/* {{{ proto int openssl_pkey_get_public(mixed cert)
+   Gets public key from X.509 certificate */
+PHP_FUNCTION(openssl_pkey_get_public)
+{
+	zval **cert;
+	EVP_PKEY *pkey;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z", &cert) == FAILURE) {
+		return;
+	}
+	Z_TYPE_P(return_value) = IS_RESOURCE;
+	pkey = php_openssl_evp_from_zval(cert, 1, NULL, 1, &Z_LVAL_P(return_value) TSRMLS_CC);
+
+	if (pkey == NULL) {
+		RETURN_FALSE;
+	}
+	zend_list_addref(Z_LVAL_P(return_value));
+}
+/* }}} */
+
+/* {{{ proto void openssl_pkey_free(int key)
+   Frees a key */
+PHP_FUNCTION(openssl_pkey_free)
+{
+	zval *key;
+	EVP_PKEY *pkey;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &key) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(pkey, EVP_PKEY *, &key, -1, "OpenSSL key", le_key);
+	zend_list_delete(Z_LVAL_P(key));
+}
+/* }}} */
+
+/* {{{ proto int openssl_pkey_get_private(string key [, string passphrase])
+   Gets private keys */
+PHP_FUNCTION(openssl_pkey_get_private)
+{
+	zval **cert;
+	EVP_PKEY *pkey;
+	char * passphrase = "";
+	int passphrase_len = sizeof("")-1;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Z|s", &cert, &passphrase, &passphrase_len) == FAILURE) {
+		return;
+	}
+	Z_TYPE_P(return_value) = IS_RESOURCE;
+	pkey = php_openssl_evp_from_zval(cert, 0, passphrase, 1, &Z_LVAL_P(return_value) TSRMLS_CC);
+
+	if (pkey == NULL) {
+		RETURN_FALSE;
+	}
+	zend_list_addref(Z_LVAL_P(return_value));
+}
+
+/* }}} */
+
+/* {{{ proto resource openssl_pkey_get_details(resource key)
+	returns an array with the key details (bits, pkey, type)*/
+PHP_FUNCTION(openssl_pkey_get_details)
+{
+	zval *key;
+	EVP_PKEY *pkey;
+	BIO *out;
+	unsigned int pbio_len;
+	char *pbio;
+	long ktype;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &key) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(pkey, EVP_PKEY *, &key, -1, "OpenSSL key", le_key);
+	if (!pkey) {
+		RETURN_FALSE;
+	}
+	out = BIO_new(BIO_s_mem());
+	PEM_write_bio_PUBKEY(out, pkey);
+	pbio_len = BIO_get_mem_data(out, &pbio);
+
+	array_init(return_value);
+	add_assoc_long(return_value, "bits", EVP_PKEY_bits(pkey));
+	add_assoc_stringl(return_value, "key", pbio, pbio_len, 1);
+	/*TODO: Use the real values once the openssl constants are used 
+	 * See the enum at the top of this file
+	 */
+	switch (EVP_PKEY_type(pkey->type)) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			ktype = OPENSSL_KEYTYPE_RSA;
+
+			if (pkey->pkey.rsa != NULL) {
+				zval *rsa;
+
+				ALLOC_INIT_ZVAL(rsa);
+				array_init(rsa);
+				OPENSSL_PKEY_GET_BN(rsa, n);
+				OPENSSL_PKEY_GET_BN(rsa, e);
+				OPENSSL_PKEY_GET_BN(rsa, d);
+				OPENSSL_PKEY_GET_BN(rsa, p);
+				OPENSSL_PKEY_GET_BN(rsa, q);
+				OPENSSL_PKEY_GET_BN(rsa, dmp1);
+				OPENSSL_PKEY_GET_BN(rsa, dmq1);
+				OPENSSL_PKEY_GET_BN(rsa, iqmp);
+				add_assoc_zval(return_value, "rsa", rsa);
+			}
+
+			break;	
+		case EVP_PKEY_DSA:
+		case EVP_PKEY_DSA2:
+		case EVP_PKEY_DSA3:
+		case EVP_PKEY_DSA4:
+			ktype = OPENSSL_KEYTYPE_DSA;
+
+			if (pkey->pkey.dsa != NULL) {
+				zval *dsa;
+
+				ALLOC_INIT_ZVAL(dsa);
+				array_init(dsa);
+				OPENSSL_PKEY_GET_BN(dsa, p);
+				OPENSSL_PKEY_GET_BN(dsa, q);
+				OPENSSL_PKEY_GET_BN(dsa, g);
+				OPENSSL_PKEY_GET_BN(dsa, priv_key);
+				OPENSSL_PKEY_GET_BN(dsa, pub_key);
+				add_assoc_zval(return_value, "dsa", dsa);
+			}
+			break;
+		case EVP_PKEY_DH:
+			
+			ktype = OPENSSL_KEYTYPE_DH;
+
+			if (pkey->pkey.dh != NULL) {
+				zval *dh;
+
+				ALLOC_INIT_ZVAL(dh);
+				array_init(dh);
+				OPENSSL_PKEY_GET_BN(dh, p);
+				OPENSSL_PKEY_GET_BN(dh, g);
+				OPENSSL_PKEY_GET_BN(dh, priv_key);
+				OPENSSL_PKEY_GET_BN(dh, pub_key);
+				add_assoc_zval(return_value, "dh", dh);
+			}
+
+			break;
+#ifdef HAVE_EVP_PKEY_EC
+		case EVP_PKEY_EC:
+			ktype = OPENSSL_KEYTYPE_EC;
+			if (pkey->pkey.ec != NULL) {
+				zval *ec;
+				const EC_GROUP *ec_group;
+				int nid;
+				char *crv_sn;
+				ASN1_OBJECT *obj;
+				// openssl recommends a buffer length of 80
+				char oir_buf[80];
+
+				ec_group = EC_KEY_get0_group(EVP_PKEY_get1_EC_KEY(pkey));
+
+				// Curve nid (numerical identifier) used for ASN1 mapping
+				nid = EC_GROUP_get_curve_name(ec_group);
+				if (nid == NID_undef) {
+					break;
+				}
+				ALLOC_INIT_ZVAL(ec);
+				array_init(ec);
+
+				// Short object name
+				crv_sn = (char*) OBJ_nid2sn(nid);
+				if (crv_sn != NULL) {
+					add_assoc_string(ec, "curve_name", crv_sn, 1);
+				}
+
+				obj = OBJ_nid2obj(nid);
+				if (obj != NULL) {
+					int oir_len = OBJ_obj2txt(oir_buf, sizeof(oir_buf), obj, 1);
+					add_assoc_stringl(ec, "curve_oid", (char*)oir_buf, oir_len, 1);
+					ASN1_OBJECT_free(obj);
+				}
+
+				add_assoc_zval(return_value, "ec", ec);
+			}
+			break;
+#endif
+		default:
+			ktype = -1;
+			break;
+	}
+	add_assoc_long(return_value, "type", ktype);
+
+	BIO_free(out);
+}
+/* }}} */
+
+/* }}} */
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+
+/* {{{ proto string openssl_pbkdf2(string password, string salt, long key_length, long iterations [, string digest_method = "sha1"])
+   Generates a PKCS5 v2 PBKDF2 string, defaults to sha1 */
+PHP_FUNCTION(openssl_pbkdf2)
+{
+	long key_length = 0, iterations = 0;
+	char *password; int password_len;
+	char *salt; int salt_len;
+	char *method; int method_len = 0;
+	unsigned char *out_buffer;
+
+	const EVP_MD *digest;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssll|s",
+				&password, &password_len,
+				&salt, &salt_len,
+				&key_length, &iterations,
+				&method, &method_len) == FAILURE) {
+		return;
+	}
+
+	if (key_length <= 0 || key_length > INT_MAX) {
+		RETURN_FALSE;
+	}
+
+	if (method_len) {
+		digest = EVP_get_digestbyname(method);
+	} else {
+		digest = EVP_sha1();
+	}
+
+	if (!digest) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		RETURN_FALSE;
+	}
+
+	out_buffer = emalloc(key_length + 1);
+	out_buffer[key_length] = '\0';
+
+	if (PKCS5_PBKDF2_HMAC(password, password_len, (unsigned char *)salt, salt_len, iterations, digest, key_length, out_buffer) == 1) {
+		RETVAL_STRINGL((char *)out_buffer, key_length, 0);
+	} else {
+		efree(out_buffer);
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+#endif
+
+/* {{{ PKCS7 S/MIME functions */
+
+/* {{{ proto bool openssl_pkcs7_verify(string filename, long flags [, string signerscerts [, array cainfo [, string extracerts [, string content]]]])
+   Verifys that the data block is intact, the signer is who they say they are, and returns the CERTs of the signers */
+PHP_FUNCTION(openssl_pkcs7_verify)
+{
+	X509_STORE * store = NULL;
+	zval * cainfo = NULL;
+	STACK_OF(X509) *signers= NULL;
+	STACK_OF(X509) *others = NULL;
+	PKCS7 * p7 = NULL;
+	BIO * in = NULL, * datain = NULL, * dataout = NULL;
+	long flags = 0;
+	char * filename; int filename_len;
+	char * extracerts = NULL; int extracerts_len = 0;
+	char * signersfilename = NULL; int signersfilename_len = 0;
+	char * datafilename = NULL; int datafilename_len = 0;
+	
+	RETVAL_LONG(-1);
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "pl|papp", &filename, &filename_len,
+				&flags, &signersfilename, &signersfilename_len, &cainfo,
+				&extracerts, &extracerts_len, &datafilename, &datafilename_len) == FAILURE) {
+		return;
+	}
+	
+	if (extracerts) {
+		others = load_all_certs_from_file(extracerts);
+		if (others == NULL) {
+			goto clean_exit;
+		}
+	}
+
+	flags = flags & ~PKCS7_DETACHED;
+
+	store = setup_verify(cainfo TSRMLS_CC);
+
+	if (!store) {
+		goto clean_exit;
+	}
+	if (php_openssl_open_base_dir_chk(filename TSRMLS_CC)) {
+		goto clean_exit;
+	}
+
+	in = BIO_new_file(filename, (flags & PKCS7_BINARY) ? "rb" : "r");
+	if (in == NULL) {
+		goto clean_exit;
+	}
+	p7 = SMIME_read_PKCS7(in, &datain);
+	if (p7 == NULL) {
+#if DEBUG_SMIME
+		zend_printf("SMIME_read_PKCS7 failed\n");
+#endif
+		goto clean_exit;
+	}
+
+	if (datafilename) {
+
+		if (php_openssl_open_base_dir_chk(datafilename TSRMLS_CC)) {
+			goto clean_exit;
+		}
+
+		dataout = BIO_new_file(datafilename, "w");
+		if (dataout == NULL) {
+			goto clean_exit;
+		}
+	}
+#if DEBUG_SMIME
+	zend_printf("Calling PKCS7 verify\n");
+#endif
+
+	if (PKCS7_verify(p7, others, store, datain, dataout, flags)) {
+
+		RETVAL_TRUE;
+
+		if (signersfilename) {
+			BIO *certout;
+		
+			if (php_openssl_open_base_dir_chk(signersfilename TSRMLS_CC)) {
+				goto clean_exit;
+			}
+		
+			certout = BIO_new_file(signersfilename, "w");
+			if (certout) {
+				int i;
+				signers = PKCS7_get0_signers(p7, NULL, flags);
+
+				for(i = 0; i < sk_X509_num(signers); i++) {
+					PEM_write_bio_X509(certout, sk_X509_value(signers, i));
+				}
+				BIO_free(certout);
+				sk_X509_free(signers);
+			} else {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "signature OK, but cannot open %s for writing", signersfilename);
+				RETVAL_LONG(-1);
+			}
+		}
+		goto clean_exit;
+	} else {
+		RETVAL_FALSE;
+	}
+clean_exit:
+	X509_STORE_free(store);
+	BIO_free(datain);
+	BIO_free(in);
+	BIO_free(dataout);
+	PKCS7_free(p7);
+	sk_X509_free(others);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs7_encrypt(string infile, string outfile, mixed recipcerts, array headers [, long flags [, long cipher]])
+   Encrypts the message in the file named infile with the certificates in recipcerts and output the result to the file named outfile */
+PHP_FUNCTION(openssl_pkcs7_encrypt)
+{
+	zval ** zrecipcerts, * zheaders = NULL;
+	STACK_OF(X509) * recipcerts = NULL;
+	BIO * infile = NULL, * outfile = NULL;
+	long flags = 0;
+	PKCS7 * p7 = NULL;
+	HashPosition hpos;
+	zval ** zcertval;
+	X509 * cert;
+	const EVP_CIPHER *cipher = NULL;
+	long cipherid = PHP_OPENSSL_CIPHER_DEFAULT;
+	uint strindexlen;
+	ulong intindex;
+	char * strindex;
+	char * infilename = NULL;	int infilename_len;
+	char * outfilename = NULL;	int outfilename_len;
+	
+	RETVAL_FALSE;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ppZa!|ll", &infilename, &infilename_len,
+				&outfilename, &outfilename_len, &zrecipcerts, &zheaders, &flags, &cipherid) == FAILURE)
+		return;
+
+	
+	if (php_openssl_open_base_dir_chk(infilename TSRMLS_CC) || php_openssl_open_base_dir_chk(outfilename TSRMLS_CC)) {
+		return;
+	}
+
+	infile = BIO_new_file(infilename, "r");
+	if (infile == NULL) {
+		goto clean_exit;
+	}
+
+	outfile = BIO_new_file(outfilename, "w");
+	if (outfile == NULL) { 
+		goto clean_exit;
+	}
+
+	recipcerts = sk_X509_new_null();
+
+	/* get certs */
+	if (Z_TYPE_PP(zrecipcerts) == IS_ARRAY) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(*zrecipcerts), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(*zrecipcerts), (void**)&zcertval, &hpos) == SUCCESS) {
+			long certresource;
+
+			cert = php_openssl_x509_from_zval(zcertval, 0, &certresource TSRMLS_CC);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+
+			if (certresource != -1) {
+				/* we shouldn't free this particular cert, as it is a resource.
+					make a copy and push that on the stack instead */
+				cert = X509_dup(cert);
+				if (cert == NULL) {
+					goto clean_exit;
+				}
+			}
+			sk_X509_push(recipcerts, cert);
+
+			zend_hash_move_forward_ex(HASH_OF(*zrecipcerts), &hpos);
+		}
+	} else {
+		/* a single certificate */
+		long certresource;
+
+		cert = php_openssl_x509_from_zval(zrecipcerts, 0, &certresource TSRMLS_CC);
+		if (cert == NULL) {
+			goto clean_exit;
+		}
+
+		if (certresource != -1) {
+			/* we shouldn't free this particular cert, as it is a resource.
+				make a copy and push that on the stack instead */
+			cert = X509_dup(cert);
+			if (cert == NULL) {
+				goto clean_exit;
+			}
+		}
+		sk_X509_push(recipcerts, cert);
+	}
+
+	/* sanity check the cipher */
+	cipher = php_openssl_get_evp_cipher_from_algo(cipherid);
+	if (cipher == NULL) {
+		/* shouldn't happen */
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to get cipher");
+		goto clean_exit;
+	}
+
+	p7 = PKCS7_encrypt(recipcerts, infile, (EVP_CIPHER*)cipher, flags);
+
+	if (p7 == NULL) {
+		goto clean_exit;
+	}
+
+	/* tack on extra headers */
+	if (zheaders) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(zheaders), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(zheaders), (void**)&zcertval, &hpos) == SUCCESS) {
+			strindex = NULL;
+			zend_hash_get_current_key_ex(HASH_OF(zheaders), &strindex, &strindexlen, &intindex, 0, &hpos);
+
+			convert_to_string_ex(zcertval);
+
+			if (strindex) {
+				BIO_printf(outfile, "%s: %s\n", strindex, Z_STRVAL_PP(zcertval));
+			} else {
+				BIO_printf(outfile, "%s\n", Z_STRVAL_PP(zcertval));
+			}
+
+			zend_hash_move_forward_ex(HASH_OF(zheaders), &hpos);
+		}
+	}
+
+	(void)BIO_reset(infile);
+
+	/* write the encrypted data */
+	SMIME_write_PKCS7(outfile, p7, infile, flags);
+
+	RETVAL_TRUE;
+
+clean_exit:
+	PKCS7_free(p7);
+	BIO_free(infile);
+	BIO_free(outfile);
+	if (recipcerts) {
+		sk_X509_pop_free(recipcerts, X509_free);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs7_sign(string infile, string outfile, mixed signcert, mixed signkey, array headers [, long flags [, string extracertsfilename]])
+   Signs the MIME message in the file named infile with signcert/signkey and output the result to file name outfile. headers lists plain text headers to exclude from the signed portion of the message, and should include to, from and subject as a minimum */
+
+PHP_FUNCTION(openssl_pkcs7_sign)
+{
+	zval ** zcert, ** zprivkey, * zheaders;
+	zval ** hval;
+	X509 * cert = NULL;
+	EVP_PKEY * privkey = NULL;
+	long flags = PKCS7_DETACHED;
+	PKCS7 * p7 = NULL;
+	BIO * infile = NULL, * outfile = NULL;
+	STACK_OF(X509) *others = NULL;
+	long certresource = -1, keyresource = -1;
+	ulong intindex;
+	uint strindexlen;
+	HashPosition hpos;
+	char * strindex;
+	char * infilename;	int infilename_len;
+	char * outfilename;	int outfilename_len;
+	char * extracertsfilename = NULL; int extracertsfilename_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ppZZa!|lp!",
+				&infilename, &infilename_len, &outfilename, &outfilename_len,
+				&zcert, &zprivkey, &zheaders, &flags, &extracertsfilename,
+				&extracertsfilename_len) == FAILURE) {
+		return;
+	}
+	
+	RETVAL_FALSE;
+
+	if (extracertsfilename) {
+		others = load_all_certs_from_file(extracertsfilename);
+		if (others == NULL) { 
+			goto clean_exit;
+		}
+	}
+
+	privkey = php_openssl_evp_from_zval(zprivkey, 0, "", 0, &keyresource TSRMLS_CC);
+	if (privkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error getting private key");
+		goto clean_exit;
+	}
+
+	cert = php_openssl_x509_from_zval(zcert, 0, &certresource TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error getting cert");
+		goto clean_exit;
+	}
+
+	if (php_openssl_open_base_dir_chk(infilename TSRMLS_CC) || php_openssl_open_base_dir_chk(outfilename TSRMLS_CC)) {
+		goto clean_exit;
+	}
+
+	infile = BIO_new_file(infilename, "r");
+	if (infile == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening input file %s!", infilename);
+		goto clean_exit;
+	}
+
+	outfile = BIO_new_file(outfilename, "w");
+	if (outfile == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error opening output file %s!", outfilename);
+		goto clean_exit;
+	}
+
+	p7 = PKCS7_sign(cert, privkey, others, infile, flags);
+	if (p7 == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error creating PKCS7 structure!");
+		goto clean_exit;
+	}
+
+	(void)BIO_reset(infile);
+
+	/* tack on extra headers */
+	if (zheaders) {
+		zend_hash_internal_pointer_reset_ex(HASH_OF(zheaders), &hpos);
+		while(zend_hash_get_current_data_ex(HASH_OF(zheaders), (void**)&hval, &hpos) == SUCCESS) {
+			strindex = NULL;
+			zend_hash_get_current_key_ex(HASH_OF(zheaders), &strindex, &strindexlen, &intindex, 0, &hpos);
+
+			convert_to_string_ex(hval);
+
+			if (strindex) {
+				BIO_printf(outfile, "%s: %s\n", strindex, Z_STRVAL_PP(hval));
+			} else {
+				BIO_printf(outfile, "%s\n", Z_STRVAL_PP(hval));
+			}
+			zend_hash_move_forward_ex(HASH_OF(zheaders), &hpos);
+		}
+	}
+	/* write the signed data */
+	SMIME_write_PKCS7(outfile, p7, infile, flags);
+
+	RETVAL_TRUE;
+
+clean_exit:
+	PKCS7_free(p7);
+	BIO_free(infile);
+	BIO_free(outfile);
+	if (others) {
+		sk_X509_pop_free(others, X509_free);
+	}
+	if (privkey && keyresource == -1) {
+		EVP_PKEY_free(privkey);
+	}
+	if (cert && certresource == -1) {
+		X509_free(cert);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_pkcs7_decrypt(string infilename, string outfilename, mixed recipcert [, mixed recipkey])
+   Decrypts the S/MIME message in the file name infilename and output the results to the file name outfilename.  recipcert is a CERT for one of the recipients. recipkey specifies the private key matching recipcert, if recipcert does not include the key */
+
+PHP_FUNCTION(openssl_pkcs7_decrypt)
+{
+	zval ** recipcert, ** recipkey = NULL;
+	X509 * cert = NULL;
+	EVP_PKEY * key = NULL;
+	long certresval, keyresval;
+	BIO * in = NULL, * out = NULL, * datain = NULL;
+	PKCS7 * p7 = NULL;
+	char * infilename;	int infilename_len;
+	char * outfilename;	int outfilename_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ppZ|Z", &infilename, &infilename_len,
+				&outfilename, &outfilename_len, &recipcert, &recipkey) == FAILURE) {
+		return;
+	}
+
+	RETVAL_FALSE;
+
+	cert = php_openssl_x509_from_zval(recipcert, 0, &certresval TSRMLS_CC);
+	if (cert == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to coerce parameter 3 to x509 cert");
+		goto clean_exit;
+	}
+
+	key = php_openssl_evp_from_zval(recipkey ? recipkey : recipcert, 0, "", 0, &keyresval TSRMLS_CC);
+	if (key == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to get private key");
+		goto clean_exit;
+	}
+	
+	if (php_openssl_open_base_dir_chk(infilename TSRMLS_CC) || php_openssl_open_base_dir_chk(outfilename TSRMLS_CC)) {
+		goto clean_exit;
+	}
+
+	in = BIO_new_file(infilename, "r");
+	if (in == NULL) {
+		goto clean_exit;
+	}
+	out = BIO_new_file(outfilename, "w");
+	if (out == NULL) {
+		goto clean_exit;
+	}
+
+	p7 = SMIME_read_PKCS7(in, &datain);
+
+	if (p7 == NULL) {
+		goto clean_exit;
+	}
+	if (PKCS7_decrypt(p7, key, cert, out, PKCS7_DETACHED)) { 
+		RETVAL_TRUE;
+	}
+clean_exit:
+	PKCS7_free(p7);
+	BIO_free(datain);
+	BIO_free(in);
+	BIO_free(out);
+	if (cert && certresval == -1) {
+		X509_free(cert);
+	}
+	if (key && keyresval == -1) {
+		EVP_PKEY_free(key);
+	}
+}
+/* }}} */
+
+/* }}} */
+
+/* {{{ proto bool openssl_private_encrypt(string data, string &crypted, mixed key [, int padding])
+   Encrypts data with private key */
+PHP_FUNCTION(openssl_private_encrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf = NULL;
+	int successful = 0;
+	long keyresource = -1;
+	char * data;
+	int data_len;
+	long padding = RSA_PKCS1_PADDING;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE) { 
+		return;
+	}
+	RETVAL_FALSE;
+
+	pkey = php_openssl_evp_from_zval(key, 0, "", 0, &keyresource TSRMLS_CC);
+
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key param is not a valid private key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	cryptedbuf = emalloc(cryptedlen + 1);
+
+	switch (pkey->type) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			successful =  (RSA_private_encrypt(data_len, 
+						(unsigned char *)data, 
+						cryptedbuf, 
+						pkey->pkey.rsa, 
+						padding) == cryptedlen);
+			break;
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+	}
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+	if (cryptedbuf) {
+		efree(cryptedbuf);
+	}
+	if (keyresource == -1) { 
+		EVP_PKEY_free(pkey);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_private_decrypt(string data, string &decrypted, mixed key [, int padding])
+   Decrypts data with private key */
+PHP_FUNCTION(openssl_private_decrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf = NULL;
+	unsigned char *crypttemp;
+	int successful = 0;
+	long padding = RSA_PKCS1_PADDING;
+	long keyresource = -1;
+	char * data;
+	int data_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+
+	pkey = php_openssl_evp_from_zval(key, 0, "", 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key parameter is not a valid private key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	crypttemp = emalloc(cryptedlen + 1);
+
+	switch (pkey->type) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			cryptedlen = RSA_private_decrypt(data_len, 
+					(unsigned char *)data, 
+					crypttemp, 
+					pkey->pkey.rsa, 
+					padding);
+			if (cryptedlen != -1) {
+				cryptedbuf = emalloc(cryptedlen + 1);
+				memcpy(cryptedbuf, crypttemp, cryptedlen);
+				successful = 1;
+			}
+			break;
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+	}
+
+	efree(crypttemp);
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	if (cryptedbuf) { 
+		efree(cryptedbuf);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_public_encrypt(string data, string &crypted, mixed key [, int padding])
+   Encrypts data with public key */
+PHP_FUNCTION(openssl_public_encrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf;
+	int successful = 0;
+	long keyresource = -1;
+	long padding = RSA_PKCS1_PADDING;
+	char * data;
+	int data_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE)
+		return;
+
+	RETVAL_FALSE;
+	
+	pkey = php_openssl_evp_from_zval(key, 1, NULL, 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key parameter is not a valid public key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	cryptedbuf = emalloc(cryptedlen + 1);
+
+	switch (pkey->type) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			successful = (RSA_public_encrypt(data_len, 
+						(unsigned char *)data, 
+						cryptedbuf, 
+						pkey->pkey.rsa, 
+						padding) == cryptedlen);
+			break;
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+
+	}
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	if (cryptedbuf) {
+		efree(cryptedbuf);
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_public_decrypt(string data, string &crypted, resource key [, int padding])
+   Decrypts data with public key */
+PHP_FUNCTION(openssl_public_decrypt)
+{
+	zval **key, *crypted;
+	EVP_PKEY *pkey;
+	int cryptedlen;
+	unsigned char *cryptedbuf = NULL;
+	unsigned char *crypttemp;
+	int successful = 0;
+	long keyresource = -1;
+	long padding = RSA_PKCS1_PADDING;
+	char * data;
+	int data_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|l", &data, &data_len, &crypted, &key, &padding) == FAILURE) {
+		return;
+	}
+	RETVAL_FALSE;
+	
+	pkey = php_openssl_evp_from_zval(key, 1, NULL, 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "key parameter is not a valid public key");
+		RETURN_FALSE;
+	}
+
+	cryptedlen = EVP_PKEY_size(pkey);
+	crypttemp = emalloc(cryptedlen + 1);
+
+	switch (pkey->type) {
+		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA2:
+			cryptedlen = RSA_public_decrypt(data_len, 
+					(unsigned char *)data, 
+					crypttemp, 
+					pkey->pkey.rsa, 
+					padding);
+			if (cryptedlen != -1) {
+				cryptedbuf = emalloc(cryptedlen + 1);
+				memcpy(cryptedbuf, crypttemp, cryptedlen);
+				successful = 1;
+			}
+			break;
+			
+		default:
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "key type not supported in this PHP build!");
+		 
+	}
+
+	efree(crypttemp);
+
+	if (successful) {
+		zval_dtor(crypted);
+		cryptedbuf[cryptedlen] = '\0';
+		ZVAL_STRINGL(crypted, (char *)cryptedbuf, cryptedlen, 0);
+		cryptedbuf = NULL;
+		RETVAL_TRUE;
+	}
+
+	if (cryptedbuf) {
+		efree(cryptedbuf);
+	}
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+}
+/* }}} */
+
+/* {{{ proto mixed openssl_error_string(void)
+   Returns a description of the last error, and alters the index of the error messages. Returns false when the are no more messages */
+PHP_FUNCTION(openssl_error_string)
+{
+	char buf[512];
+	unsigned long val;
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	val = ERR_get_error();
+	if (val) {
+		RETURN_STRING(ERR_error_string(val, buf), 1);
+	} else {
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+/* {{{ proto bool openssl_sign(string data, &string signature, mixed key[, mixed method])
+   Signs data */
+PHP_FUNCTION(openssl_sign)
+{
+	zval **key, *signature;
+	EVP_PKEY *pkey;
+	int siglen;
+	unsigned char *sigbuf;
+	long keyresource = -1;
+	char * data;
+	int data_len;
+	EVP_MD_CTX md_ctx;
+	zval *method = NULL;
+	long signature_algo = OPENSSL_ALGO_SHA1;
+	const EVP_MD *mdtype;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szZ|z", &data, &data_len, &signature, &key, &method) == FAILURE) {
+		return;
+	}
+	pkey = php_openssl_evp_from_zval(key, 0, "", 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied key param cannot be coerced into a private key");
+		RETURN_FALSE;
+	}
+
+	if (method == NULL || Z_TYPE_P(method) == IS_LONG) {
+		if (method != NULL) {
+			signature_algo = Z_LVAL_P(method);
+		}
+		mdtype = php_openssl_get_evp_md_from_algo(signature_algo);
+	} else if (Z_TYPE_P(method) == IS_STRING) {
+		mdtype = EVP_get_digestbyname(Z_STRVAL_P(method));
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+
+	siglen = EVP_PKEY_size(pkey);
+	sigbuf = emalloc(siglen + 1);
+
+	EVP_SignInit(&md_ctx, mdtype);
+	EVP_SignUpdate(&md_ctx, data, data_len);
+	if (EVP_SignFinal (&md_ctx, sigbuf,(unsigned int *)&siglen, pkey)) {
+		zval_dtor(signature);
+		sigbuf[siglen] = '\0';
+		ZVAL_STRINGL(signature, (char *)sigbuf, siglen, 0);
+		RETVAL_TRUE;
+	} else {
+		efree(sigbuf);
+		RETVAL_FALSE;
+	}
+	EVP_MD_CTX_cleanup(&md_ctx);
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+}
+/* }}} */
+
+/* {{{ proto int openssl_verify(string data, string signature, mixed key[, mixed method])
+   Verifys data */
+PHP_FUNCTION(openssl_verify)
+{
+	zval **key;
+	EVP_PKEY *pkey;
+	int err;
+	EVP_MD_CTX     md_ctx;
+	const EVP_MD *mdtype;
+	long keyresource = -1;
+	char * data;	int data_len;
+	char * signature;	int signature_len;
+	zval *method = NULL;
+	long signature_algo = OPENSSL_ALGO_SHA1;
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssZ|z", &data, &data_len, &signature, &signature_len, &key, &method) == FAILURE) {
+		return;
+	}
+
+	if (method == NULL || Z_TYPE_P(method) == IS_LONG) {
+		if (method != NULL) {
+			signature_algo = Z_LVAL_P(method);
+		}
+		mdtype = php_openssl_get_evp_md_from_algo(signature_algo);
+	} else if (Z_TYPE_P(method) == IS_STRING) {
+		mdtype = EVP_get_digestbyname(Z_STRVAL_P(method));
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+		RETURN_FALSE;
+	}
+
+	pkey = php_openssl_evp_from_zval(key, 1, NULL, 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied key param cannot be coerced into a public key");
+		RETURN_FALSE;
+	}
+
+	EVP_VerifyInit   (&md_ctx, mdtype);
+	EVP_VerifyUpdate (&md_ctx, data, data_len);
+	err = EVP_VerifyFinal (&md_ctx, (unsigned char *)signature, signature_len, pkey);
+	EVP_MD_CTX_cleanup(&md_ctx);
+
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	RETURN_LONG(err);
+}
+/* }}} */
+
+/* {{{ proto int openssl_seal(string data, &string sealdata, &array ekeys, array pubkeys)
+   Seals data */
+PHP_FUNCTION(openssl_seal)
+{
+	zval *pubkeys, **pubkey, *sealdata, *ekeys;
+	HashTable *pubkeysht;
+	HashPosition pos;
+	EVP_PKEY **pkeys;
+	long * key_resources;	/* so we know what to cleanup */
+	int i, len1, len2, *eksl, nkeys;
+	unsigned char *buf = NULL, **eks;
+	char * data; int data_len;
+	char *method =NULL;
+	int method_len = 0;
+	const EVP_CIPHER *cipher;
+	EVP_CIPHER_CTX ctx;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szza/|s", &data, &data_len, &sealdata, &ekeys, &pubkeys, &method, &method_len) == FAILURE) {
+		return;
+	}
+	
+	pubkeysht = HASH_OF(pubkeys);
+	nkeys = pubkeysht ? zend_hash_num_elements(pubkeysht) : 0;
+	if (!nkeys) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Fourth argument to openssl_seal() must be a non-empty array");
+		RETURN_FALSE;
+	}
+
+	if (method) {
+		cipher = EVP_get_cipherbyname(method);
+		if (!cipher) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+			RETURN_FALSE;
+		}
+		if (EVP_CIPHER_iv_length(cipher) > 0) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Ciphers with modes requiring IV are not supported");
+			RETURN_FALSE;
+		}
+	} else {
+		cipher = EVP_rc4();
+	}
+
+	pkeys = safe_emalloc(nkeys, sizeof(*pkeys), 0);
+	eksl = safe_emalloc(nkeys, sizeof(*eksl), 0);
+	eks = safe_emalloc(nkeys, sizeof(*eks), 0);
+	memset(eks, 0, sizeof(*eks) * nkeys);
+	key_resources = safe_emalloc(nkeys, sizeof(long), 0);
+	memset(key_resources, 0, sizeof(*key_resources) * nkeys);
+
+	/* get the public keys we are using to seal this data */
+	zend_hash_internal_pointer_reset_ex(pubkeysht, &pos);
+	i = 0;
+	while (zend_hash_get_current_data_ex(pubkeysht, (void **) &pubkey,
+				&pos) == SUCCESS) {
+		pkeys[i] = php_openssl_evp_from_zval(pubkey, 1, NULL, 0, &key_resources[i] TSRMLS_CC);
+		if (pkeys[i] == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "not a public key (%dth member of pubkeys)", i+1);
+			RETVAL_FALSE;
+			goto clean_exit;
+		}
+		eks[i] = emalloc(EVP_PKEY_size(pkeys[i]) + 1);
+		zend_hash_move_forward_ex(pubkeysht, &pos);
+		i++;
+	}
+
+	if (!EVP_EncryptInit(&ctx,cipher,NULL,NULL)) {
+		RETVAL_FALSE;
+		EVP_CIPHER_CTX_cleanup(&ctx);
+		goto clean_exit;
+	}
+
+#if 0
+	/* Need this if allow ciphers that require initialization vector */
+	ivlen = EVP_CIPHER_CTX_iv_length(&ctx);
+	iv = ivlen ? emalloc(ivlen + 1) : NULL;
+#endif
+	/* allocate one byte extra to make room for \0 */
+	buf = emalloc(data_len + EVP_CIPHER_CTX_block_size(&ctx));
+	EVP_CIPHER_CTX_cleanup(&ctx);
+
+	if (EVP_SealInit(&ctx, cipher, eks, eksl, NULL, pkeys, nkeys) <= 0 ||
+			!EVP_SealUpdate(&ctx, buf, &len1, (unsigned char *)data, data_len) ||
+			!EVP_SealFinal(&ctx, buf + len1, &len2)) {
+		RETVAL_FALSE;
+		efree(buf);
+		EVP_CIPHER_CTX_cleanup(&ctx);
+		goto clean_exit;
+	}
+
+	if (len1 + len2 > 0) {
+		zval_dtor(sealdata);
+		buf[len1 + len2] = '\0';
+		buf = erealloc(buf, len1 + len2 + 1);
+		ZVAL_STRINGL(sealdata, (char *)buf, len1 + len2, 0);
+
+		zval_dtor(ekeys);
+		array_init(ekeys);
+		for (i=0; i<nkeys; i++) {
+			eks[i][eksl[i]] = '\0';
+			add_next_index_stringl(ekeys, erealloc(eks[i], eksl[i] + 1), eksl[i], 0);
+			eks[i] = NULL;
+		}
+#if 0
+		/* If allow ciphers that need IV, we need this */
+		zval_dtor(*ivec);
+		if (ivlen) {
+			iv[ivlen] = '\0';
+			ZVAL_STRINGL(*ivec, erealloc(iv, ivlen + 1), ivlen, 0);
+		} else {
+			ZVAL_EMPTY_STRING(*ivec);
+		}
+#endif
+	} else {
+		efree(buf);
+	}
+	RETVAL_LONG(len1 + len2);
+	EVP_CIPHER_CTX_cleanup(&ctx);
+
+clean_exit:
+	for (i=0; i<nkeys; i++) {
+		if (key_resources[i] == -1) {
+			EVP_PKEY_free(pkeys[i]);
+		}
+		if (eks[i]) { 
+			efree(eks[i]);
+		}
+	}
+	efree(eks);
+	efree(eksl);
+	efree(pkeys);
+	efree(key_resources);
+}
+/* }}} */
+
+/* {{{ proto bool openssl_open(string data, &string opendata, string ekey, mixed privkey)
+   Opens data */
+PHP_FUNCTION(openssl_open)
+{
+	zval **privkey, *opendata;
+	EVP_PKEY *pkey;
+	int len1, len2;
+	unsigned char *buf;
+	long keyresource = -1;
+	EVP_CIPHER_CTX ctx;
+	char * data;	int data_len;
+	char * ekey;	int ekey_len;
+	char *method =NULL;
+	int method_len = 0;
+	const EVP_CIPHER *cipher;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "szsZ|s", &data, &data_len, &opendata, &ekey, &ekey_len, &privkey, &method, &method_len) == FAILURE) {
+		return;
+	}
+
+	pkey = php_openssl_evp_from_zval(privkey, 0, "", 0, &keyresource TSRMLS_CC);
+	if (pkey == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "unable to coerce parameter 4 into a private key");
+		RETURN_FALSE;
+	}
+
+	if (method) {
+		cipher = EVP_get_cipherbyname(method);
+		if (!cipher) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm.");
+			RETURN_FALSE;
+		}
+	} else {
+		cipher = EVP_rc4();
+	}
+	
+	buf = emalloc(data_len + 1);
+
+	if (EVP_OpenInit(&ctx, cipher, (unsigned char *)ekey, ekey_len, NULL, pkey) && EVP_OpenUpdate(&ctx, buf, &len1, (unsigned char *)data, data_len)) {
+		if (!EVP_OpenFinal(&ctx, buf + len1, &len2) || (len1 + len2 == 0)) {
+			efree(buf);
+			RETVAL_FALSE;
+		} else {
+			zval_dtor(opendata);
+			buf[len1 + len2] = '\0';
+			ZVAL_STRINGL(opendata, erealloc(buf, len1 + len2 + 1), len1 + len2, 0);
+			RETVAL_TRUE;
+		}
+	} else {
+		efree(buf);
+		RETVAL_FALSE;
+	}
+	if (keyresource == -1) {
+		EVP_PKEY_free(pkey);
+	}
+	EVP_CIPHER_CTX_cleanup(&ctx);
+}
+/* }}} */
+
+
+
+static void openssl_add_method_or_alias(const OBJ_NAME *name, void *arg) /* {{{ */
+{
+	add_next_index_string((zval*)arg, (char*)name->name, 1);
+}
+/* }}} */
+
+static void openssl_add_method(const OBJ_NAME *name, void *arg) /* {{{ */
+{
+	if (name->alias == 0) {
+		add_next_index_string((zval*)arg, (char*)name->name, 1);
+	}
+}
+/* }}} */
+
+/* {{{ proto array openssl_get_md_methods([bool aliases = false])
+   Return array of available digest methods */
+PHP_FUNCTION(openssl_get_md_methods)
+{
+	zend_bool aliases = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &aliases) == FAILURE) {
+		return;
+	}
+	array_init(return_value);
+	OBJ_NAME_do_all_sorted(OBJ_NAME_TYPE_MD_METH,
+		aliases ? openssl_add_method_or_alias: openssl_add_method, 
+		return_value);
+}
+/* }}} */
+
+/* {{{ proto array openssl_get_cipher_methods([bool aliases = false])
+   Return array of available cipher methods */
+PHP_FUNCTION(openssl_get_cipher_methods)
+{
+	zend_bool aliases = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &aliases) == FAILURE) {
+		return;
+	}
+	array_init(return_value);
+	OBJ_NAME_do_all_sorted(OBJ_NAME_TYPE_CIPHER_METH,
+		aliases ? openssl_add_method_or_alias: openssl_add_method, 
+		return_value);
+}
+/* }}} */
+
+/* {{{ proto string openssl_digest(string data, string method [, bool raw_output=false])
+   Computes digest hash value for given data using given method, returns raw or binhex encoded string */
+PHP_FUNCTION(openssl_digest)
+{
+	zend_bool raw_output = 0;
+	char *data, *method;
+	int data_len, method_len;
+	const EVP_MD *mdtype;
+	EVP_MD_CTX md_ctx;
+	int siglen;
+	unsigned char *sigbuf;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|b", &data, &data_len, &method, &method_len, &raw_output) == FAILURE) {
+		return;
+	}
+	mdtype = EVP_get_digestbyname(method);
+	if (!mdtype) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown signature algorithm");
+		RETURN_FALSE;
+	}
+
+	siglen = EVP_MD_size(mdtype);
+	sigbuf = emalloc(siglen + 1);
+
+	EVP_DigestInit(&md_ctx, mdtype);
+	EVP_DigestUpdate(&md_ctx, (unsigned char *)data, data_len);
+	if (EVP_DigestFinal (&md_ctx, (unsigned char *)sigbuf, (unsigned int *)&siglen)) {
+		if (raw_output) {
+			sigbuf[siglen] = '\0';
+			RETVAL_STRINGL((char *)sigbuf, siglen, 0);
+		} else {
+			int digest_str_len = siglen * 2;
+			char *digest_str = emalloc(digest_str_len + 1);
+
+			make_digest_ex(digest_str, sigbuf, siglen);
+			efree(sigbuf);
+			RETVAL_STRINGL(digest_str, digest_str_len, 0);
+		}
+	} else {
+		efree(sigbuf);
+		RETVAL_FALSE;
+	}
+}
+/* }}} */
+
+static zend_bool php_openssl_validate_iv(char **piv, int *piv_len, int iv_required_len TSRMLS_DC)
+{
+	char *iv_new;
+
+	/* Best case scenario, user behaved */
+	if (*piv_len == iv_required_len) {
+		return 0;
+	}
+
+	iv_new = ecalloc(1, iv_required_len + 1);
+
+	if (*piv_len <= 0) {
+		/* BC behavior */
+		*piv_len = iv_required_len;
+		*piv     = iv_new;
+		return 1;
+	}
+
+	if (*piv_len < iv_required_len) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "IV passed is only %d bytes long, cipher expects an IV of precisely %d bytes, padding with \\0", *piv_len, iv_required_len);
+		memcpy(iv_new, *piv, *piv_len);
+		*piv_len = iv_required_len;
+		*piv     = iv_new;
+		return 1;
+	}
+
+	php_error_docref(NULL TSRMLS_CC, E_WARNING, "IV passed is %d bytes long which is longer than the %d expected by selected cipher, truncating", *piv_len, iv_required_len);
+	memcpy(iv_new, *piv, iv_required_len);
+	*piv_len = iv_required_len;
+	*piv     = iv_new;
+	return 1;
+
+}
+
+/* {{{ proto string openssl_encrypt(string data, string method, string password [, long options=0 [, string $iv='']])
+   Encrypts given data with given method and key, returns raw or base64 encoded string */
+PHP_FUNCTION(openssl_encrypt)
+{
+	long options = 0;
+	char *data, *method, *password, *iv = "";
+	int data_len, method_len, password_len, iv_len = 0, max_iv_len;
+	const EVP_CIPHER *cipher_type;
+	EVP_CIPHER_CTX cipher_ctx;
+	int i=0, outlen, keylen;
+	unsigned char *outbuf, *key;
+	zend_bool free_iv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss|ls", &data, &data_len, &method, &method_len, &password, &password_len, &options, &iv, &iv_len) == FAILURE) {
+		return;
+	}
+	cipher_type = EVP_get_cipherbyname(method);
+	if (!cipher_type) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	keylen = EVP_CIPHER_key_length(cipher_type);
+	if (keylen > password_len) {
+		key = emalloc(keylen);
+		memset(key, 0, keylen);
+		memcpy(key, password, password_len);
+	} else {
+		key = (unsigned char*)password;
+	}
+
+	max_iv_len = EVP_CIPHER_iv_length(cipher_type);
+	if (iv_len <= 0 && max_iv_len > 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Using an empty Initialization Vector (iv) is potentially insecure and not recommended");
+	}
+	free_iv = php_openssl_validate_iv(&iv, &iv_len, max_iv_len TSRMLS_CC);
+
+	outlen = data_len + EVP_CIPHER_block_size(cipher_type);
+	outbuf = safe_emalloc(outlen, 1, 1);
+
+	EVP_EncryptInit(&cipher_ctx, cipher_type, NULL, NULL);
+	if (password_len > keylen) {
+		EVP_CIPHER_CTX_set_key_length(&cipher_ctx, password_len);
+	}
+	EVP_EncryptInit_ex(&cipher_ctx, NULL, NULL, key, (unsigned char *)iv);
+	if (options & OPENSSL_ZERO_PADDING) {
+		EVP_CIPHER_CTX_set_padding(&cipher_ctx, 0);
+	}
+	if (data_len > 0) {
+		EVP_EncryptUpdate(&cipher_ctx, outbuf, &i, (unsigned char *)data, data_len);
+	}
+	outlen = i;
+	if (EVP_EncryptFinal(&cipher_ctx, (unsigned char *)outbuf + i, &i)) {
+		outlen += i;
+		if (options & OPENSSL_RAW_DATA) {
+			outbuf[outlen] = '\0';
+			RETVAL_STRINGL_CHECK((char *)outbuf, outlen, 0);
+		} else {
+			int base64_str_len;
+			char *base64_str;
+
+			base64_str = (char*)php_base64_encode(outbuf, outlen, &base64_str_len);
+			efree(outbuf);
+			if (!base64_str) {
+				RETVAL_FALSE;
+			} else {
+				RETVAL_STRINGL(base64_str, base64_str_len, 0);
+			}
+		}
+	} else {
+		efree(outbuf);
+		RETVAL_FALSE;
+	}
+	if (key != (unsigned char*)password) {
+		efree(key);
+	}
+	if (free_iv) {
+		efree(iv);
+	}
+	EVP_CIPHER_CTX_cleanup(&cipher_ctx);
+}
+/* }}} */
+
+/* {{{ proto string openssl_decrypt(string data, string method, string password [, long options=0 [, string $iv = '']])
+   Takes raw or base64 encoded string and dectupt it using given method and key */
+PHP_FUNCTION(openssl_decrypt)
+{
+	long options = 0;
+	char *data, *method, *password, *iv = "";
+	int data_len, method_len, password_len, iv_len = 0;
+	const EVP_CIPHER *cipher_type;
+	EVP_CIPHER_CTX cipher_ctx;
+	int i, outlen, keylen;
+	unsigned char *outbuf, *key;
+	int base64_str_len;
+	char *base64_str = NULL;
+	zend_bool free_iv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss|ls", &data, &data_len, &method, &method_len, &password, &password_len, &options, &iv, &iv_len) == FAILURE) {
+		return;
+	}
+
+	if (!method_len) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	cipher_type = EVP_get_cipherbyname(method);
+	if (!cipher_type) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	if (!(options & OPENSSL_RAW_DATA)) {
+		base64_str = (char*)php_base64_decode((unsigned char*)data, data_len, &base64_str_len);
+		if (!base64_str) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to base64 decode the input");
+			RETURN_FALSE;
+		}
+		data_len = base64_str_len;
+		data = base64_str;
+	}
+
+	keylen = EVP_CIPHER_key_length(cipher_type);
+	if (keylen > password_len) {
+		key = emalloc(keylen);
+		memset(key, 0, keylen);
+		memcpy(key, password, password_len);
+	} else {
+		key = (unsigned char*)password;
+	}
+
+	free_iv = php_openssl_validate_iv(&iv, &iv_len, EVP_CIPHER_iv_length(cipher_type) TSRMLS_CC);
+
+	outlen = data_len + EVP_CIPHER_block_size(cipher_type);
+	outbuf = emalloc(outlen + 1);
+
+	EVP_DecryptInit(&cipher_ctx, cipher_type, NULL, NULL);
+	if (password_len > keylen) {
+		EVP_CIPHER_CTX_set_key_length(&cipher_ctx, password_len);
+	}
+	EVP_DecryptInit_ex(&cipher_ctx, NULL, NULL, key, (unsigned char *)iv);
+	if (options & OPENSSL_ZERO_PADDING) {
+		EVP_CIPHER_CTX_set_padding(&cipher_ctx, 0);
+	}
+	EVP_DecryptUpdate(&cipher_ctx, outbuf, &i, (unsigned char *)data, data_len);
+	outlen = i;
+	if (EVP_DecryptFinal(&cipher_ctx, (unsigned char *)outbuf + i, &i)) {
+		outlen += i;
+		outbuf[outlen] = '\0';
+		RETVAL_STRINGL((char *)outbuf, outlen, 0);
+	} else {
+		efree(outbuf);
+		RETVAL_FALSE;
+	}
+	if (key != (unsigned char*)password) {
+		efree(key);
+	}
+	if (free_iv) {
+		efree(iv);
+	}
+	if (base64_str) {
+		efree(base64_str);
+	}
+ 	EVP_CIPHER_CTX_cleanup(&cipher_ctx);
+}
+/* }}} */
+
+/* {{{ proto int openssl_cipher_iv_length(string $method) */
+PHP_FUNCTION(openssl_cipher_iv_length)
+{
+	char *method;
+	int method_len;
+	const EVP_CIPHER *cipher_type;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &method, &method_len) == FAILURE) {
+		return;
+	}
+
+	if (!method_len) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	cipher_type = EVP_get_cipherbyname(method);
+	if (!cipher_type) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown cipher algorithm");
+		RETURN_FALSE;
+	}
+
+	RETURN_LONG(EVP_CIPHER_iv_length(cipher_type));
+}
+/* }}} */
+
+
+/* {{{ proto string openssl_dh_compute_key(string pub_key, resource dh_key)
+   Computes shared secret for public value of remote DH key and local DH key */
+PHP_FUNCTION(openssl_dh_compute_key)
+{
+	zval *key;
+	char *pub_str;
+	int pub_len;
+	EVP_PKEY *pkey;
+	BIGNUM *pub;
+	char *data;
+	int len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sr", &pub_str, &pub_len, &key) == FAILURE) {
+		return;
+	}
+	ZEND_FETCH_RESOURCE(pkey, EVP_PKEY *, &key, -1, "OpenSSL key", le_key);
+	if (!pkey || EVP_PKEY_type(pkey->type) != EVP_PKEY_DH || !pkey->pkey.dh) {
+		RETURN_FALSE;
+	}
+
+	pub = BN_bin2bn((unsigned char*)pub_str, pub_len, NULL);
+
+	data = emalloc(DH_size(pkey->pkey.dh) + 1);
+	len = DH_compute_key((unsigned char*)data, pub, pkey->pkey.dh);
+
+	if (len >= 0) {
+		data[len] = 0;
+		RETVAL_STRINGL(data, len, 0);
+	} else {
+		efree(data);
+		RETVAL_FALSE;
+	}
+
+	BN_free(pub);
+}
+/* }}} */
+
+/* {{{ proto string openssl_random_pseudo_bytes(integer length [, &bool returned_strong_result])
+   Returns a string of the length specified filled with random pseudo bytes */
+PHP_FUNCTION(openssl_random_pseudo_bytes)
+{
+	long buffer_length;
+	unsigned char *buffer = NULL;
+	zval *zstrong_result_returned = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|z", &buffer_length, &zstrong_result_returned) == FAILURE) {
+		return;
+	}
+
+	if (zstrong_result_returned) {
+		zval_dtor(zstrong_result_returned);
+		ZVAL_BOOL(zstrong_result_returned, 0);
+	}
+
+	if (buffer_length <= 0 || buffer_length > INT_MAX) {
+		RETURN_FALSE;
+	}
+
+	buffer = safe_emalloc(buffer_length, 1, 1);
+
+#ifdef PHP_WIN32
+	/* random/urandom equivalent on Windows */
+	if (php_win32_get_random_bytes(buffer, (size_t) buffer_length) == FAILURE){
+		efree(buffer);
+		if (zstrong_result_returned) {
+			ZVAL_BOOL(zstrong_result_returned, 0);
+		}
+		RETURN_FALSE;
+	}
+#else
+	PHP_OPENSSL_RAND_ADD_TIME();
+	if (RAND_bytes(buffer, buffer_length) <= 0) {
+		efree(buffer);
+		if (zstrong_result_returned) {
+			ZVAL_BOOL(zstrong_result_returned, 0);
+		}
+		RETURN_FALSE;
+	}
+#endif
+
+	buffer[buffer_length] = 0;
+	RETVAL_STRINGL((char *)buffer, buffer_length, 0);
+
+	if (zstrong_result_returned) {
+		ZVAL_BOOL(zstrong_result_returned, 1);
+	}
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 8
+ * c-basic-offset: 8
+ * End:
+ * vim600: sw=4 ts=4 fdm=marker
+ * vim<600: sw=4 ts=4
+ */
+

--- a/tests/fixtures/php/5.6.40/ext/openssl/xp_ssl.c
+++ b/tests/fixtures/php/5.6.40/ext/openssl/xp_ssl.c
@@ -1,0 +1,2472 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 5                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2016 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Wez Furlong <wez@thebrainroom.com>                          |
+  |          Daniel Lowrey <rdlowrey@php.net>                            |
+  |          Chris Wright <daverandom@php.net>                           |
+  +----------------------------------------------------------------------+
+*/
+
+/* $Id$ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "ext/standard/file.h"
+#include "ext/standard/url.h"
+#include "streams/php_streams_int.h"
+#include "ext/standard/php_smart_str.h"
+#include "php_openssl.h"
+#include "php_network.h"
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/err.h>
+
+#ifdef PHP_WIN32
+#include "win32/winutil.h"
+#include "win32/time.h"
+#include <Wincrypt.h>
+/* These are from Wincrypt.h, they conflict with OpenSSL */
+#undef X509_NAME
+#undef X509_CERT_PAIR
+#undef X509_EXTENSIONS
+#endif
+
+#ifdef NETWARE
+#include <sys/select.h>
+#endif
+
+#if !defined(OPENSSL_NO_ECDH) && OPENSSL_VERSION_NUMBER >= 0x0090800fL
+#define HAVE_ECDH 1
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x00908070L && !defined(OPENSSL_NO_TLSEXT)
+#define HAVE_SNI 1 
+#endif
+
+/* Flags for determining allowed stream crypto methods */
+#define STREAM_CRYPTO_IS_CLIENT            (1<<0)
+#define STREAM_CRYPTO_METHOD_SSLv2         (1<<1)
+#define STREAM_CRYPTO_METHOD_SSLv3         (1<<2)
+#define STREAM_CRYPTO_METHOD_TLSv1_0       (1<<3)
+#define STREAM_CRYPTO_METHOD_TLSv1_1       (1<<4)
+#define STREAM_CRYPTO_METHOD_TLSv1_2       (1<<5)
+
+/* Simplify ssl context option retrieval */
+#define GET_VER_OPT(name)               (stream->context && SUCCESS == php_stream_context_get_option(stream->context, "ssl", name, &val))
+#define GET_VER_OPT_STRING(name, str)   if (GET_VER_OPT(name)) { convert_to_string_ex(val); str = Z_STRVAL_PP(val); }
+#define GET_VER_OPT_LONG(name, num)     if (GET_VER_OPT(name)) { convert_to_long_ex(val); num = Z_LVAL_PP(val); }
+
+/* Used for peer verification in windows */
+#define PHP_X509_NAME_ENTRY_TO_UTF8(ne, i, out) ASN1_STRING_to_UTF8(&out, X509_NAME_ENTRY_get_data(X509_NAME_get_entry(ne, i)))
+
+extern php_stream* php_openssl_get_stream_from_ssl_handle(const SSL *ssl);
+extern int php_openssl_x509_fingerprint(X509 *peer, const char *method, zend_bool raw, char **out, int *out_len TSRMLS_DC);
+extern int php_openssl_get_ssl_stream_data_index();
+extern int php_openssl_get_x509_list_id(void);
+static struct timeval subtract_timeval( struct timeval a, struct timeval b );
+static int compare_timeval( struct timeval a, struct timeval b );
+static size_t php_openssl_sockop_io(int read, php_stream *stream, char *buf, size_t count TSRMLS_DC);
+
+php_stream_ops php_openssl_socket_ops;
+
+/* Certificate contexts used for server-side SNI selection */
+typedef struct _php_openssl_sni_cert_t {
+	char *name;
+	SSL_CTX *ctx;
+} php_openssl_sni_cert_t;
+
+/* Provides leaky bucket handhsake renegotiation rate-limiting  */
+typedef struct _php_openssl_handshake_bucket_t {
+	long prev_handshake;
+	long limit;
+	long window;
+	float tokens;
+	unsigned should_close;
+} php_openssl_handshake_bucket_t;
+
+/* This implementation is very closely tied to the that of the native
+ * sockets implemented in the core.
+ * Don't try this technique in other extensions!
+ * */
+typedef struct _php_openssl_netstream_data_t {
+	php_netstream_data_t s;
+	SSL *ssl_handle;
+	SSL_CTX *ctx;
+	struct timeval connect_timeout;
+	int enable_on_connect;
+	int is_client;
+	int ssl_active;
+	php_stream_xport_crypt_method_t method;
+	php_openssl_handshake_bucket_t *reneg;
+	php_openssl_sni_cert_t *sni_certs;
+	unsigned sni_cert_count;
+	char *url_name;
+	unsigned state_set:1;
+	unsigned _spare:31;
+} php_openssl_netstream_data_t;
+
+/* it doesn't matter that we do some hash traversal here, since it is done only
+ * in an error condition arising from a network connection problem */
+static int is_http_stream_talking_to_iis(php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	if (stream->wrapperdata && stream->wrapper && strcasecmp(stream->wrapper->wops->label, "HTTP") == 0) {
+		/* the wrapperdata is an array zval containing the headers */
+		zval **tmp;
+
+#define SERVER_MICROSOFT_IIS	"Server: Microsoft-IIS"
+#define SERVER_GOOGLE "Server: GFE/"
+		
+		zend_hash_internal_pointer_reset(Z_ARRVAL_P(stream->wrapperdata));
+		while (SUCCESS == zend_hash_get_current_data(Z_ARRVAL_P(stream->wrapperdata), (void**)&tmp)) {
+
+			if (strncasecmp(Z_STRVAL_PP(tmp), SERVER_MICROSOFT_IIS, sizeof(SERVER_MICROSOFT_IIS)-1) == 0) {
+				return 1;
+			} else if (strncasecmp(Z_STRVAL_PP(tmp), SERVER_GOOGLE, sizeof(SERVER_GOOGLE)-1) == 0) {
+				return 1;
+			}
+			
+			zend_hash_move_forward(Z_ARRVAL_P(stream->wrapperdata));
+		}
+	}
+	return 0;
+}
+/* }}} */
+
+static int handle_ssl_error(php_stream *stream, int nr_bytes, zend_bool is_init TSRMLS_DC) /* {{{ */
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	int err = SSL_get_error(sslsock->ssl_handle, nr_bytes);
+	char esbuf[512];
+	smart_str ebuf = {0};
+	unsigned long ecode;
+	int retry = 1;
+
+	switch(err) {
+		case SSL_ERROR_ZERO_RETURN:
+			/* SSL terminated (but socket may still be active) */
+			retry = 0;
+			break;
+		case SSL_ERROR_WANT_READ:
+		case SSL_ERROR_WANT_WRITE:
+			/* re-negotiation, or perhaps the SSL layer needs more
+			 * packets: retry in next iteration */
+			errno = EAGAIN;
+			retry = is_init ? 1 : sslsock->s.is_blocked;
+			break;
+		case SSL_ERROR_SYSCALL:
+			if (ERR_peek_error() == 0) {
+				if (nr_bytes == 0) {
+					if (!is_http_stream_talking_to_iis(stream TSRMLS_CC) && ERR_get_error() != 0) {
+						php_error_docref(NULL TSRMLS_CC, E_WARNING,
+								"SSL: fatal protocol error");
+					}
+					SSL_set_shutdown(sslsock->ssl_handle, SSL_SENT_SHUTDOWN|SSL_RECEIVED_SHUTDOWN);
+					stream->eof = 1;
+					retry = 0;
+				} else {
+					char *estr = php_socket_strerror(php_socket_errno(), NULL, 0);
+
+					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+							"SSL: %s", estr);
+
+					efree(estr);
+					retry = 0;
+				}
+				break;
+			}
+
+			
+			/* fall through */
+		default:
+			/* some other error */
+			ecode = ERR_get_error();
+
+			switch (ERR_GET_REASON(ecode)) {
+				case SSL_R_NO_SHARED_CIPHER:
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL_R_NO_SHARED_CIPHER: no suitable shared cipher could be used.  This could be because the server is missing an SSL certificate (local_cert context option)");
+					retry = 0;
+					break;
+
+				default:
+					do {
+						/* NULL is automatically added */
+						ERR_error_string_n(ecode, esbuf, sizeof(esbuf));
+						if (ebuf.c) {
+							smart_str_appendc(&ebuf, '\n');
+						}
+						smart_str_appends(&ebuf, esbuf);
+					} while ((ecode = ERR_get_error()) != 0);
+
+					smart_str_0(&ebuf);
+
+					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+							"SSL operation failed with code %d. %s%s",
+							err,
+							ebuf.c ? "OpenSSL Error messages:\n" : "",
+							ebuf.c ? ebuf.c : "");
+					if (ebuf.c) {
+						smart_str_free(&ebuf);
+					}
+			}
+				
+			retry = 0;
+			errno = 0;
+	}
+	return retry;
+}
+/* }}} */
+
+static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx) /* {{{ */
+{
+	php_stream *stream;
+	SSL *ssl;
+	int err, depth, ret;
+	zval **val;
+	unsigned long allowed_depth = OPENSSL_DEFAULT_STREAM_VERIFY_DEPTH;
+
+	ret = preverify_ok;
+
+	/* determine the status for the current cert */
+	err = X509_STORE_CTX_get_error(ctx);
+	depth = X509_STORE_CTX_get_error_depth(ctx);
+
+	/* conjure the stream & context to use */
+	ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+	stream = (php_stream*)SSL_get_ex_data(ssl, php_openssl_get_ssl_stream_data_index());
+
+	/* if allow_self_signed is set, make sure that verification succeeds */
+	if (err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT &&
+		GET_VER_OPT("allow_self_signed") &&
+		zend_is_true(*val)
+	) {
+		ret = 1;
+	}
+
+	/* check the depth */
+	GET_VER_OPT_LONG("verify_depth", allowed_depth);
+	if ((unsigned long)depth > allowed_depth) {
+		ret = 0;
+		X509_STORE_CTX_set_error(ctx, X509_V_ERR_CERT_CHAIN_TOO_LONG);
+	}
+
+	return ret;
+}
+/* }}} */
+
+static int php_x509_fingerprint_cmp(X509 *peer, const char *method, const char *expected TSRMLS_DC)
+{
+	char *fingerprint;
+	int fingerprint_len;
+	int result = -1;
+
+	if (php_openssl_x509_fingerprint(peer, method, 0, &fingerprint, &fingerprint_len TSRMLS_CC) == SUCCESS) {
+		result = strcasecmp(expected, fingerprint);
+		efree(fingerprint);
+	}
+
+	return result;
+}
+
+static zend_bool php_x509_fingerprint_match(X509 *peer, zval *val TSRMLS_DC)
+{
+	if (Z_TYPE_P(val) == IS_STRING) {
+		const char *method = NULL;
+
+		switch (Z_STRLEN_P(val)) {
+			case 32:
+				method = "md5";
+				break;
+
+			case 40:
+				method = "sha1";
+				break;
+		}
+
+		return method && php_x509_fingerprint_cmp(peer, method, Z_STRVAL_P(val) TSRMLS_CC) == 0;
+
+	} else if (Z_TYPE_P(val) == IS_ARRAY) {
+		HashPosition pos;
+		zval **current;
+		char *key;
+		uint key_len;
+		ulong key_index;
+
+		if (!zend_hash_num_elements(Z_ARRVAL_P(val))) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid peer_fingerprint array; [algo => fingerprint] form required");
+			return 0;
+		}
+
+		for (zend_hash_internal_pointer_reset_ex(Z_ARRVAL_P(val), &pos);
+			zend_hash_get_current_data_ex(Z_ARRVAL_P(val), (void **)&current, &pos) == SUCCESS;
+			zend_hash_move_forward_ex(Z_ARRVAL_P(val), &pos)
+		) {
+			int key_type = zend_hash_get_current_key_ex(Z_ARRVAL_P(val), &key, &key_len, &key_index, 0, &pos);
+
+			if (!(key_type == HASH_KEY_IS_STRING && Z_TYPE_PP(current) == IS_STRING)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid peer_fingerprint array; [algo => fingerprint] form required");
+				return 0;
+			}
+			if (php_x509_fingerprint_cmp(peer, key, Z_STRVAL_PP(current) TSRMLS_CC) != 0) {
+				return 0;
+			}
+		}
+
+		return 1;
+
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"Invalid peer_fingerprint value; fingerprint string or array of the form [algo => fingerprint] required");
+	}
+
+	return 0;
+}
+
+static zend_bool matches_wildcard_name(const char *subjectname, const char *certname) /* {{{ */
+{
+	char *wildcard = NULL;
+	int prefix_len, suffix_len, subject_len;
+
+	if (strcasecmp(subjectname, certname) == 0) {
+		return 1;
+	}
+
+	/* wildcard, if present, must only be present in the left-most component */
+	if (!(wildcard = strchr(certname, '*')) || memchr(certname, '.', wildcard - certname)) {
+		return 0;
+	}
+
+	/* 1) prefix, if not empty, must match subject */
+	prefix_len = wildcard - certname;
+	if (prefix_len && strncasecmp(subjectname, certname, prefix_len) != 0) {
+		return 0;
+	}
+
+	suffix_len = strlen(wildcard + 1);
+	subject_len = strlen(subjectname);
+	if (suffix_len <= subject_len) {
+		/* 2) suffix must match
+		 * 3) no . between prefix and suffix
+		 **/
+		return strcasecmp(wildcard + 1, subjectname + subject_len - suffix_len) == 0 &&
+			memchr(subjectname + prefix_len, '.', subject_len - suffix_len - prefix_len) == NULL;
+	}
+
+	return 0;
+}
+/* }}} */
+
+static zend_bool matches_san_list(X509 *peer, const char *subject_name) /* {{{ */
+{
+	int i, len;
+	unsigned char *cert_name = NULL;
+	char ipbuffer[64];
+
+	GENERAL_NAMES *alt_names = X509_get_ext_d2i(peer, NID_subject_alt_name, 0, 0);
+	int alt_name_count = sk_GENERAL_NAME_num(alt_names);
+
+	for (i = 0; i < alt_name_count; i++) {
+		GENERAL_NAME *san = sk_GENERAL_NAME_value(alt_names, i);
+
+		if (san->type == GEN_DNS) {
+			ASN1_STRING_to_UTF8(&cert_name, san->d.dNSName);
+			if (ASN1_STRING_length(san->d.dNSName) != strlen((const char*)cert_name)) {
+				OPENSSL_free(cert_name);
+				/* prevent null-byte poisoning*/
+				continue;
+			}
+
+			/* accommodate valid FQDN entries ending in "." */
+			len = strlen((const char*)cert_name);
+			if (len && strcmp((const char *)&cert_name[len-1], ".") == 0) {
+				cert_name[len-1] = '\0';
+			}
+
+			if (matches_wildcard_name(subject_name, (const char *)cert_name)) {
+				OPENSSL_free(cert_name);
+				return 1;
+			}
+			OPENSSL_free(cert_name);
+		} else if (san->type == GEN_IPADD) {
+			if (san->d.iPAddress->length == 4) {
+				sprintf(ipbuffer, "%d.%d.%d.%d",
+					san->d.iPAddress->data[0],
+					san->d.iPAddress->data[1],
+					san->d.iPAddress->data[2],
+					san->d.iPAddress->data[3]
+				);
+				if (strcasecmp(subject_name, (const char*)ipbuffer) == 0) {
+					return 1;
+				}
+			}
+			/* No, we aren't bothering to check IPv6 addresses. Why?
+			 * Because IP SAN names are officially deprecated and are
+			 * not allowed by CAs starting in 2015. Deal with it.
+			 */
+		}
+	}
+
+	return 0;
+}
+/* }}} */
+
+static zend_bool matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC) /* {{{ */
+{
+	char buf[1024];
+	X509_NAME *cert_name;
+	zend_bool is_match = 0;
+	int cert_name_len;
+
+	cert_name = X509_get_subject_name(peer);
+	cert_name_len = X509_NAME_get_text_by_NID(cert_name, NID_commonName, buf, sizeof(buf));
+
+	if (cert_name_len == -1) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate peer certificate CN");
+	} else if (cert_name_len != strlen(buf)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Peer certificate CN=`%.*s' is malformed", cert_name_len, buf);
+	} else if (matches_wildcard_name(subject_name, buf)) {
+		is_match = 1;
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Peer certificate CN=`%.*s' did not match expected CN=`%s'", cert_name_len, buf, subject_name);
+	}
+
+	return is_match;
+}
+/* }}} */
+
+static int apply_peer_verification_policy(SSL *ssl, X509 *peer, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	zval **val = NULL;
+	char *peer_name = NULL;
+	int err,
+		must_verify_peer,
+		must_verify_peer_name,
+		must_verify_fingerprint,
+		has_cnmatch_ctx_opt;
+
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	must_verify_peer = GET_VER_OPT("verify_peer")
+		? zend_is_true(*val)
+		: sslsock->is_client;
+
+	has_cnmatch_ctx_opt = GET_VER_OPT("CN_match");
+	must_verify_peer_name = (has_cnmatch_ctx_opt || GET_VER_OPT("verify_peer_name"))
+		? zend_is_true(*val)
+		: sslsock->is_client;
+
+	must_verify_fingerprint = GET_VER_OPT("peer_fingerprint");
+
+	if ((must_verify_peer || must_verify_peer_name || must_verify_fingerprint) && peer == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not get peer certificate");
+		return FAILURE;
+	}
+
+	/* Verify the peer against using CA file/path settings */
+	if (must_verify_peer) {
+		err = SSL_get_verify_result(ssl);
+		switch (err) {
+			case X509_V_OK:
+				/* fine */
+				break;
+			case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+				if (GET_VER_OPT("allow_self_signed") && zend_is_true(*val)) {
+					/* allowed */
+					break;
+				}
+				/* not allowed, so fall through */
+			default:
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+						"Could not verify peer: code:%d %s",
+						err,
+						X509_verify_cert_error_string(err)
+				);
+				return FAILURE;
+		}
+	}
+
+	/* If a peer_fingerprint match is required this trumps peer and peer_name verification */
+	if (must_verify_fingerprint) {
+		if (Z_TYPE_PP(val) == IS_STRING || Z_TYPE_PP(val) == IS_ARRAY) {
+			if (!php_x509_fingerprint_match(peer, *val TSRMLS_CC)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					"peer_fingerprint match failure"
+				);
+				return FAILURE;
+			}
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"Expected peer fingerprint must be a string or an array"
+			);
+			return FAILURE;
+		}
+	}
+
+	/* verify the host name presented in the peer certificate */
+	if (must_verify_peer_name) {
+		GET_VER_OPT_STRING("peer_name", peer_name);
+
+		if (has_cnmatch_ctx_opt) {
+			GET_VER_OPT_STRING("CN_match", peer_name);
+			php_error(E_DEPRECATED,
+				"the 'CN_match' SSL context option is deprecated in favor of 'peer_name'"
+			);
+		}
+		/* If no peer name was specified we use the autodetected url name in client environments */
+		if (peer_name == NULL && sslsock->is_client) {
+			peer_name = sslsock->url_name;
+		}
+
+		if (peer_name) {
+			if (matches_san_list(peer, peer_name)) {
+				return SUCCESS;
+			} else if (matches_common_name(peer, peer_name TSRMLS_CC)) {
+				return SUCCESS;
+			} else {
+				return FAILURE;
+			}
+		} else {
+			return FAILURE;
+		}
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+static int passwd_callback(char *buf, int num, int verify, void *data) /* {{{ */
+{
+	php_stream *stream = (php_stream *)data;
+	zval **val = NULL;
+	char *passphrase = NULL;
+	/* TODO: could expand this to make a callback into PHP user-space */
+
+	GET_VER_OPT_STRING("passphrase", passphrase);
+
+	if (passphrase) {
+		if (Z_STRLEN_PP(val) < num - 1) {
+			memcpy(buf, Z_STRVAL_PP(val), Z_STRLEN_PP(val)+1);
+			return Z_STRLEN_PP(val);
+		}
+	}
+	return 0;
+}
+/* }}} */
+
+#if defined(PHP_WIN32) && OPENSSL_VERSION_NUMBER >= 0x00907000L
+#define RETURN_CERT_VERIFY_FAILURE(code) X509_STORE_CTX_set_error(x509_store_ctx, code); return 0;
+static int win_cert_verify_callback(X509_STORE_CTX *x509_store_ctx, void *arg) /* {{{ */
+{
+	PCCERT_CONTEXT cert_ctx = NULL;
+	PCCERT_CHAIN_CONTEXT cert_chain_ctx = NULL;
+
+	php_stream *stream;
+	php_openssl_netstream_data_t *sslsock;
+	zval **val;
+	zend_bool is_self_signed = 0;
+
+	TSRMLS_FETCH();
+
+	stream = (php_stream*)arg;
+	sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	{ /* First convert the x509 struct back to a DER encoded buffer and let Windows decode it into a form it can work with */
+		unsigned char *der_buf = NULL;
+		int der_len;
+
+		der_len = i2d_X509(x509_store_ctx->cert, &der_buf);
+		if (der_len < 0) {
+			unsigned long err_code, e;
+			char err_buf[512];
+
+			while ((e = ERR_get_error()) != 0) {
+				err_code = e;
+			}
+
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error encoding X509 certificate: %d: %s", err_code, ERR_error_string(err_code, err_buf));
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+
+		cert_ctx = CertCreateCertificateContext(X509_ASN_ENCODING, der_buf, der_len);
+		OPENSSL_free(der_buf);
+
+		if (cert_ctx == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error creating certificate context: %s", php_win_err());
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+	}
+
+	{ /* Next fetch the relevant cert chain from the store */
+		CERT_ENHKEY_USAGE enhkey_usage = {0};
+		CERT_USAGE_MATCH cert_usage = {0};
+		CERT_CHAIN_PARA chain_params = {sizeof(CERT_CHAIN_PARA)};
+		LPSTR usages[] = {szOID_PKIX_KP_SERVER_AUTH, szOID_SERVER_GATED_CRYPTO, szOID_SGC_NETSCAPE};
+		DWORD chain_flags = 0;
+		unsigned long allowed_depth = OPENSSL_DEFAULT_STREAM_VERIFY_DEPTH;
+		unsigned int i;
+
+		enhkey_usage.cUsageIdentifier = 3;
+		enhkey_usage.rgpszUsageIdentifier = usages;
+		cert_usage.dwType = USAGE_MATCH_TYPE_OR;
+		cert_usage.Usage = enhkey_usage;
+		chain_params.RequestedUsage = cert_usage;
+		chain_flags = CERT_CHAIN_CACHE_END_CERT | CERT_CHAIN_REVOCATION_CHECK_CHAIN_EXCLUDE_ROOT;
+
+		if (!CertGetCertificateChain(NULL, cert_ctx, NULL, NULL, &chain_params, chain_flags, NULL, &cert_chain_ctx)) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error getting certificate chain: %s", php_win_err());
+			CertFreeCertificateContext(cert_ctx);
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+
+		/* check if the cert is self-signed */
+		if (cert_chain_ctx->cChain > 0 && cert_chain_ctx->rgpChain[0]->cElement > 0
+			&& (cert_chain_ctx->rgpChain[0]->rgpElement[0]->TrustStatus.dwInfoStatus & CERT_TRUST_IS_SELF_SIGNED) != 0) {
+			is_self_signed = 1;
+		}
+
+		/* check the depth */
+		GET_VER_OPT_LONG("verify_depth", allowed_depth);
+
+		for (i = 0; i < cert_chain_ctx->cChain; i++) {
+			if (cert_chain_ctx->rgpChain[i]->cElement > allowed_depth) {
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(X509_V_ERR_CERT_CHAIN_TOO_LONG);
+			}
+		}
+	}
+
+	{ /* Then verify it against a policy */
+		SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_policy_params = {sizeof(SSL_EXTRA_CERT_CHAIN_POLICY_PARA)};
+		CERT_CHAIN_POLICY_PARA chain_policy_params = {sizeof(CERT_CHAIN_POLICY_PARA)};
+		CERT_CHAIN_POLICY_STATUS chain_policy_status = {sizeof(CERT_CHAIN_POLICY_STATUS)};
+		LPWSTR server_name = NULL;
+		BOOL verify_result;
+
+		{ /* This looks ridiculous and it is - but we validate the name ourselves using the peer_name
+		     ctx option, so just use the CN from the cert here */
+
+			X509_NAME *cert_name;
+			unsigned char *cert_name_utf8;
+			int index, cert_name_utf8_len;
+			DWORD num_wchars;
+
+			cert_name = X509_get_subject_name(x509_store_ctx->cert);
+			index = X509_NAME_get_index_by_NID(cert_name, NID_commonName, -1);
+			if (index < 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate certificate CN");
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+
+			cert_name_utf8_len = PHP_X509_NAME_ENTRY_TO_UTF8(cert_name, index, cert_name_utf8);
+
+			num_wchars = MultiByteToWideChar(CP_UTF8, 0, (char*)cert_name_utf8, -1, NULL, 0);
+			if (num_wchars == 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to convert %s to wide character string", cert_name_utf8);
+				OPENSSL_free(cert_name_utf8);
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+
+			server_name = emalloc((num_wchars * sizeof(WCHAR)) + sizeof(WCHAR));
+
+			num_wchars = MultiByteToWideChar(CP_UTF8, 0, (char*)cert_name_utf8, -1, server_name, num_wchars);
+			if (num_wchars == 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to convert %s to wide character string", cert_name_utf8);
+				efree(server_name);
+				OPENSSL_free(cert_name_utf8);
+				CertFreeCertificateChain(cert_chain_ctx);
+				CertFreeCertificateContext(cert_ctx);
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+
+			OPENSSL_free(cert_name_utf8);
+		}
+
+		ssl_policy_params.dwAuthType = (sslsock->is_client) ? AUTHTYPE_SERVER : AUTHTYPE_CLIENT;
+		ssl_policy_params.pwszServerName = server_name;
+		chain_policy_params.pvExtraPolicyPara = &ssl_policy_params;
+
+		verify_result = CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, cert_chain_ctx, &chain_policy_params, &chain_policy_status);
+
+		efree(server_name);
+		CertFreeCertificateChain(cert_chain_ctx);
+		CertFreeCertificateContext(cert_ctx);
+
+		if (!verify_result) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error verifying certificate chain policy: %s", php_win_err());
+			RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+		}
+
+		if (chain_policy_status.dwError != 0) {
+			/* The chain does not match the policy */
+			if (is_self_signed && chain_policy_status.dwError == CERT_E_UNTRUSTEDROOT
+				&& GET_VER_OPT("allow_self_signed") && zend_is_true(*val)) {
+				/* allow self-signed certs */
+				X509_STORE_CTX_set_error(x509_store_ctx, X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT);
+			} else {
+				RETURN_CERT_VERIFY_FAILURE(SSL_R_CERTIFICATE_VERIFY_FAILED);
+			}
+		}
+	}
+
+	return 1;
+}
+/* }}} */
+#endif
+
+static long load_stream_cafile(X509_STORE *cert_store, const char *cafile TSRMLS_DC) /* {{{ */
+{
+	php_stream *stream;
+	X509 *cert;
+	BIO *buffer;
+	int buffer_active = 0;
+	char *line = NULL;
+	size_t line_len;
+	long certs_added = 0;
+
+	stream = php_stream_open_wrapper(cafile, "rb", 0, NULL);
+
+	if (stream == NULL) {
+		php_error(E_WARNING, "failed loading cafile stream: `%s'", cafile);
+		return 0;
+	} else if (stream->wrapper->is_url) {
+		php_stream_close(stream);
+		php_error(E_WARNING, "remote cafile streams are disabled for security purposes");
+		return 0;
+	}
+
+	cert_start: {
+		line = php_stream_get_line(stream, NULL, 0, &line_len);
+		if (line == NULL) {
+			goto stream_complete;
+		} else if (!strcmp(line, "-----BEGIN CERTIFICATE-----\n") ||
+			!strcmp(line, "-----BEGIN CERTIFICATE-----\r\n")
+		) {
+			buffer = BIO_new(BIO_s_mem());
+			buffer_active = 1;
+			goto cert_line;
+		} else {
+			efree(line);
+			goto cert_start;
+		}
+	}
+
+	cert_line: {
+		BIO_puts(buffer, line);
+		efree(line);
+		line = php_stream_get_line(stream, NULL, 0, &line_len);
+		if (line == NULL) {
+			goto stream_complete;
+		} else if (!strcmp(line, "-----END CERTIFICATE-----") ||
+			!strcmp(line, "-----END CERTIFICATE-----\n") ||
+			!strcmp(line, "-----END CERTIFICATE-----\r\n")
+		) {
+			goto add_cert;
+		} else {
+			goto cert_line;
+		}
+	}
+
+	add_cert: {
+		BIO_puts(buffer, line);
+		efree(line);
+		cert = PEM_read_bio_X509(buffer, NULL, 0, NULL);
+		BIO_free(buffer);
+		buffer_active = 0;
+		if (cert && X509_STORE_add_cert(cert_store, cert)) {
+			++certs_added;
+		}
+		goto cert_start;
+	}
+
+	stream_complete: {
+		php_stream_close(stream);
+		if (buffer_active == 1) {
+			BIO_free(buffer);
+		}
+	}
+
+	if (certs_added == 0) {
+		php_error(E_WARNING, "no valid certs found cafile stream: `%s'", cafile);
+	}
+
+	return certs_added;
+}
+/* }}} */
+
+static int enable_peer_verification(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	zval **val = NULL;
+	char *cafile = NULL;
+	char *capath = NULL;
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	GET_VER_OPT_STRING("cafile", cafile);
+	GET_VER_OPT_STRING("capath", capath);
+
+	if (cafile == NULL) {
+		cafile = zend_ini_string("openssl.cafile", sizeof("openssl.cafile"), 0);
+		cafile = strlen(cafile) ? cafile : NULL;
+	} else if (!sslsock->is_client) {
+		/* Servers need to load and assign CA names from the cafile */
+		STACK_OF(X509_NAME) *cert_names = SSL_load_client_CA_file(cafile);
+		if (cert_names != NULL) {
+			SSL_CTX_set_client_CA_list(ctx, cert_names);
+		} else {
+			php_error(E_WARNING, "SSL: failed loading CA names from cafile");
+			return FAILURE;
+		}
+	}
+
+	if (capath == NULL) {
+		capath = zend_ini_string("openssl.capath", sizeof("openssl.capath"), 0);
+		capath = strlen(capath) ? capath : NULL;
+	}
+
+	if (cafile || capath) {
+		if (!SSL_CTX_load_verify_locations(ctx, cafile, capath)) {
+			if (cafile && !load_stream_cafile(SSL_CTX_get_cert_store(ctx), cafile TSRMLS_CC)) {
+				return FAILURE;
+			}
+		}
+	} else {
+#if defined(PHP_WIN32) && OPENSSL_VERSION_NUMBER >= 0x00907000L
+		SSL_CTX_set_cert_verify_callback(ctx, win_cert_verify_callback, (void *)stream);
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+#else
+		if (sslsock->is_client && !SSL_CTX_set_default_verify_paths(ctx)) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"Unable to set default verify locations and no CA settings specified");
+			return FAILURE;
+		}
+#endif
+	}
+
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_callback);
+
+	return SUCCESS;
+}
+/* }}} */
+
+static void disable_peer_verification(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+}
+/* }}} */
+
+static int set_local_cert(SSL_CTX *ctx, php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	zval **val = NULL;
+	char *certfile = NULL;
+
+	GET_VER_OPT_STRING("local_cert", certfile);
+
+	if (certfile) {
+		char resolved_path_buff[MAXPATHLEN];
+		const char * private_key = NULL;
+
+		if (VCWD_REALPATH(certfile, resolved_path_buff)) {
+			/* a certificate to use for authentication */
+			if (SSL_CTX_use_certificate_chain_file(ctx, resolved_path_buff) != 1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to set local cert chain file `%s'; Check that your cafile/capath settings include details of your certificate and its issuer", certfile);
+				return FAILURE;
+			}
+			GET_VER_OPT_STRING("local_pk", private_key);
+
+			if (private_key) {
+				char resolved_path_buff_pk[MAXPATHLEN];
+				if (VCWD_REALPATH(private_key, resolved_path_buff_pk)) {
+					if (SSL_CTX_use_PrivateKey_file(ctx, resolved_path_buff_pk, SSL_FILETYPE_PEM) != 1) {
+						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to set private key file `%s'", resolved_path_buff_pk);
+						return FAILURE;
+					}
+				}
+			} else {
+				if (SSL_CTX_use_PrivateKey_file(ctx, resolved_path_buff, SSL_FILETYPE_PEM) != 1) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to set private key file `%s'", resolved_path_buff);
+					return FAILURE;
+				}		
+			}
+
+#if OPENSSL_VERSION_NUMBER < 0x10001001L
+			do {
+				/* Unnecessary as of OpenSSLv1.0.1 (will segfault if used with >= 10001001 ) */
+				X509 *cert = NULL;
+				EVP_PKEY *key = NULL;
+				SSL *tmpssl = SSL_new(ctx);
+				cert = SSL_get_certificate(tmpssl);
+
+				if (cert) {
+					key = X509_get_pubkey(cert);
+					EVP_PKEY_copy_parameters(key, SSL_get_privatekey(tmpssl));
+					EVP_PKEY_free(key);
+				}
+				SSL_free(tmpssl);
+			} while (0);
+#endif
+			if (!SSL_CTX_check_private_key(ctx)) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Private key does not match certificate!");
+			}
+		}
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+static const SSL_METHOD *php_select_crypto_method(long method_value, int is_client TSRMLS_DC) /* {{{ */
+{
+	if (method_value == STREAM_CRYPTO_METHOD_SSLv2) {
+#ifndef OPENSSL_NO_SSL2
+		return is_client ? SSLv2_client_method() : SSLv2_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SSLv2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (method_value == STREAM_CRYPTO_METHOD_SSLv3) {
+#ifndef OPENSSL_NO_SSL3
+		return is_client ? SSLv3_client_method() : SSLv3_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SSLv3 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_0) {
+		return is_client ? TLSv1_client_method() : TLSv1_server_method();
+	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_1) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		return is_client ? TLSv1_1_client_method() : TLSv1_1_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"TLSv1.1 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_2) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		return is_client ? TLSv1_2_client_method() : TLSv1_2_server_method();
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"TLSv1.2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"Invalid crypto method");
+		return NULL;
+	}
+}
+/* }}} */
+
+static long php_get_crypto_method_ctx_flags(long method_flags TSRMLS_DC) /* {{{ */
+{
+	long ssl_ctx_options = SSL_OP_ALL;
+
+#ifndef OPENSSL_NO_SSL2
+	if (!(method_flags & STREAM_CRYPTO_METHOD_SSLv2)) {
+		ssl_ctx_options |= SSL_OP_NO_SSLv2;
+	}
+#endif
+#ifndef OPENSSL_NO_SSL3
+	if (!(method_flags & STREAM_CRYPTO_METHOD_SSLv3)) {
+		ssl_ctx_options |= SSL_OP_NO_SSLv3;
+	}
+#endif
+#ifndef OPENSSL_NO_TLS1
+	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_0)) {
+		ssl_ctx_options |= SSL_OP_NO_TLSv1;
+	}
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_1)) {
+		ssl_ctx_options |= SSL_OP_NO_TLSv1_1;
+	}
+
+	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_2)) {
+		ssl_ctx_options |= SSL_OP_NO_TLSv1_2;
+	}
+#endif
+
+	return ssl_ctx_options;
+}
+/* }}} */
+
+static void limit_handshake_reneg(const SSL *ssl) /* {{{ */
+{
+	php_stream *stream;
+	php_openssl_netstream_data_t *sslsock;
+	struct timeval now;
+	long elapsed_time;
+
+	stream = php_openssl_get_stream_from_ssl_handle(ssl);
+	sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	gettimeofday(&now, NULL);
+
+	/* The initial handshake is never rate-limited */
+	if (sslsock->reneg->prev_handshake == 0) {
+		sslsock->reneg->prev_handshake = now.tv_sec;
+		return;
+	}
+
+	elapsed_time = (now.tv_sec - sslsock->reneg->prev_handshake);
+	sslsock->reneg->prev_handshake = now.tv_sec;
+	sslsock->reneg->tokens -= (elapsed_time * (sslsock->reneg->limit / sslsock->reneg->window));
+
+	if (sslsock->reneg->tokens < 0) {
+		sslsock->reneg->tokens = 0;
+	}
+	++sslsock->reneg->tokens;
+
+	/* The token level exceeds our allowed limit */
+	if (sslsock->reneg->tokens > sslsock->reneg->limit) {
+		zval **val;
+
+		TSRMLS_FETCH();
+
+		sslsock->reneg->should_close = 1;
+
+		if (stream->context && SUCCESS == php_stream_context_get_option(stream->context,
+				"ssl", "reneg_limit_callback", &val)
+		) {
+			zval *param, **params[1], *retval;
+
+			MAKE_STD_ZVAL(param);
+			php_stream_to_zval(stream, param);
+			params[0] = &param;
+
+			/* Closing the stream inside this callback would segfault! */
+			stream->flags |= PHP_STREAM_FLAG_NO_FCLOSE;
+			if (FAILURE == call_user_function_ex(EG(function_table), NULL, *val, &retval, 1, params, 0, NULL TSRMLS_CC)) {
+				php_error(E_WARNING, "SSL: failed invoking reneg limit notification callback");
+			}
+			stream->flags ^= PHP_STREAM_FLAG_NO_FCLOSE;
+
+			/* If the reneg_limit_callback returned true don't auto-close */
+			if (retval != NULL && Z_TYPE_P(retval) == IS_BOOL && Z_BVAL_P(retval) == 1) {
+				sslsock->reneg->should_close = 0;
+			}
+
+			FREE_ZVAL(param);
+			if (retval != NULL) {
+				zval_ptr_dtor(&retval);
+			}
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SSL: client-initiated handshake rate limit exceeded by peer");
+		}
+	}
+}
+/* }}} */
+
+static void info_callback(const SSL *ssl, int where, int ret) /* {{{ */
+{
+	/* Rate-limit client-initiated handshake renegotiation to prevent DoS */
+	if (where & SSL_CB_HANDSHAKE_START) {
+		limit_handshake_reneg(ssl);
+	}
+}
+/* }}} */
+
+static void init_server_reneg_limit(php_stream *stream, php_openssl_netstream_data_t *sslsock) /* {{{ */
+{
+	zval **val;
+	long limit = OPENSSL_DEFAULT_RENEG_LIMIT;
+	long window = OPENSSL_DEFAULT_RENEG_WINDOW;
+
+	if (stream->context &&
+		SUCCESS == php_stream_context_get_option(stream->context,
+				"ssl", "reneg_limit", &val)
+	) {
+		convert_to_long(*val);
+		limit = Z_LVAL_PP(val);
+	}
+
+	/* No renegotiation rate-limiting */
+	if (limit < 0) {
+		return;
+	}
+
+	if (stream->context &&
+		SUCCESS == php_stream_context_get_option(stream->context,
+				"ssl", "reneg_window", &val)
+	) {
+		convert_to_long(*val);
+		window = Z_LVAL_PP(val);
+	}
+
+	sslsock->reneg = (void*)pemalloc(sizeof(php_openssl_handshake_bucket_t),
+		php_stream_is_persistent(stream)
+	);
+
+	sslsock->reneg->limit = limit;
+	sslsock->reneg->window = window;
+	sslsock->reneg->prev_handshake = 0;
+	sslsock->reneg->tokens = 0;
+	sslsock->reneg->should_close = 0;
+
+	SSL_set_info_callback(sslsock->ssl_handle, info_callback);
+}
+/* }}} */
+
+static int set_server_rsa_key(php_stream *stream, SSL_CTX *ctx TSRMLS_DC) /* {{{ */
+{
+	zval ** val;
+	int rsa_key_size;
+	RSA* rsa;
+
+	if (php_stream_context_get_option(stream->context, "ssl", "rsa_key_size", &val) == SUCCESS) {
+		rsa_key_size = (int) Z_LVAL_PP(val);
+		if ((rsa_key_size != 1) && (rsa_key_size & (rsa_key_size - 1))) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RSA key size requires a power of 2: %d", rsa_key_size);
+			rsa_key_size = 2048;
+		}
+	} else {
+		rsa_key_size = 2048;
+	}
+
+	rsa = RSA_generate_key(rsa_key_size, RSA_F4, NULL, NULL);
+
+	if (!SSL_CTX_set_tmp_rsa(ctx, rsa)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed setting RSA key");
+		RSA_free(rsa);
+		return FAILURE;
+	}
+
+	RSA_free(rsa);
+
+	return SUCCESS;
+}
+/* }}} */
+
+static int set_server_dh_param(SSL_CTX *ctx, char *dh_path TSRMLS_DC) /* {{{ */
+{
+	DH *dh;
+	BIO* bio;
+
+	bio = BIO_new_file(dh_path, "r");
+
+	if (bio == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid dh_param file: %s", dh_path);
+		return FAILURE;
+	}
+
+	dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
+	BIO_free(bio);
+
+	if (dh == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed reading DH params from file: %s", dh_path);
+		return FAILURE;
+	}
+
+	if (SSL_CTX_set_tmp_dh(ctx, dh) < 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "DH param assignment failed");
+		DH_free(dh);
+		return FAILURE;
+	}
+
+	DH_free(dh);
+
+	return SUCCESS;
+}
+/* }}} */
+
+#ifdef HAVE_ECDH
+static int set_server_ecdh_curve(php_stream *stream, SSL_CTX *ctx TSRMLS_DC) /* {{{ */
+{
+	zval **val;
+	int curve_nid;
+	char *curve_str;
+	EC_KEY *ecdh;
+
+	if (php_stream_context_get_option(stream->context, "ssl", "ecdh_curve", &val) == SUCCESS) {
+		convert_to_string_ex(val);
+		curve_str = Z_STRVAL_PP(val);
+		curve_nid = OBJ_sn2nid(curve_str);
+		if (curve_nid == NID_undef) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid ECDH curve: %s", curve_str);
+			return FAILURE;
+		}
+	} else {
+		curve_nid = NID_X9_62_prime256v1;
+	}
+
+	ecdh = EC_KEY_new_by_curve_name(curve_nid);
+	if (ecdh == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"Failed generating ECDH curve");
+
+		return FAILURE;
+	}
+
+	SSL_CTX_set_tmp_ecdh(ctx, ecdh);
+	EC_KEY_free(ecdh);
+
+	return SUCCESS;
+}
+/* }}} */
+#endif
+
+static int set_server_specific_opts(php_stream *stream, SSL_CTX *ctx TSRMLS_DC) /* {{{ */
+{
+	zval **val;
+	long ssl_ctx_options = SSL_CTX_get_options(ctx);
+
+#ifdef HAVE_ECDH
+	if (FAILURE == set_server_ecdh_curve(stream, ctx TSRMLS_CC)) {
+		return FAILURE;
+	}
+#else
+	if (SUCCESS == php_stream_context_get_option(stream->context, "ssl", "ecdh_curve", &val)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"ECDH curve support not compiled into the OpenSSL lib against which PHP is linked");
+
+		return FAILURE;
+	}
+#endif
+
+	if (php_stream_context_get_option(stream->context, "ssl", "dh_param", &val) == SUCCESS) {
+		convert_to_string_ex(val);
+		if (FAILURE == set_server_dh_param(ctx,  Z_STRVAL_PP(val) TSRMLS_CC)) {
+			return FAILURE;
+		}
+	}
+
+	if (FAILURE == set_server_rsa_key(stream, ctx TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (SUCCESS == php_stream_context_get_option(
+				stream->context, "ssl", "honor_cipher_order", &val) &&
+			zend_is_true(*val)
+	) {
+		ssl_ctx_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+	}
+
+	if (SUCCESS == php_stream_context_get_option(
+				stream->context, "ssl", "single_dh_use", &val) &&
+			zend_is_true(*val)
+	) {
+		ssl_ctx_options |= SSL_OP_SINGLE_DH_USE;
+	}
+
+#ifdef HAVE_ECDH
+	if (SUCCESS == php_stream_context_get_option(
+				stream->context, "ssl", "single_ecdh_use", &val) &&
+			zend_is_true(*val)
+	) {
+		ssl_ctx_options |= SSL_OP_SINGLE_ECDH_USE;
+	}
+#endif
+
+	SSL_CTX_set_options(ctx, ssl_ctx_options);
+
+	return SUCCESS;
+}
+/* }}} */
+
+#ifdef HAVE_SNI
+static int server_sni_callback(SSL *ssl_handle, int *al, void *arg) /* {{{ */
+{
+	php_stream *stream;
+	php_openssl_netstream_data_t *sslsock;
+	unsigned i;
+	const char *server_name;
+
+	server_name = SSL_get_servername(ssl_handle, TLSEXT_NAMETYPE_host_name);
+
+	if (!server_name) {
+		return SSL_TLSEXT_ERR_NOACK;
+	}
+
+	stream = (php_stream*)SSL_get_ex_data(ssl_handle, php_openssl_get_ssl_stream_data_index());
+	sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	if (!(sslsock->sni_cert_count && sslsock->sni_certs)) {
+		return SSL_TLSEXT_ERR_NOACK;
+	}
+
+	for (i=0; i < sslsock->sni_cert_count; i++) {
+		if (matches_wildcard_name(server_name, sslsock->sni_certs[i].name)) {
+			SSL_set_SSL_CTX(ssl_handle, sslsock->sni_certs[i].ctx);
+			return SSL_TLSEXT_ERR_OK;
+		}
+	}
+
+	return SSL_TLSEXT_ERR_NOACK;
+}
+/* }}} */
+
+static int enable_server_sni(php_stream *stream, php_openssl_netstream_data_t *sslsock TSRMLS_DC)
+{
+	zval **val;
+	zval **current;
+	char *key;
+	uint key_len;
+	ulong key_index;
+	int key_type;
+	HashPosition pos;
+	int i = 0;
+	char resolved_path_buff[MAXPATHLEN];
+	SSL_CTX *ctx;
+
+	/* If the stream ctx disables SNI we're finished here */
+	if (GET_VER_OPT("SNI_enabled") && !zend_is_true(*val)) {
+		return SUCCESS;
+	}
+
+	/* If no SNI cert array is specified we're finished here */
+	if (!GET_VER_OPT("SNI_server_certs")) {
+		return SUCCESS;
+	}
+
+	if (Z_TYPE_PP(val) != IS_ARRAY) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"SNI_server_certs requires an array mapping host names to cert paths"
+		);
+		return FAILURE;
+	}
+
+	sslsock->sni_cert_count = zend_hash_num_elements(Z_ARRVAL_PP(val));
+	if (sslsock->sni_cert_count == 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			"SNI_server_certs host cert array must not be empty"
+		);
+		return FAILURE;
+	}
+
+	sslsock->sni_certs = (php_openssl_sni_cert_t*)safe_pemalloc(sslsock->sni_cert_count,
+		sizeof(php_openssl_sni_cert_t), 0, php_stream_is_persistent(stream)
+	);
+	memset(sslsock->sni_certs, 0, sslsock->sni_cert_count * sizeof(php_openssl_sni_cert_t));
+
+	for (zend_hash_internal_pointer_reset_ex(Z_ARRVAL_PP(val), &pos);
+		zend_hash_get_current_data_ex(Z_ARRVAL_PP(val), (void **)&current, &pos) == SUCCESS;
+		zend_hash_move_forward_ex(Z_ARRVAL_PP(val), &pos)
+	) {
+		key_type = zend_hash_get_current_key_ex(Z_ARRVAL_PP(val), &key, &key_len, &key_index, 0, &pos);
+		if (key_type != HASH_KEY_IS_STRING) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"SNI_server_certs array requires string host name keys"
+			);
+			return FAILURE;
+		}
+
+		if (VCWD_REALPATH(Z_STRVAL_PP(current), resolved_path_buff)) {
+			/* The hello method is not inherited by SSL structs when assigning a new context
+			 * inside the SNI callback, so the just use SSLv23 */
+			ctx = SSL_CTX_new(SSLv23_server_method());
+
+			if (SSL_CTX_use_certificate_chain_file(ctx, resolved_path_buff) != 1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					"failed setting local cert chain file `%s'; " \
+					"check that your cafile/capath settings include " \
+					"details of your certificate and its issuer",
+					resolved_path_buff
+				);
+				SSL_CTX_free(ctx);
+				return FAILURE;
+			} else if (SSL_CTX_use_PrivateKey_file(ctx, resolved_path_buff, SSL_FILETYPE_PEM) != 1) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					"failed setting private key from file `%s'",
+					resolved_path_buff
+				);
+				SSL_CTX_free(ctx);
+				return FAILURE;
+			} else {
+				sslsock->sni_certs[i].name = pestrdup(key, php_stream_is_persistent(stream));
+				sslsock->sni_certs[i].ctx = ctx;
+				++i;
+			}
+		} else {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+				"failed setting local cert chain file `%s'; file not found",
+				Z_STRVAL_PP(current)
+			);
+			return FAILURE;
+		}
+	}
+
+	SSL_CTX_set_tlsext_servername_callback(sslsock->ctx, server_sni_callback);
+
+	return SUCCESS;
+}
+
+static void enable_client_sni(php_stream *stream, php_openssl_netstream_data_t *sslsock) /* {{{ */
+{
+	zval **val;
+	char *sni_server_name;
+
+	/* If SNI is explicitly disabled we're finished here */
+	if (GET_VER_OPT("SNI_enabled") && !zend_is_true(*val)) {
+		return;
+	}
+
+	sni_server_name = sslsock->url_name;
+
+	GET_VER_OPT_STRING("peer_name", sni_server_name);
+
+	if (GET_VER_OPT("SNI_server_name")) {
+		GET_VER_OPT_STRING("SNI_server_name", sni_server_name);
+		php_error(E_DEPRECATED, "SNI_server_name is deprecated in favor of peer_name");
+	}
+
+	if (sni_server_name) {
+		SSL_set_tlsext_host_name(sslsock->ssl_handle, sni_server_name);
+	}
+}
+/* }}} */
+#endif
+
+int php_openssl_setup_crypto(php_stream *stream,
+		php_openssl_netstream_data_t *sslsock,
+		php_stream_xport_crypto_param *cparam
+		TSRMLS_DC) /* {{{ */
+{
+	const SSL_METHOD *method;
+	long ssl_ctx_options;
+	long method_flags;
+	char *cipherlist = NULL;
+	zval **val;
+
+	if (sslsock->ssl_handle) {
+		if (sslsock->s.is_blocked) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL/TLS already set-up for this stream");
+			return FAILURE;
+		} else {
+			return SUCCESS;
+		}
+	}
+
+	ERR_clear_error();
+
+	/* We need to do slightly different things based on client/server method
+	 * so lets remember which method was selected */
+	sslsock->is_client = cparam->inputs.method & STREAM_CRYPTO_IS_CLIENT;
+	method_flags = ((cparam->inputs.method >> 1) << 1);
+
+	/* Should we use a specific crypto method or is generic SSLv23 okay? */
+	if ((method_flags & (method_flags-1)) == 0) {
+		ssl_ctx_options = SSL_OP_ALL;
+		method = php_select_crypto_method(method_flags, sslsock->is_client TSRMLS_CC);
+		if (method == NULL) {
+			return FAILURE;
+		}
+	} else {
+		method = sslsock->is_client ? SSLv23_client_method() : SSLv23_server_method();
+		ssl_ctx_options = php_get_crypto_method_ctx_flags(method_flags TSRMLS_CC);
+		if (ssl_ctx_options == -1) {
+			return FAILURE;
+		}
+	}
+
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+	sslsock->ctx = SSL_CTX_new(method);
+#else
+	/* Avoid const warning with old versions */
+	sslsock->ctx = SSL_CTX_new((SSL_METHOD*)method);
+#endif
+
+	if (sslsock->ctx == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL context creation failure");
+		return FAILURE;
+	}
+
+#if OPENSSL_VERSION_NUMBER >= 0x0090806fL
+	if (GET_VER_OPT("no_ticket") && zend_is_true(*val)) {
+		ssl_ctx_options |= SSL_OP_NO_TICKET;
+	}
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x0090605fL
+	ssl_ctx_options &= ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (!GET_VER_OPT("disable_compression") || zend_is_true(*val)) {
+		ssl_ctx_options |= SSL_OP_NO_COMPRESSION;
+	}
+#endif
+
+	if (GET_VER_OPT("verify_peer") && !zend_is_true(*val)) {
+		disable_peer_verification(sslsock->ctx, stream TSRMLS_CC);
+	} else if (FAILURE == enable_peer_verification(sslsock->ctx, stream TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	/* callback for the passphrase (for localcert) */
+	if (GET_VER_OPT("passphrase")) {
+		SSL_CTX_set_default_passwd_cb_userdata(sslsock->ctx, stream);
+		SSL_CTX_set_default_passwd_cb(sslsock->ctx, passwd_callback);
+	}
+
+	GET_VER_OPT_STRING("ciphers", cipherlist);
+#ifndef USE_OPENSSL_SYSTEM_CIPHERS
+	if (!cipherlist) {
+		cipherlist = OPENSSL_DEFAULT_STREAM_CIPHERS;
+	}
+#endif
+	if (cipherlist) {
+		if (SSL_CTX_set_cipher_list(sslsock->ctx, cipherlist) != 1) {
+			return FAILURE;
+		}
+	}
+	if (FAILURE == set_local_cert(sslsock->ctx, stream TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	SSL_CTX_set_options(sslsock->ctx, ssl_ctx_options);
+
+	if (sslsock->is_client == 0 &&
+		stream->context &&
+		FAILURE == set_server_specific_opts(stream, sslsock->ctx TSRMLS_CC)
+	) {
+		return FAILURE;
+	}
+
+	sslsock->ssl_handle = SSL_new(sslsock->ctx);
+	if (sslsock->ssl_handle == NULL) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL handle creation failure");
+		SSL_CTX_free(sslsock->ctx);
+		sslsock->ctx = NULL;
+		return FAILURE;
+	} else {
+		SSL_set_ex_data(sslsock->ssl_handle, php_openssl_get_ssl_stream_data_index(), stream);
+	}
+
+	if (!SSL_set_fd(sslsock->ssl_handle, sslsock->s.socket)) {
+		handle_ssl_error(stream, 0, 1 TSRMLS_CC);
+	}
+
+#ifdef HAVE_SNI
+	/* Enable server-side SNI */
+	if (sslsock->is_client == 0 && enable_server_sni(stream, sslsock TSRMLS_CC) == FAILURE) {
+		return FAILURE;
+	}
+#endif
+
+	/* Enable server-side handshake renegotiation rate-limiting */
+	if (sslsock->is_client == 0) {
+		init_server_reneg_limit(stream, sslsock);
+	}
+
+#ifdef SSL_MODE_RELEASE_BUFFERS
+	do {
+		long mode = SSL_get_mode(sslsock->ssl_handle);
+		SSL_set_mode(sslsock->ssl_handle, mode | SSL_MODE_RELEASE_BUFFERS);
+	} while (0);
+#endif
+
+	if (cparam->inputs.session) {
+		if (cparam->inputs.session->ops != &php_openssl_socket_ops) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied session stream must be an SSL enabled stream");
+		} else if (((php_openssl_netstream_data_t*)cparam->inputs.session->abstract)->ssl_handle == NULL) {
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "supplied SSL session stream is not initialized");
+		} else {
+			SSL_copy_session_id(sslsock->ssl_handle, ((php_openssl_netstream_data_t*)cparam->inputs.session->abstract)->ssl_handle);
+		}
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+static zval *capture_session_meta(SSL *ssl_handle) /* {{{ */
+{
+	zval *meta_arr;
+	char *proto_str;
+	long proto = SSL_version(ssl_handle);
+	const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl_handle);
+
+	switch (proto) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		case TLS1_2_VERSION: proto_str = "TLSv1.2"; break;
+		case TLS1_1_VERSION: proto_str = "TLSv1.1"; break;
+#endif
+		case TLS1_VERSION: proto_str = "TLSv1"; break;
+		case SSL3_VERSION: proto_str = "SSLv3"; break;
+		case SSL2_VERSION: proto_str = "SSLv2"; break;
+		default: proto_str = "UNKNOWN";
+	}
+
+	MAKE_STD_ZVAL(meta_arr);
+	array_init(meta_arr);
+	add_assoc_string(meta_arr, "protocol", proto_str, 1);
+	add_assoc_string(meta_arr, "cipher_name", (char *) SSL_CIPHER_get_name(cipher), 1);
+	add_assoc_long(meta_arr, "cipher_bits", SSL_CIPHER_get_bits(cipher, NULL));
+	add_assoc_string(meta_arr, "cipher_version", SSL_CIPHER_get_version(cipher), 1);
+
+	return meta_arr;
+}
+/* }}} */
+
+static int capture_peer_certs(php_stream *stream, php_openssl_netstream_data_t *sslsock, X509 *peer_cert TSRMLS_DC) /* {{{ */
+{
+	zval **val, *zcert;
+	int cert_captured = 0;
+
+	if (SUCCESS == php_stream_context_get_option(stream->context,
+			"ssl", "capture_peer_cert", &val) &&
+		zend_is_true(*val)
+	) {
+		MAKE_STD_ZVAL(zcert);
+		ZVAL_RESOURCE(zcert, zend_list_insert(peer_cert, php_openssl_get_x509_list_id() TSRMLS_CC));
+		php_stream_context_set_option(stream->context, "ssl", "peer_certificate", zcert);
+		cert_captured = 1;
+		FREE_ZVAL(zcert);
+	}
+
+	if (SUCCESS == php_stream_context_get_option(stream->context,
+			"ssl", "capture_peer_cert_chain", &val) &&
+		zend_is_true(*val)
+	) {
+		zval *arr;
+		STACK_OF(X509) *chain;
+
+		MAKE_STD_ZVAL(arr);
+		chain = SSL_get_peer_cert_chain(sslsock->ssl_handle);
+
+		if (chain && sk_X509_num(chain) > 0) {
+			int i;
+			array_init(arr);
+
+			for (i = 0; i < sk_X509_num(chain); i++) {
+				X509 *mycert = X509_dup(sk_X509_value(chain, i));
+				MAKE_STD_ZVAL(zcert);
+				ZVAL_RESOURCE(zcert, zend_list_insert(mycert, php_openssl_get_x509_list_id() TSRMLS_CC));
+				add_next_index_zval(arr, zcert);
+			}
+
+		} else {
+			ZVAL_NULL(arr);
+		}
+
+		php_stream_context_set_option(stream->context, "ssl", "peer_certificate_chain", arr);
+		zval_dtor(arr);
+		efree(arr);
+	}
+
+	return cert_captured;
+}
+/* }}} */
+
+static int php_openssl_enable_crypto(php_stream *stream,
+		php_openssl_netstream_data_t *sslsock,
+		php_stream_xport_crypto_param *cparam
+		TSRMLS_DC)
+{
+	int n;
+	int retry = 1;
+	int cert_captured;
+	X509 *peer_cert;
+
+	if (cparam->inputs.activate && !sslsock->ssl_active) {
+		struct timeval	start_time,
+						*timeout;
+		int				blocked		= sslsock->s.is_blocked,
+						has_timeout = 0;
+
+#ifdef HAVE_SNI
+		if (sslsock->is_client) {
+			enable_client_sni(stream, sslsock);
+		}
+#endif
+
+		if (!sslsock->state_set) {
+			if (sslsock->is_client) {
+				SSL_set_connect_state(sslsock->ssl_handle);
+			} else {
+				SSL_set_accept_state(sslsock->ssl_handle);
+			}
+			sslsock->state_set = 1;
+		}
+
+		if (SUCCESS == php_set_sock_blocking(sslsock->s.socket, 0 TSRMLS_CC)) {
+			sslsock->s.is_blocked = 0;
+		}
+		
+		timeout = sslsock->is_client ? &sslsock->connect_timeout : &sslsock->s.timeout;
+		has_timeout = !sslsock->s.is_blocked && (timeout->tv_sec || timeout->tv_usec);
+		/* gettimeofday is not monotonic; using it here is not strictly correct */
+		if (has_timeout) {
+			gettimeofday(&start_time, NULL);
+		}
+		
+		do {
+			struct timeval	cur_time,
+							elapsed_time = {0};
+			
+			if (sslsock->is_client) {
+				n = SSL_connect(sslsock->ssl_handle);
+			} else {
+				n = SSL_accept(sslsock->ssl_handle);
+			}
+
+			if (has_timeout) {
+				gettimeofday(&cur_time, NULL);
+				elapsed_time = subtract_timeval( cur_time, start_time );
+			
+				if (compare_timeval( elapsed_time, *timeout) > 0) {
+					php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSL: Handshake timed out");
+					return -1;
+				}
+			}
+
+			if (n <= 0) {
+				/* in case of SSL_ERROR_WANT_READ/WRITE, do not retry in non-blocking mode */
+				retry = handle_ssl_error(stream, n, blocked TSRMLS_CC);
+				if (retry) {
+					/* wait until something interesting happens in the socket. It may be a
+					 * timeout. Also consider the unlikely of possibility of a write block  */
+					int err = SSL_get_error(sslsock->ssl_handle, n);
+					struct timeval left_time;
+					
+					if (has_timeout) {
+						left_time = subtract_timeval( *timeout, elapsed_time );
+					}
+					php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_READ) ?
+						(POLLIN|POLLPRI) : POLLOUT, has_timeout ? &left_time : NULL);
+				}
+			} else {
+				retry = 0;
+			}
+		} while (retry);
+
+		if (sslsock->s.is_blocked != blocked && SUCCESS == php_set_sock_blocking(sslsock->s.socket, blocked TSRMLS_CC)) {
+			sslsock->s.is_blocked = blocked;
+		}
+
+		if (n == 1) {
+			peer_cert = SSL_get_peer_certificate(sslsock->ssl_handle);
+			if (peer_cert && stream->context) {
+				cert_captured = capture_peer_certs(stream, sslsock, peer_cert TSRMLS_CC);
+			}
+
+			if (FAILURE == apply_peer_verification_policy(sslsock->ssl_handle, peer_cert, stream TSRMLS_CC)) {
+				SSL_shutdown(sslsock->ssl_handle);
+				n = -1;
+			} else {	
+				sslsock->ssl_active = 1;
+
+				if (stream->context) {
+					zval **val;
+
+					if (SUCCESS == php_stream_context_get_option(stream->context,
+							"ssl", "capture_session_meta", &val) &&
+						zend_is_true(*val)
+					) {
+						zval *meta_arr = capture_session_meta(sslsock->ssl_handle);
+						php_stream_context_set_option(stream->context, "ssl", "session_meta", meta_arr);
+						zval_dtor(meta_arr);
+						efree(meta_arr);
+					}
+				}
+			}
+		} else if (errno == EAGAIN) {
+			n = 0;
+		} else {
+			n = -1;
+			peer_cert = SSL_get_peer_certificate(sslsock->ssl_handle);
+			if (peer_cert && stream->context) {
+				cert_captured = capture_peer_certs(stream, sslsock, peer_cert TSRMLS_CC);
+			}
+		}
+
+		if (n && peer_cert && cert_captured == 0) {
+			X509_free(peer_cert);
+		}
+
+		return n;
+
+	} else if (!cparam->inputs.activate && sslsock->ssl_active) {
+		/* deactivate - common for server/client */
+		SSL_shutdown(sslsock->ssl_handle);
+		sslsock->ssl_active = 0;
+	}
+
+	return -1;
+}
+
+static size_t php_openssl_sockop_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)/* {{{ */
+{
+	return php_openssl_sockop_io(1, stream, buf, count TSRMLS_CC);
+}
+/* }}} */
+
+static size_t php_openssl_sockop_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC) /* {{{ */
+{
+	return php_openssl_sockop_io(0, stream, (char*)buf, count TSRMLS_CC);
+}
+/* }}} */
+
+/**
+ * Factored out common functionality (blocking, timeout, loop management) for read and write.
+ * Perform IO (read or write) to an SSL socket. If we have a timeout, we switch to non-blocking mode
+ * for the duration of the operation, using select to do our waits. If we time out, or we have an error
+ * report that back to PHP
+ *
+ */
+static size_t php_openssl_sockop_io(int read, php_stream *stream, char *buf, size_t count TSRMLS_DC)
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	int nr_bytes = 0;
+
+	/* Only do this if SSL is active. */
+	if (sslsock->ssl_active) {
+		int retry = 1;
+		struct timeval start_time;
+		struct timeval *timeout = NULL;
+		int began_blocked = sslsock->s.is_blocked;
+		int has_timeout = 0;
+
+		/* never use a timeout with non-blocking sockets */
+		if (began_blocked && &sslsock->s.timeout) {
+			timeout = &sslsock->s.timeout;
+		}
+
+		if (timeout && php_set_sock_blocking(sslsock->s.socket, 0 TSRMLS_CC) == SUCCESS) {
+			sslsock->s.is_blocked = 0;
+		}
+
+		if (!sslsock->s.is_blocked && timeout && (timeout->tv_sec || timeout->tv_usec)) {
+			has_timeout = 1;
+			/* gettimeofday is not monotonic; using it here is not strictly correct */
+			gettimeofday(&start_time, NULL);
+		}
+
+		/* Main IO loop. */
+		do {
+			struct timeval cur_time, elapsed_time, left_time;
+	
+			/* If we have a timeout to check, figure out how much time has elapsed since we started. */
+			if (has_timeout) {
+				gettimeofday(&cur_time, NULL);
+
+				/* Determine how much time we've taken so far. */
+				elapsed_time = subtract_timeval(cur_time, start_time);
+
+				/* and return an error if we've taken too long. */
+				if (compare_timeval(elapsed_time, *timeout) > 0 ) {
+					/* If the socket was originally blocking, set it back. */
+					if (began_blocked) {
+						php_set_sock_blocking(sslsock->s.socket, 1 TSRMLS_CC);
+						sslsock->s.is_blocked = 1;
+					}
+					sslsock->s.timeout_event = 1;
+					return -1;
+				}
+			}
+
+			/* Now, do the IO operation. Don't block if we can't complete... */
+			if (read) {
+				nr_bytes = SSL_read(sslsock->ssl_handle, buf, count);
+
+				if (sslsock->reneg && sslsock->reneg->should_close) {
+					/* renegotiation rate limiting triggered */
+					php_stream_xport_shutdown(stream, (stream_shutdown_t)SHUT_RDWR TSRMLS_CC);
+					nr_bytes = 0;
+					stream->eof = 1;
+					break;
+				}
+			} else {
+				nr_bytes = SSL_write(sslsock->ssl_handle, buf, count);
+			}
+
+			/* Now, how much time until we time out? */
+			if (has_timeout) {
+				left_time = subtract_timeval( *timeout, elapsed_time );
+			}
+
+			/* If we didn't do anything on the last loop (or an error) check to see if we should retry or exit. */
+			if (nr_bytes <= 0) {
+
+				/* Get the error code from SSL, and check to see if it's an error or not. */
+				int err = SSL_get_error(sslsock->ssl_handle, nr_bytes );
+				retry = handle_ssl_error(stream, nr_bytes, 0 TSRMLS_CC);
+
+				/* If we get this (the above doesn't check) then we'll retry as well. */
+				if (errno == EAGAIN && err == SSL_ERROR_WANT_READ && read) {
+					retry = 1;
+				}
+				if (errno == EAGAIN && err == SSL_ERROR_WANT_WRITE && read == 0) {
+					retry = 1;
+				}
+
+				/* Also, on reads, we may get this condition on an EOF. We should check properly. */
+				if (read) {
+					stream->eof = (retry == 0 && errno != EAGAIN && !SSL_pending(sslsock->ssl_handle));
+				}
+
+				/* Don't loop indefinitely in non-blocking mode if no data is available */
+				if (began_blocked == 0) {
+					break;
+				}
+
+				/* Now, if we have to wait some time, and we're supposed to be blocking, wait for the socket to become
+				 * available. Now, php_pollfd_for uses select to wait up to our time_left value only...
+				 */
+				if (retry) {
+					if (read) {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_WRITE) ?
+							(POLLOUT|POLLPRI) : (POLLIN|POLLPRI), has_timeout ? &left_time : NULL);
+					} else {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_READ) ?
+							(POLLIN|POLLPRI) : (POLLOUT|POLLPRI), has_timeout ? &left_time : NULL);
+					}
+				}
+			} else {
+				/* Else, if we got bytes back, check for possible errors. */
+				int err = SSL_get_error(sslsock->ssl_handle, nr_bytes);
+
+				/* If we didn't get any error, then let's return it to PHP. */
+				if (err == SSL_ERROR_NONE)
+				break;
+
+				/* Otherwise, we need to wait again (up to time_left or we get an error) */
+				if (began_blocked) {
+					if (read) {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_WRITE) ?
+							(POLLOUT|POLLPRI) : (POLLIN|POLLPRI), has_timeout ? &left_time : NULL);
+					} else {
+						php_pollfd_for(sslsock->s.socket, (err == SSL_ERROR_WANT_READ) ?
+							(POLLIN|POLLPRI) : (POLLOUT|POLLPRI), has_timeout ? &left_time : NULL);
+					}
+				}
+			}
+		/* Finally, we keep going until we got data, and an SSL_ERROR_NONE, unless we had an error. */
+		} while (retry);
+
+		/* Tell PHP if we read / wrote bytes. */
+		if (nr_bytes > 0) {
+			php_stream_notify_progress_increment(stream->context, nr_bytes, 0);
+		}
+
+		/* And if we were originally supposed to be blocking, let's reset the socket to that. */
+		if (began_blocked && php_set_sock_blocking(sslsock->s.socket, 1 TSRMLS_CC) == SUCCESS) {
+			sslsock->s.is_blocked = 1;
+		}
+	} else {
+		/*
+		 * This block is if we had no timeout... We will just sit and wait forever on the IO operation.
+		 */
+		if (read) {
+			nr_bytes = php_stream_socket_ops.read(stream, buf, count TSRMLS_CC);
+		} else {
+			nr_bytes = php_stream_socket_ops.write(stream, buf, count TSRMLS_CC);
+		}
+	}
+
+	/* PHP doesn't expect a negative return. */
+	if (nr_bytes < 0) {
+		nr_bytes = 0;
+	}
+
+	return nr_bytes;
+}
+/* }}} */
+
+struct timeval subtract_timeval( struct timeval a, struct timeval b )
+{
+	struct timeval difference;
+
+	difference.tv_sec  = a.tv_sec  - b.tv_sec;
+	difference.tv_usec = a.tv_usec - b.tv_usec;
+
+	if (a.tv_usec < b.tv_usec) {
+	  	b.tv_sec  -= 1L;
+	   	b.tv_usec += 1000000L;
+	}
+
+	return difference;
+}
+
+int compare_timeval( struct timeval a, struct timeval b )
+{
+	if (a.tv_sec > b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_usec > b.tv_usec) ) {
+		return 1;
+	} else if( a.tv_sec == b.tv_sec && a.tv_usec == b.tv_usec ) {
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int php_openssl_sockop_close(php_stream *stream, int close_handle TSRMLS_DC) /* {{{ */
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+#ifdef PHP_WIN32
+	int n;
+#endif
+	unsigned i;
+
+	if (close_handle) {
+		if (sslsock->ssl_active) {
+			SSL_shutdown(sslsock->ssl_handle);
+			sslsock->ssl_active = 0;
+		}
+		if (sslsock->ssl_handle) {
+			SSL_free(sslsock->ssl_handle);
+			sslsock->ssl_handle = NULL;
+		}
+		if (sslsock->ctx) {
+			SSL_CTX_free(sslsock->ctx);
+			sslsock->ctx = NULL;
+		}
+#ifdef PHP_WIN32
+		if (sslsock->s.socket == -1)
+			sslsock->s.socket = SOCK_ERR;
+#endif
+		if (sslsock->s.socket != SOCK_ERR) {
+#ifdef PHP_WIN32
+			/* prevent more data from coming in */
+			shutdown(sslsock->s.socket, SHUT_RD);
+
+			/* try to make sure that the OS sends all data before we close the connection.
+			 * Essentially, we are waiting for the socket to become writeable, which means
+			 * that all pending data has been sent.
+			 * We use a small timeout which should encourage the OS to send the data,
+			 * but at the same time avoid hanging indefinitely.
+			 * */
+			do {
+				n = php_pollfd_for_ms(sslsock->s.socket, POLLOUT, 500);
+			} while (n == -1 && php_socket_errno() == EINTR);
+#endif
+			closesocket(sslsock->s.socket);
+			sslsock->s.socket = SOCK_ERR;
+		}
+	}
+
+	if (sslsock->sni_certs) {
+		for (i = 0; i < sslsock->sni_cert_count; i++) {
+			if (sslsock->sni_certs[i].ctx) {
+				SSL_CTX_free(sslsock->sni_certs[i].ctx);
+				pefree(sslsock->sni_certs[i].name, php_stream_is_persistent(stream));
+			}
+		}
+		pefree(sslsock->sni_certs, php_stream_is_persistent(stream));
+		sslsock->sni_certs = NULL;
+	}
+
+	if (sslsock->url_name) {
+		pefree(sslsock->url_name, php_stream_is_persistent(stream));
+	}
+
+	if (sslsock->reneg) {
+		pefree(sslsock->reneg, php_stream_is_persistent(stream));
+	}
+
+	pefree(sslsock, php_stream_is_persistent(stream));
+
+	return 0;
+}
+/* }}} */
+
+static int php_openssl_sockop_flush(php_stream *stream TSRMLS_DC) /* {{{ */
+{
+	return php_stream_socket_ops.flush(stream TSRMLS_CC);
+}
+/* }}} */
+
+static int php_openssl_sockop_stat(php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC) /* {{{ */
+{
+	return php_stream_socket_ops.stat(stream, ssb TSRMLS_CC);
+}
+/* }}} */
+
+static inline int php_openssl_tcp_sockop_accept(php_stream *stream, php_openssl_netstream_data_t *sock,
+		php_stream_xport_param *xparam STREAMS_DC TSRMLS_DC)
+{
+	int clisock;
+
+	xparam->outputs.client = NULL;
+
+	clisock = php_network_accept_incoming(sock->s.socket,
+			xparam->want_textaddr ? &xparam->outputs.textaddr : NULL,
+			xparam->want_textaddr ? &xparam->outputs.textaddrlen : NULL,
+			xparam->want_addr ? &xparam->outputs.addr : NULL,
+			xparam->want_addr ? &xparam->outputs.addrlen : NULL,
+			xparam->inputs.timeout,
+			xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+			&xparam->outputs.error_code
+			TSRMLS_CC);
+
+	if (clisock >= 0) {
+		php_openssl_netstream_data_t *clisockdata;
+
+		clisockdata = emalloc(sizeof(*clisockdata));
+
+		if (clisockdata == NULL) {
+			closesocket(clisock);
+			/* technically a fatal error */
+		} else {
+			/* copy underlying tcp fields */
+			memset(clisockdata, 0, sizeof(*clisockdata));
+			memcpy(clisockdata, sock, sizeof(clisockdata->s));
+
+			clisockdata->s.socket = clisock;
+			
+			xparam->outputs.client = php_stream_alloc_rel(stream->ops, clisockdata, NULL, "r+");
+			if (xparam->outputs.client) {
+				xparam->outputs.client->context = stream->context;
+				if (stream->context) {
+					zend_list_addref(stream->context->rsrc_id);
+				}
+			}
+		}
+
+		if (xparam->outputs.client && sock->enable_on_connect) {
+			/* remove the client bit */
+			if (sock->method & STREAM_CRYPTO_IS_CLIENT) {
+				sock->method = ((sock->method >> 1) << 1);
+			}
+
+			clisockdata->method = sock->method;
+
+			if (php_stream_xport_crypto_setup(xparam->outputs.client, clisockdata->method,
+					NULL TSRMLS_CC) < 0 || php_stream_xport_crypto_enable(
+					xparam->outputs.client, 1 TSRMLS_CC) < 0) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to enable crypto");
+
+				php_stream_close(xparam->outputs.client);
+				xparam->outputs.client = NULL;
+				xparam->outputs.returncode = -1;
+			}
+		}
+	}
+	
+	return xparam->outputs.client == NULL ? -1 : 0;
+}
+
+static int php_openssl_sockop_set_option(php_stream *stream, int option, int value, void *ptrparam TSRMLS_DC)
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+	php_stream_xport_crypto_param *cparam = (php_stream_xport_crypto_param *)ptrparam;
+	php_stream_xport_param *xparam = (php_stream_xport_param *)ptrparam;
+
+	switch (option) {
+		case PHP_STREAM_OPTION_CHECK_LIVENESS:
+			{
+				struct timeval tv;
+				char buf;
+				int alive = 1;
+
+				if (value == -1) {
+					if (sslsock->s.timeout.tv_sec == -1) {
+						tv.tv_sec = FG(default_socket_timeout);
+						tv.tv_usec = 0;
+					} else {
+						tv = sslsock->connect_timeout;
+					}
+				} else {
+					tv.tv_sec = value;
+					tv.tv_usec = 0;
+				}
+
+				if (sslsock->s.socket == -1) {
+					alive = 0;
+				} else if (php_pollfd_for(sslsock->s.socket, PHP_POLLREADABLE|POLLPRI, &tv) > 0) {
+					if (sslsock->ssl_active) {
+						int n;
+
+						do {
+							n = SSL_peek(sslsock->ssl_handle, &buf, sizeof(buf));
+							if (n <= 0) {
+								int err = SSL_get_error(sslsock->ssl_handle, n);
+
+								if (err == SSL_ERROR_SYSCALL) {
+									alive = php_socket_errno() == EAGAIN;
+									break;
+								}
+
+								if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+									/* re-negotiate */
+									continue;
+								}
+
+								/* any other problem is a fatal error */
+								alive = 0;
+							}
+							/* either peek succeeded or there was an error; we
+							 * have set the alive flag appropriately */
+							break;
+						} while (1);
+					} else if (0 == recv(sslsock->s.socket, &buf, sizeof(buf), MSG_PEEK) && php_socket_errno() != EAGAIN) {
+						alive = 0;
+					}
+				}
+				return alive ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;
+			}
+			
+		case PHP_STREAM_OPTION_CRYPTO_API:
+
+			switch(cparam->op) {
+
+				case STREAM_XPORT_CRYPTO_OP_SETUP:
+					cparam->outputs.returncode = php_openssl_setup_crypto(stream, sslsock, cparam TSRMLS_CC);
+					return PHP_STREAM_OPTION_RETURN_OK;
+					break;
+				case STREAM_XPORT_CRYPTO_OP_ENABLE:
+					cparam->outputs.returncode = php_openssl_enable_crypto(stream, sslsock, cparam TSRMLS_CC);
+					return PHP_STREAM_OPTION_RETURN_OK;
+					break;
+				default:
+					/* fall through */
+					break;
+			}
+
+			break;
+
+		case PHP_STREAM_OPTION_XPORT_API:
+			switch(xparam->op) {
+
+				case STREAM_XPORT_OP_CONNECT:
+				case STREAM_XPORT_OP_CONNECT_ASYNC:
+					/* TODO: Async connects need to check the enable_on_connect option when
+					 * we notice that the connect has actually been established */
+					php_stream_socket_ops.set_option(stream, option, value, ptrparam TSRMLS_CC);
+
+					if ((sslsock->enable_on_connect) &&
+						((xparam->outputs.returncode == 0) ||
+						(xparam->op == STREAM_XPORT_OP_CONNECT_ASYNC && 
+						xparam->outputs.returncode == 1 && xparam->outputs.error_code == EINPROGRESS)))
+					{
+						if (php_stream_xport_crypto_setup(stream, sslsock->method, NULL TSRMLS_CC) < 0 ||
+								php_stream_xport_crypto_enable(stream, 1 TSRMLS_CC) < 0) {
+							php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to enable crypto");
+							xparam->outputs.returncode = -1;
+						}
+					}
+					return PHP_STREAM_OPTION_RETURN_OK;
+
+				case STREAM_XPORT_OP_ACCEPT:
+					/* we need to copy the additional fields that the underlying tcp transport
+					 * doesn't know about */
+					xparam->outputs.returncode = php_openssl_tcp_sockop_accept(stream, sslsock, xparam STREAMS_CC TSRMLS_CC);
+
+					
+					return PHP_STREAM_OPTION_RETURN_OK;
+
+				default:
+					/* fall through */
+					break;
+			}
+	}
+
+	return php_stream_socket_ops.set_option(stream, option, value, ptrparam TSRMLS_CC);
+}
+
+static int php_openssl_sockop_cast(php_stream *stream, int castas, void **ret TSRMLS_DC)
+{
+	php_openssl_netstream_data_t *sslsock = (php_openssl_netstream_data_t*)stream->abstract;
+
+	switch(castas)	{
+		case PHP_STREAM_AS_STDIO:
+			if (sslsock->ssl_active) {
+				return FAILURE;
+			}
+			if (ret)	{
+				*ret = fdopen(sslsock->s.socket, stream->mode);
+				if (*ret) {
+					return SUCCESS;
+				}
+				return FAILURE;
+			}
+			return SUCCESS;
+
+		case PHP_STREAM_AS_FD_FOR_SELECT:
+			if (ret) {
+				size_t pending;
+				if (stream->writepos == stream->readpos
+					&& sslsock->ssl_active
+					&& (pending = (size_t)SSL_pending(sslsock->ssl_handle)) > 0) {
+						php_stream_fill_read_buffer(stream, pending < stream->chunk_size
+							? pending
+							: stream->chunk_size);
+				}
+
+				*(php_socket_t *)ret = sslsock->s.socket;
+			}
+			return SUCCESS;
+
+		case PHP_STREAM_AS_FD:
+		case PHP_STREAM_AS_SOCKETD:
+			if (sslsock->ssl_active) {
+				return FAILURE;
+			}
+			if (ret) {
+				*(php_socket_t *)ret = sslsock->s.socket;
+			}
+			return SUCCESS;
+		default:
+			return FAILURE;
+	}
+}
+
+php_stream_ops php_openssl_socket_ops = {
+	php_openssl_sockop_write, php_openssl_sockop_read,
+	php_openssl_sockop_close, php_openssl_sockop_flush,
+	"tcp_socket/ssl",
+	NULL, /* seek */
+	php_openssl_sockop_cast,
+	php_openssl_sockop_stat,
+	php_openssl_sockop_set_option,
+};
+
+static long get_crypto_method(php_stream_context *ctx, long crypto_method)
+{
+	zval **val;
+
+	if (ctx && php_stream_context_get_option(ctx, "ssl", "crypto_method", &val) == SUCCESS) {
+		convert_to_long_ex(val);
+		crypto_method = (long)Z_LVAL_PP(val);
+		crypto_method |= STREAM_CRYPTO_IS_CLIENT;
+	}
+
+	return crypto_method;
+}
+
+static char *get_url_name(const char *resourcename, size_t resourcenamelen, int is_persistent TSRMLS_DC)
+{
+	php_url *url;
+
+	if (!resourcename) {
+		return NULL;
+	}
+
+	url = php_url_parse_ex(resourcename, resourcenamelen);
+	if (!url) {
+		return NULL;
+	}
+
+	if (url->host) {
+		const char * host = url->host;
+		char * url_name = NULL;
+		size_t len = strlen(host);
+
+		/* skip trailing dots */
+		while (len && host[len-1] == '.') {
+			--len;
+		}
+
+		if (len) {
+			url_name = pestrndup(host, len, is_persistent);
+		}
+
+		php_url_free(url);
+		return url_name;
+	}
+
+	php_url_free(url);
+	return NULL;
+}
+
+php_stream *php_openssl_ssl_socket_factory(const char *proto, size_t protolen,
+		const char *resourcename, size_t resourcenamelen,
+		const char *persistent_id, int options, int flags,
+		struct timeval *timeout,
+		php_stream_context *context STREAMS_DC TSRMLS_DC)
+{
+	php_stream *stream = NULL;
+	php_openssl_netstream_data_t *sslsock = NULL;
+
+	sslsock = pemalloc(sizeof(php_openssl_netstream_data_t), persistent_id ? 1 : 0);
+	memset(sslsock, 0, sizeof(*sslsock));
+
+	sslsock->s.is_blocked = 1;
+	/* this timeout is used by standard stream funcs, therefor it should use the default value */
+	sslsock->s.timeout.tv_sec = FG(default_socket_timeout);
+	sslsock->s.timeout.tv_usec = 0;
+
+	/* use separate timeout for our private funcs */
+	sslsock->connect_timeout.tv_sec = timeout->tv_sec;
+	sslsock->connect_timeout.tv_usec = timeout->tv_usec;
+
+	/* we don't know the socket until we have determined if we are binding or
+	 * connecting */
+	sslsock->s.socket = -1;
+
+	/* Initialize context as NULL */
+	sslsock->ctx = NULL;	
+
+	stream = php_stream_alloc_rel(&php_openssl_socket_ops, sslsock, persistent_id, "r+");
+
+	if (stream == NULL)	{
+		pefree(sslsock, persistent_id ? 1 : 0);
+		return NULL;
+	}
+
+	if (strncmp(proto, "ssl", protolen) == 0) {
+		sslsock->enable_on_connect = 1;
+		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_ANY_CLIENT);
+	} else if (strncmp(proto, "sslv2", protolen) == 0) {
+#ifdef OPENSSL_NO_SSL2
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSLv2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#else
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_SSLv2_CLIENT;
+#endif
+	} else if (strncmp(proto, "sslv3", protolen) == 0) {
+#ifdef OPENSSL_NO_SSL3
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSLv3 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#else
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_SSLv3_CLIENT;
+#endif
+	} else if (strncmp(proto, "tls", protolen) == 0) {
+		sslsock->enable_on_connect = 1;
+		sslsock->method = get_crypto_method(context, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+	} else if (strncmp(proto, "tlsv1.0", protolen) == 0) {
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+	} else if (strncmp(proto, "tlsv1.1", protolen) == 0) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "TLSv1.1 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	} else if (strncmp(proto, "tlsv1.2", protolen) == 0) {
+#if OPENSSL_VERSION_NUMBER >= 0x10001001L
+		sslsock->enable_on_connect = 1;
+		sslsock->method = STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+#else
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "TLSv1.2 support is not compiled into the OpenSSL library PHP is linked against");
+		return NULL;
+#endif
+	}
+
+	sslsock->url_name = get_url_name(resourcename, resourcenamelen, !!persistent_id TSRMLS_CC);
+
+	return stream;
+}
+
+
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/tests/fixtures/php/5.6.40/ext/phar/util.c
+++ b/tests/fixtures/php/5.6.40/ext/phar/util.c
@@ -1,0 +1,2142 @@
+/*
+  +----------------------------------------------------------------------+
+  | phar php single-file executable PHP extension                        |
+  | utility functions                                                    |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2005-2016 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Gregory Beaver <cellog@php.net>                             |
+  |          Marcus Boerger <helly@php.net>                              |
+  +----------------------------------------------------------------------+
+*/
+
+/* $Id$ */
+
+#include "phar_internal.h"
+#ifdef PHAR_HASH_OK
+#include "ext/hash/php_hash_sha.h"
+#endif
+
+#ifdef PHAR_HAVE_OPENSSL
+/* OpenSSL includes */
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/crypto.h>
+#include <openssl/pem.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+#include <openssl/pkcs12.h>
+#else
+static int phar_call_openssl_signverify(int is_sign, php_stream *fp, off_t end, char *key, int key_len, char **signature, int *signature_len TSRMLS_DC);
+#endif
+
+/* for links to relative location, prepend cwd of the entry */
+static char *phar_get_link_location(phar_entry_info *entry TSRMLS_DC) /* {{{ */
+{
+	char *p, *ret = NULL;
+	if (!entry->link) {
+		return NULL;
+	}
+	if (entry->link[0] == '/') {
+		return estrdup(entry->link + 1);
+	}
+	p = strrchr(entry->filename, '/');
+	if (p) {
+		*p = '\0';
+		spprintf(&ret, 0, "%s/%s", entry->filename, entry->link);
+		return ret;
+	}
+	return entry->link;
+}
+/* }}} */
+
+phar_entry_info *phar_get_link_source(phar_entry_info *entry TSRMLS_DC) /* {{{ */
+{
+	phar_entry_info *link_entry;
+	char *link;
+
+	if (!entry->link) {
+		return entry;
+	}
+
+	link = phar_get_link_location(entry TSRMLS_CC);
+	if (SUCCESS == zend_hash_find(&(entry->phar->manifest), entry->link, strlen(entry->link), (void **)&link_entry) ||
+		SUCCESS == zend_hash_find(&(entry->phar->manifest), link, strlen(link), (void **)&link_entry)) {
+		if (link != entry->link) {
+			efree(link);
+		}
+		return phar_get_link_source(link_entry TSRMLS_CC);
+	} else {
+		if (link != entry->link) {
+			efree(link);
+		}
+		return NULL;
+	}
+}
+/* }}} */
+
+/* retrieve a phar_entry_info's current file pointer for reading contents */
+php_stream *phar_get_efp(phar_entry_info *entry, int follow_links TSRMLS_DC) /* {{{ */
+{
+	if (follow_links && entry->link) {
+		phar_entry_info *link_entry = phar_get_link_source(entry TSRMLS_CC);
+
+		if (link_entry && link_entry != entry) {
+			return phar_get_efp(link_entry, 1 TSRMLS_CC);
+		}
+	}
+
+	if (phar_get_fp_type(entry TSRMLS_CC) == PHAR_FP) {
+		if (!phar_get_entrypfp(entry TSRMLS_CC)) {
+			/* re-open just in time for cases where our refcount reached 0 on the phar archive */
+			phar_open_archive_fp(entry->phar TSRMLS_CC);
+		}
+		return phar_get_entrypfp(entry TSRMLS_CC);
+	} else if (phar_get_fp_type(entry TSRMLS_CC) == PHAR_UFP) {
+		return phar_get_entrypufp(entry TSRMLS_CC);
+	} else if (entry->fp_type == PHAR_MOD) {
+		return entry->fp;
+	} else {
+		/* temporary manifest entry */
+		if (!entry->fp) {
+			entry->fp = php_stream_open_wrapper(entry->tmp, "rb", STREAM_MUST_SEEK|0, NULL);
+		}
+		return entry->fp;
+	}
+}
+/* }}} */
+
+int phar_seek_efp(phar_entry_info *entry, off_t offset, int whence, off_t position, int follow_links TSRMLS_DC) /* {{{ */
+{
+	php_stream *fp = phar_get_efp(entry, follow_links TSRMLS_CC);
+	off_t temp, eoffset;
+
+	if (!fp) {
+		return -1;
+	}
+
+	if (follow_links) {
+		phar_entry_info *t;
+		t = phar_get_link_source(entry TSRMLS_CC);
+		if (t) {
+			entry = t;
+		}
+	}
+
+	if (entry->is_dir) {
+		return 0;
+	}
+
+	eoffset = phar_get_fp_offset(entry TSRMLS_CC);
+
+	switch (whence) {
+		case SEEK_END:
+			temp = eoffset + entry->uncompressed_filesize + offset;
+			break;
+		case SEEK_CUR:
+			temp = eoffset + position + offset;
+			break;
+		case SEEK_SET:
+			temp = eoffset + offset;
+			break;
+		default:
+			temp = 0;
+	}
+
+	if (temp > eoffset + (off_t) entry->uncompressed_filesize) {
+		return -1;
+	}
+
+	if (temp < eoffset) {
+		return -1;
+	}
+
+	return php_stream_seek(fp, temp, SEEK_SET);
+}
+/* }}} */
+
+/* mount an absolute path or uri to a path internal to the phar archive */
+int phar_mount_entry(phar_archive_data *phar, char *filename, int filename_len, char *path, int path_len TSRMLS_DC) /* {{{ */
+{
+	phar_entry_info entry = {0};
+	php_stream_statbuf ssb;
+	int is_phar;
+	const char *err;
+
+	if (phar_path_check(&path, &path_len, &err) > pcr_is_ok) {
+		return FAILURE;
+	}
+
+	if (path_len >= sizeof(".phar")-1 && !memcmp(path, ".phar", sizeof(".phar")-1)) {
+		/* no creating magic phar files by mounting them */
+		return FAILURE;
+	}
+
+	is_phar = (filename_len > 7 && !memcmp(filename, "phar://", 7));
+
+	entry.phar = phar;
+	entry.filename = estrndup(path, path_len);
+#ifdef PHP_WIN32
+	phar_unixify_path_separators(entry.filename, path_len);
+#endif
+	entry.filename_len = path_len;
+	if (is_phar) {
+		entry.tmp = estrndup(filename, filename_len);
+	} else {
+		entry.tmp = expand_filepath(filename, NULL TSRMLS_CC);
+		if (!entry.tmp) {
+			entry.tmp = estrndup(filename, filename_len);
+		}
+	}
+#if PHP_API_VERSION < 20100412
+	if (PG(safe_mode) && !is_phar && (!php_checkuid(entry.tmp, NULL, CHECKUID_CHECK_FILE_AND_DIR))) {
+		efree(entry.tmp);
+		efree(entry.filename);
+		return FAILURE;
+	}
+#endif
+	filename = entry.tmp;
+
+	/* only check openbasedir for files, not for phar streams */
+	if (!is_phar && php_check_open_basedir(filename TSRMLS_CC)) {
+		efree(entry.tmp);
+		efree(entry.filename);
+		return FAILURE;
+	}
+
+	entry.is_mounted = 1;
+	entry.is_crc_checked = 1;
+	entry.fp_type = PHAR_TMP;
+
+	if (SUCCESS != php_stream_stat_path(filename, &ssb)) {
+		efree(entry.tmp);
+		efree(entry.filename);
+		return FAILURE;
+	}
+
+	if (ssb.sb.st_mode & S_IFDIR) {
+		entry.is_dir = 1;
+		if (SUCCESS != zend_hash_add(&phar->mounted_dirs, entry.filename, path_len, (void *)&(entry.filename), sizeof(char *), NULL)) {
+			/* directory already mounted */
+			efree(entry.tmp);
+			efree(entry.filename);
+			return FAILURE;
+		}
+	} else {
+		entry.is_dir = 0;
+		entry.uncompressed_filesize = entry.compressed_filesize = ssb.sb.st_size;
+	}
+
+	entry.flags = ssb.sb.st_mode;
+
+	if (SUCCESS == zend_hash_add(&phar->manifest, entry.filename, path_len, (void*)&entry, sizeof(phar_entry_info), NULL)) {
+		return SUCCESS;
+	}
+
+	efree(entry.tmp);
+	efree(entry.filename);
+	return FAILURE;
+}
+/* }}} */
+
+char *phar_find_in_include_path(char *filename, int filename_len, phar_archive_data **pphar TSRMLS_DC) /* {{{ */
+{
+	char *path, *fname, *arch, *entry, *ret, *test;
+	int arch_len, entry_len, fname_len, ret_len;
+	phar_archive_data *phar;
+
+	if (pphar) {
+		*pphar = NULL;
+	} else {
+		pphar = &phar;
+	}
+
+	if (!zend_is_executing(TSRMLS_C) || !PHAR_G(cwd)) {
+		return phar_save_resolve_path(filename, filename_len TSRMLS_CC);
+	}
+
+	fname = (char*)zend_get_executed_filename(TSRMLS_C);
+	fname_len = strlen(fname);
+
+	if (PHAR_G(last_phar) && !memcmp(fname, "phar://", 7) && fname_len - 7 >= PHAR_G(last_phar_name_len) && !memcmp(fname + 7, PHAR_G(last_phar_name), PHAR_G(last_phar_name_len))) {
+		arch = estrndup(PHAR_G(last_phar_name), PHAR_G(last_phar_name_len));
+		arch_len = PHAR_G(last_phar_name_len);
+		phar = PHAR_G(last_phar);
+		goto splitted;
+	}
+
+	if (fname_len < 7 || memcmp(fname, "phar://", 7) || SUCCESS != phar_split_fname(fname, strlen(fname), &arch, &arch_len, &entry, &entry_len, 1, 0 TSRMLS_CC)) {
+		return phar_save_resolve_path(filename, filename_len TSRMLS_CC);
+	}
+
+	efree(entry);
+
+	if (*filename == '.') {
+		int try_len;
+
+		if (FAILURE == phar_get_archive(&phar, arch, arch_len, NULL, 0, NULL TSRMLS_CC)) {
+			efree(arch);
+			return phar_save_resolve_path(filename, filename_len TSRMLS_CC);
+		}
+splitted:
+		if (pphar) {
+			*pphar = phar;
+		}
+
+		try_len = filename_len;
+		test = phar_fix_filepath(estrndup(filename, filename_len), &try_len, 1 TSRMLS_CC);
+
+		if (*test == '/') {
+			if (zend_hash_exists(&(phar->manifest), test + 1, try_len - 1)) {
+				spprintf(&ret, 0, "phar://%s%s", arch, test);
+				efree(arch);
+				efree(test);
+				return ret;
+			}
+		} else {
+			if (zend_hash_exists(&(phar->manifest), test, try_len)) {
+				spprintf(&ret, 0, "phar://%s/%s", arch, test);
+				efree(arch);
+				efree(test);
+				return ret;
+			}
+		}
+		efree(test);
+	}
+
+	spprintf(&path, MAXPATHLEN, "phar://%s/%s%c%s", arch, PHAR_G(cwd), DEFAULT_DIR_SEPARATOR, PG(include_path));
+	efree(arch);
+	ret = php_resolve_path(filename, filename_len, path TSRMLS_CC);
+	efree(path);
+
+	if (ret && strlen(ret) > 8 && !strncmp(ret, "phar://", 7)) {
+		ret_len = strlen(ret);
+		/* found phar:// */
+
+		if (SUCCESS != phar_split_fname(ret, ret_len, &arch, &arch_len, &entry, &entry_len, 1, 0 TSRMLS_CC)) {
+			return ret;
+		}
+
+		zend_hash_find(&(PHAR_GLOBALS->phar_fname_map), arch, arch_len, (void **) &pphar);
+
+		if (!pphar && PHAR_G(manifest_cached)) {
+			zend_hash_find(&cached_phars, arch, arch_len, (void **) &pphar);
+		}
+
+		efree(arch);
+		efree(entry);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/**
+ * Retrieve a copy of the file information on a single file within a phar, or null.
+ * This also transfers the open file pointer, if any, to the entry.
+ *
+ * If the file does not already exist, this will fail.  Pre-existing files can be
+ * appended, truncated, or read.  For read, if the entry is marked unmodified, it is
+ * assumed that the file pointer, if present, is opened for reading
+ */
+int phar_get_entry_data(phar_entry_data **ret, char *fname, int fname_len, char *path, int path_len, const char *mode, char allow_dir, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *phar;
+	phar_entry_info *entry;
+	int for_write  = mode[0] != 'r' || mode[1] == '+';
+	int for_append = mode[0] == 'a';
+	int for_create = mode[0] != 'r';
+	int for_trunc  = mode[0] == 'w';
+
+	if (!ret) {
+		return FAILURE;
+	}
+
+	*ret = NULL;
+
+	if (error) {
+		*error = NULL;
+	}
+
+	if (FAILURE == phar_get_archive(&phar, fname, fname_len, NULL, 0, error TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (for_write && PHAR_G(readonly) && !phar->is_data) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for writing, disabled by ini setting", path, fname);
+		}
+		return FAILURE;
+	}
+
+	if (!path_len) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"\" in phar \"%s\" cannot be empty", fname);
+		}
+		return FAILURE;
+	}
+really_get_entry:
+	if (allow_dir) {
+		if ((entry = phar_get_entry_info_dir(phar, path, path_len, allow_dir, for_create && !PHAR_G(readonly) && !phar->is_data ? NULL : error, security TSRMLS_CC)) == NULL) {
+			if (for_create && (!PHAR_G(readonly) || phar->is_data)) {
+				return SUCCESS;
+			}
+			return FAILURE;
+		}
+	} else {
+		if ((entry = phar_get_entry_info(phar, path, path_len, for_create && !PHAR_G(readonly) && !phar->is_data ? NULL : error, security TSRMLS_CC)) == NULL) {
+			if (for_create && (!PHAR_G(readonly) || phar->is_data)) {
+				return SUCCESS;
+			}
+			return FAILURE;
+		}
+	}
+
+	if (for_write && phar->is_persistent) {
+		if (FAILURE == phar_copy_on_write(&phar TSRMLS_CC)) {
+			if (error) {
+				spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for writing, could not make cached phar writeable", path, fname);
+			}
+			return FAILURE;
+		} else {
+			goto really_get_entry;
+		}
+	}
+
+	if (entry->is_modified && !for_write) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for reading, writable file pointers are open", path, fname);
+		}
+		return FAILURE;
+	}
+
+	if (entry->fp_refcount && for_write) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be opened for writing, readable file pointers are open", path, fname);
+		}
+		return FAILURE;
+	}
+
+	if (entry->is_deleted) {
+		if (!for_create) {
+			return FAILURE;
+		}
+		entry->is_deleted = 0;
+	}
+
+	if (entry->is_dir) {
+		*ret = (phar_entry_data *) emalloc(sizeof(phar_entry_data));
+		(*ret)->position = 0;
+		(*ret)->fp = NULL;
+		(*ret)->phar = phar;
+		(*ret)->for_write = for_write;
+		(*ret)->internal_file = entry;
+		(*ret)->is_zip = entry->is_zip;
+		(*ret)->is_tar = entry->is_tar;
+
+		if (!phar->is_persistent) {
+			++(entry->phar->refcount);
+			++(entry->fp_refcount);
+		}
+
+		return SUCCESS;
+	}
+
+	if (entry->fp_type == PHAR_MOD) {
+		if (for_trunc) {
+			if (FAILURE == phar_create_writeable_entry(phar, entry, error TSRMLS_CC)) {
+				return FAILURE;
+			}
+		} else if (for_append) {
+			phar_seek_efp(entry, 0, SEEK_END, 0, 0 TSRMLS_CC);
+		}
+	} else {
+		if (for_write) {
+			if (entry->link) {
+				efree(entry->link);
+				entry->link = NULL;
+				entry->tar_type = (entry->is_tar ? TAR_FILE : '\0');
+			}
+
+			if (for_trunc) {
+				if (FAILURE == phar_create_writeable_entry(phar, entry, error TSRMLS_CC)) {
+					return FAILURE;
+				}
+			} else {
+				if (FAILURE == phar_separate_entry_fp(entry, error TSRMLS_CC)) {
+					return FAILURE;
+				}
+			}
+		} else {
+			if (FAILURE == phar_open_entry_fp(entry, error, 1 TSRMLS_CC)) {
+				return FAILURE;
+			}
+		}
+	}
+
+	*ret = (phar_entry_data *) emalloc(sizeof(phar_entry_data));
+	(*ret)->position = 0;
+	(*ret)->phar = phar;
+	(*ret)->for_write = for_write;
+	(*ret)->internal_file = entry;
+	(*ret)->is_zip = entry->is_zip;
+	(*ret)->is_tar = entry->is_tar;
+	(*ret)->fp = phar_get_efp(entry, 1 TSRMLS_CC);
+	if (entry->link) {
+		phar_entry_info *link = phar_get_link_source(entry TSRMLS_CC);
+		if(!link) {
+			efree(*ret);
+			return FAILURE;
+		}
+		(*ret)->zero = phar_get_fp_offset(link TSRMLS_CC);
+	} else {
+		(*ret)->zero = phar_get_fp_offset(entry TSRMLS_CC);
+	}
+
+	if (!phar->is_persistent) {
+		++(entry->fp_refcount);
+		++(entry->phar->refcount);
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/**
+ * Create a new dummy file slot within a writeable phar for a newly created file
+ */
+phar_entry_data *phar_get_or_create_entry_data(char *fname, int fname_len, char *path, int path_len, const char *mode, char allow_dir, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *phar;
+	phar_entry_info *entry, etemp;
+	phar_entry_data *ret;
+	const char *pcr_error;
+	char is_dir;
+
+#ifdef PHP_WIN32
+	phar_unixify_path_separators(path, path_len);
+#endif
+
+	is_dir = (path_len && path[path_len - 1] == '/') ? 1 : 0;
+
+	if (FAILURE == phar_get_archive(&phar, fname, fname_len, NULL, 0, error TSRMLS_CC)) {
+		return NULL;
+	}
+
+	if (FAILURE == phar_get_entry_data(&ret, fname, fname_len, path, path_len, mode, allow_dir, error, security TSRMLS_CC)) {
+		return NULL;
+	} else if (ret) {
+		return ret;
+	}
+
+	if (phar_path_check(&path, &path_len, &pcr_error) > pcr_is_ok) {
+		if (error) {
+			spprintf(error, 0, "phar error: invalid path \"%s\" contains %s", path, pcr_error);
+		}
+		return NULL;
+	}
+
+	if (phar->is_persistent && FAILURE == phar_copy_on_write(&phar TSRMLS_CC)) {
+		if (error) {
+			spprintf(error, 4096, "phar error: file \"%s\" in phar \"%s\" cannot be created, could not make cached phar writeable", path, fname);
+		}
+		return NULL;
+	}
+
+	/* create a new phar data holder */
+	ret = (phar_entry_data *) emalloc(sizeof(phar_entry_data));
+
+	/* create an entry, this is a new file */
+	memset(&etemp, 0, sizeof(phar_entry_info));
+	etemp.filename_len = path_len;
+	etemp.fp_type = PHAR_MOD;
+	etemp.fp = php_stream_fopen_tmpfile();
+
+	if (!etemp.fp) {
+		if (error) {
+			spprintf(error, 0, "phar error: unable to create temporary file");
+		}
+		efree(ret);
+		return NULL;
+	}
+
+	etemp.fp_refcount = 1;
+
+	if (allow_dir == 2) {
+		etemp.is_dir = 1;
+		etemp.flags = etemp.old_flags = PHAR_ENT_PERM_DEF_DIR;
+	} else {
+		etemp.flags = etemp.old_flags = PHAR_ENT_PERM_DEF_FILE;
+	}
+	if (is_dir) {
+		etemp.filename_len--; /* strip trailing / */
+		path_len--;
+	}
+
+	phar_add_virtual_dirs(phar, path, path_len TSRMLS_CC);
+	etemp.is_modified = 1;
+	etemp.timestamp = time(0);
+	etemp.is_crc_checked = 1;
+	etemp.phar = phar;
+	etemp.filename = estrndup(path, path_len);
+	etemp.is_zip = phar->is_zip;
+
+	if (phar->is_tar) {
+		etemp.is_tar = phar->is_tar;
+		etemp.tar_type = etemp.is_dir ? TAR_DIR : TAR_FILE;
+	}
+
+	if (FAILURE == zend_hash_add(&phar->manifest, etemp.filename, path_len, (void*)&etemp, sizeof(phar_entry_info), (void **) &entry)) {
+		php_stream_close(etemp.fp);
+		if (error) {
+			spprintf(error, 0, "phar error: unable to add new entry \"%s\" to phar \"%s\"", etemp.filename, phar->fname);
+		}
+		efree(ret);
+		efree(etemp.filename);
+		return NULL;
+	}
+
+	if (!entry) {
+		php_stream_close(etemp.fp);
+		efree(etemp.filename);
+		efree(ret);
+		return NULL;
+	}
+
+	++(phar->refcount);
+	ret->phar = phar;
+	ret->fp = entry->fp;
+	ret->position = ret->zero = 0;
+	ret->for_write = 1;
+	ret->is_zip = entry->is_zip;
+	ret->is_tar = entry->is_tar;
+	ret->internal_file = entry;
+
+	return ret;
+}
+/* }}} */
+
+/* initialize a phar_archive_data's read-only fp for existing phar data */
+int phar_open_archive_fp(phar_archive_data *phar TSRMLS_DC) /* {{{ */
+{
+	if (phar_get_pharfp(phar TSRMLS_CC)) {
+		return SUCCESS;
+	}
+
+	if (php_check_open_basedir(phar->fname TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	phar_set_pharfp(phar, php_stream_open_wrapper(phar->fname, "rb", IGNORE_URL|STREAM_MUST_SEEK|0, NULL) TSRMLS_CC);
+
+	if (!phar_get_pharfp(phar TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* copy file data from an existing to a new phar_entry_info that is not in the manifest */
+int phar_copy_entry_fp(phar_entry_info *source, phar_entry_info *dest, char **error TSRMLS_DC) /* {{{ */
+{
+	phar_entry_info *link;
+
+	if (FAILURE == phar_open_entry_fp(source, error, 1 TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (dest->link) {
+		efree(dest->link);
+		dest->link = NULL;
+		dest->tar_type = (dest->is_tar ? TAR_FILE : '\0');
+	}
+
+	dest->fp_type = PHAR_MOD;
+	dest->offset = 0;
+	dest->is_modified = 1;
+	dest->fp = php_stream_fopen_tmpfile();
+	if (dest->fp == NULL) {
+		spprintf(error, 0, "phar error: unable to create temporary file");
+		return EOF;
+	}
+	phar_seek_efp(source, 0, SEEK_SET, 0, 1 TSRMLS_CC);
+	link = phar_get_link_source(source TSRMLS_CC);
+
+	if (!link) {
+		link = source;
+	}
+
+	if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(link, 0 TSRMLS_CC), dest->fp, link->uncompressed_filesize, NULL)) {
+		php_stream_close(dest->fp);
+		dest->fp_type = PHAR_FP;
+		if (error) {
+			spprintf(error, 4096, "phar error: unable to copy contents of file \"%s\" to \"%s\" in phar archive \"%s\"", source->filename, dest->filename, source->phar->fname);
+		}
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* open and decompress a compressed phar entry
+ */
+int phar_open_entry_fp(phar_entry_info *entry, char **error, int follow_links TSRMLS_DC) /* {{{ */
+{
+	php_stream_filter *filter;
+	phar_archive_data *phar = entry->phar;
+	char *filtername;
+	off_t loc;
+	php_stream *ufp;
+	phar_entry_data dummy;
+
+	if (follow_links && entry->link) {
+		phar_entry_info *link_entry = phar_get_link_source(entry TSRMLS_CC);
+		if (link_entry && link_entry != entry) {
+			return phar_open_entry_fp(link_entry, error, 1 TSRMLS_CC);
+		}
+	}
+
+	if (entry->is_modified) {
+		return SUCCESS;
+	}
+
+	if (entry->fp_type == PHAR_TMP) {
+		if (!entry->fp) {
+			entry->fp = php_stream_open_wrapper(entry->tmp, "rb", STREAM_MUST_SEEK|0, NULL);
+		}
+		return SUCCESS;
+	}
+
+	if (entry->fp_type != PHAR_FP) {
+		/* either newly created or already modified */
+		return SUCCESS;
+	}
+
+	if (!phar_get_pharfp(phar TSRMLS_CC)) {
+		if (FAILURE == phar_open_archive_fp(phar TSRMLS_CC)) {
+			spprintf(error, 4096, "phar error: Cannot open phar archive \"%s\" for reading", phar->fname);
+			return FAILURE;
+		}
+	}
+
+	if ((entry->old_flags && !(entry->old_flags & PHAR_ENT_COMPRESSION_MASK)) || !(entry->flags & PHAR_ENT_COMPRESSION_MASK)) {
+		dummy.internal_file = entry;
+		dummy.phar = phar;
+		dummy.zero = entry->offset;
+		dummy.fp = phar_get_pharfp(phar TSRMLS_CC);
+		if (FAILURE == phar_postprocess_file(&dummy, entry->crc32, error, 1 TSRMLS_CC)) {
+			return FAILURE;
+		}
+		return SUCCESS;
+	}
+
+	if (!phar_get_entrypufp(entry TSRMLS_CC)) {
+		phar_set_entrypufp(entry, php_stream_fopen_tmpfile() TSRMLS_CC);
+		if (!phar_get_entrypufp(entry TSRMLS_CC)) {
+			spprintf(error, 4096, "phar error: Cannot open temporary file for decompressing phar archive \"%s\" file \"%s\"", phar->fname, entry->filename);
+			return FAILURE;
+		}
+	}
+
+	dummy.internal_file = entry;
+	dummy.phar = phar;
+	dummy.zero = entry->offset;
+	dummy.fp = phar_get_pharfp(phar TSRMLS_CC);
+	if (FAILURE == phar_postprocess_file(&dummy, entry->crc32, error, 1 TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	ufp = phar_get_entrypufp(entry TSRMLS_CC);
+
+	if ((filtername = phar_decompress_filter(entry, 0)) != NULL) {
+		filter = php_stream_filter_create(filtername, NULL, 0 TSRMLS_CC);
+	} else {
+		filter = NULL;
+	}
+
+	if (!filter) {
+		spprintf(error, 4096, "phar error: unable to read phar \"%s\" (cannot create %s filter while decompressing file \"%s\")", phar->fname, phar_decompress_filter(entry, 1), entry->filename);
+		return FAILURE;
+	}
+
+	/* now we can safely use proper decompression */
+	/* save the new offset location within ufp */
+	php_stream_seek(ufp, 0, SEEK_END);
+	loc = php_stream_tell(ufp);
+	php_stream_filter_append(&ufp->writefilters, filter);
+	php_stream_seek(phar_get_entrypfp(entry TSRMLS_CC), phar_get_fp_offset(entry TSRMLS_CC), SEEK_SET);
+
+	if (entry->uncompressed_filesize) {
+		if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_entrypfp(entry TSRMLS_CC), ufp, entry->compressed_filesize, NULL)) {
+			spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", phar->fname, entry->filename);
+			php_stream_filter_remove(filter, 1 TSRMLS_CC);
+			return FAILURE;
+		}
+	}
+
+	php_stream_filter_flush(filter, 1);
+	php_stream_flush(ufp);
+	php_stream_filter_remove(filter, 1 TSRMLS_CC);
+
+	if (php_stream_tell(ufp) - loc != (off_t) entry->uncompressed_filesize) {
+		spprintf(error, 4096, "phar error: internal corruption of phar \"%s\" (actual filesize mismatch on file \"%s\")", phar->fname, entry->filename);
+		return FAILURE;
+	}
+
+	entry->old_flags = entry->flags;
+
+	/* this is now the new location of the file contents within this fp */
+	phar_set_fp_type(entry, PHAR_UFP, loc TSRMLS_CC);
+	dummy.zero = entry->offset;
+	dummy.fp = ufp;
+	if (FAILURE == phar_postprocess_file(&dummy, entry->crc32, error, 0 TSRMLS_CC)) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+int phar_create_writeable_entry(phar_archive_data *phar, phar_entry_info *entry, char **error TSRMLS_DC) /* {{{ */
+{
+	if (entry->fp_type == PHAR_MOD) {
+		/* already newly created, truncate */
+		php_stream_truncate_set_size(entry->fp, 0);
+
+		entry->old_flags = entry->flags;
+		entry->is_modified = 1;
+		phar->is_modified = 1;
+		/* reset file size */
+		entry->uncompressed_filesize = 0;
+		entry->compressed_filesize = 0;
+		entry->crc32 = 0;
+		entry->flags = PHAR_ENT_PERM_DEF_FILE;
+		entry->fp_type = PHAR_MOD;
+		entry->offset = 0;
+		return SUCCESS;
+	}
+
+	if (error) {
+		*error = NULL;
+	}
+
+	/* open a new temp file for writing */
+	if (entry->link) {
+		efree(entry->link);
+		entry->link = NULL;
+		entry->tar_type = (entry->is_tar ? TAR_FILE : '\0');
+	}
+
+	entry->fp = php_stream_fopen_tmpfile();
+
+	if (!entry->fp) {
+		if (error) {
+			spprintf(error, 0, "phar error: unable to create temporary file");
+		}
+		return FAILURE;
+	}
+
+	entry->old_flags = entry->flags;
+	entry->is_modified = 1;
+	phar->is_modified = 1;
+	/* reset file size */
+	entry->uncompressed_filesize = 0;
+	entry->compressed_filesize = 0;
+	entry->crc32 = 0;
+	entry->flags = PHAR_ENT_PERM_DEF_FILE;
+	entry->fp_type = PHAR_MOD;
+	entry->offset = 0;
+	return SUCCESS;
+}
+/* }}} */
+
+int phar_separate_entry_fp(phar_entry_info *entry, char **error TSRMLS_DC) /* {{{ */
+{
+	php_stream *fp;
+	phar_entry_info *link;
+
+	if (FAILURE == phar_open_entry_fp(entry, error, 1 TSRMLS_CC)) {
+		return FAILURE;
+	}
+
+	if (entry->fp_type == PHAR_MOD) {
+		return SUCCESS;
+	}
+
+	fp = php_stream_fopen_tmpfile();
+	if (fp == NULL) {
+		spprintf(error, 0, "phar error: unable to create temporary file");
+		return FAILURE;
+	}
+	phar_seek_efp(entry, 0, SEEK_SET, 0, 1 TSRMLS_CC);
+	link = phar_get_link_source(entry TSRMLS_CC);
+
+	if (!link) {
+		link = entry;
+	}
+
+	if (SUCCESS != php_stream_copy_to_stream_ex(phar_get_efp(link, 0 TSRMLS_CC), fp, link->uncompressed_filesize, NULL)) {
+		if (error) {
+			spprintf(error, 4096, "phar error: cannot separate entry file \"%s\" contents in phar archive \"%s\" for write access", entry->filename, entry->phar->fname);
+		}
+		return FAILURE;
+	}
+
+	if (entry->link) {
+		efree(entry->link);
+		entry->link = NULL;
+		entry->tar_type = (entry->is_tar ? TAR_FILE : '\0');
+	}
+
+	entry->offset = 0;
+	entry->fp = fp;
+	entry->fp_type = PHAR_MOD;
+	entry->is_modified = 1;
+	return SUCCESS;
+}
+/* }}} */
+
+/**
+ * helper function to open an internal file's fp just-in-time
+ */
+phar_entry_info * phar_open_jit(phar_archive_data *phar, phar_entry_info *entry, char **error TSRMLS_DC) /* {{{ */
+{
+	if (error) {
+		*error = NULL;
+	}
+	/* seek to start of internal file and read it */
+	if (FAILURE == phar_open_entry_fp(entry, error, 1 TSRMLS_CC)) {
+		return NULL;
+	}
+	if (-1 == phar_seek_efp(entry, 0, SEEK_SET, 0, 1 TSRMLS_CC)) {
+		spprintf(error, 4096, "phar error: cannot seek to start of file \"%s\" in phar \"%s\"", entry->filename, phar->fname);
+		return NULL;
+	}
+	return entry;
+}
+/* }}} */
+
+PHP_PHAR_API int phar_resolve_alias(char *alias, int alias_len, char **filename, int *filename_len TSRMLS_DC) /* {{{ */ {
+	phar_archive_data **fd_ptr;
+	if (PHAR_GLOBALS->phar_alias_map.arBuckets
+			&& SUCCESS == zend_hash_find(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, (void**)&fd_ptr)) {
+		*filename = (*fd_ptr)->fname;
+		*filename_len = (*fd_ptr)->fname_len;
+		return SUCCESS;
+	}
+	return FAILURE;
+}
+/* }}} */
+
+int phar_free_alias(phar_archive_data *phar, char *alias, int alias_len TSRMLS_DC) /* {{{ */
+{
+	if (phar->refcount || phar->is_persistent) {
+		return FAILURE;
+	}
+
+	/* this archive has no open references, so emit an E_STRICT and remove it */
+	if (zend_hash_del(&(PHAR_GLOBALS->phar_fname_map), phar->fname, phar->fname_len) != SUCCESS) {
+		return FAILURE;
+	}
+
+	/* invalidate phar cache */
+	PHAR_G(last_phar) = NULL;
+	PHAR_G(last_phar_name) = PHAR_G(last_alias) = NULL;
+
+	return SUCCESS;
+}
+/* }}} */
+
+/**
+ * Looks up a phar archive in the filename map, connecting it to the alias
+ * (if any) or returns null
+ */
+int phar_get_archive(phar_archive_data **archive, char *fname, int fname_len, char *alias, int alias_len, char **error TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *fd, **fd_ptr;
+	char *my_realpath, *save;
+	int save_len;
+	ulong fhash, ahash = 0;
+
+	phar_request_initialize(TSRMLS_C);
+
+	if (error) {
+		*error = NULL;
+	}
+
+	*archive = NULL;
+
+	if (PHAR_G(last_phar) && fname_len == PHAR_G(last_phar_name_len) && !memcmp(fname, PHAR_G(last_phar_name), fname_len)) {
+		*archive = PHAR_G(last_phar);
+		if (alias && alias_len) {
+
+			if (!PHAR_G(last_phar)->is_temporary_alias && (alias_len != PHAR_G(last_phar)->alias_len || memcmp(PHAR_G(last_phar)->alias, alias, alias_len))) {
+				if (error) {
+					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, PHAR_G(last_phar)->fname, fname);
+				}
+				*archive = NULL;
+				return FAILURE;
+			}
+
+			if (PHAR_G(last_phar)->alias_len && SUCCESS == zend_hash_find(&(PHAR_GLOBALS->phar_alias_map), PHAR_G(last_phar)->alias, PHAR_G(last_phar)->alias_len, (void**)&fd_ptr)) {
+				zend_hash_del(&(PHAR_GLOBALS->phar_alias_map), PHAR_G(last_phar)->alias, PHAR_G(last_phar)->alias_len);
+			}
+
+			zend_hash_add(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, (void*)&(*archive), sizeof(phar_archive_data*), NULL);
+			PHAR_G(last_alias) = alias;
+			PHAR_G(last_alias_len) = alias_len;
+		}
+
+		return SUCCESS;
+	}
+
+	if (alias && alias_len && PHAR_G(last_phar) && alias_len == PHAR_G(last_alias_len) && !memcmp(alias, PHAR_G(last_alias), alias_len)) {
+		fd = PHAR_G(last_phar);
+		fd_ptr = &fd;
+		goto alias_success;
+	}
+
+	if (alias && alias_len) {
+		ahash = zend_inline_hash_func(alias, alias_len);
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, ahash, (void**)&fd_ptr)) {
+alias_success:
+			if (fname && (fname_len != (*fd_ptr)->fname_len || strncmp(fname, (*fd_ptr)->fname, fname_len))) {
+				if (error) {
+					spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, (*fd_ptr)->fname, fname);
+				}
+				if (SUCCESS == phar_free_alias(*fd_ptr, alias, alias_len TSRMLS_CC)) {
+					if (error) {
+						efree(*error);
+						*error = NULL;
+					}
+				}
+				return FAILURE;
+			}
+
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = alias;
+			PHAR_G(last_alias_len) = alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_alias, alias, alias_len, ahash, (void **)&fd_ptr)) {
+			goto alias_success;
+		}
+	}
+
+	fhash = zend_inline_hash_func(fname, fname_len);
+	my_realpath = NULL;
+	save = fname;
+	save_len = fname_len;
+
+	if (fname && fname_len) {
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_fname_map), fname, fname_len, fhash, (void**)&fd_ptr)) {
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+
+			if (alias && alias_len) {
+				if (!fd->is_temporary_alias && (alias_len != fd->alias_len || memcmp(fd->alias, alias, alias_len))) {
+					if (error) {
+						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, (*fd_ptr)->fname, fname);
+					}
+					return FAILURE;
+				}
+
+				if (fd->alias_len && SUCCESS == zend_hash_find(&(PHAR_GLOBALS->phar_alias_map), fd->alias, fd->alias_len, (void**)&fd_ptr)) {
+					zend_hash_del(&(PHAR_GLOBALS->phar_alias_map), fd->alias, fd->alias_len);
+				}
+
+				zend_hash_quick_add(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, ahash, (void*)&fd, sizeof(phar_archive_data*), NULL);
+			}
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_phars, fname, fname_len, fhash, (void**)&fd_ptr)) {
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+
+			/* this could be problematic - alias should never be different from manifest alias
+			   for cached phars */
+			if (!fd->is_temporary_alias && alias && alias_len) {
+				if (alias_len != fd->alias_len || memcmp(fd->alias, alias, alias_len)) {
+					if (error) {
+						spprintf(error, 0, "alias \"%s\" is already used for archive \"%s\" cannot be overloaded with \"%s\"", alias, (*fd_ptr)->fname, fname);
+					}
+					return FAILURE;
+				}
+			}
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_alias_map), save, save_len, fhash, (void**)&fd_ptr)) {
+			fd = *archive = *fd_ptr;
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_alias, save, save_len, fhash, (void**)&fd_ptr)) {
+			fd = *archive = *fd_ptr;
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		/* not found, try converting \ to / */
+		my_realpath = expand_filepath(fname, my_realpath TSRMLS_CC);
+
+		if (my_realpath) {
+			fname_len = strlen(my_realpath);
+			fname = my_realpath;
+		} else {
+			return FAILURE;
+		}
+#ifdef PHP_WIN32
+		phar_unixify_path_separators(fname, fname_len);
+#endif
+		fhash = zend_inline_hash_func(fname, fname_len);
+
+		if (SUCCESS == zend_hash_quick_find(&(PHAR_GLOBALS->phar_fname_map), fname, fname_len, fhash, (void**)&fd_ptr)) {
+realpath_success:
+			*archive = *fd_ptr;
+			fd = *fd_ptr;
+
+			if (alias && alias_len) {
+				zend_hash_quick_add(&(PHAR_GLOBALS->phar_alias_map), alias, alias_len, ahash, (void*)&fd, sizeof(phar_archive_data*), NULL);
+			}
+
+			efree(my_realpath);
+
+			PHAR_G(last_phar) = fd;
+			PHAR_G(last_phar_name) = fd->fname;
+			PHAR_G(last_phar_name_len) = fd->fname_len;
+			PHAR_G(last_alias) = fd->alias;
+			PHAR_G(last_alias_len) = fd->alias_len;
+
+			return SUCCESS;
+		}
+
+		if (PHAR_G(manifest_cached) && SUCCESS == zend_hash_quick_find(&cached_phars, fname, fname_len, fhash, (void**)&fd_ptr)) {
+			goto realpath_success;
+		}
+
+		efree(my_realpath);
+	}
+
+	return FAILURE;
+}
+/* }}} */
+
+/**
+ * Determine which stream compression filter (if any) we need to read this file
+ */
+char * phar_compress_filter(phar_entry_info * entry, int return_unknown) /* {{{ */
+{
+	switch (entry->flags & PHAR_ENT_COMPRESSION_MASK) {
+	case PHAR_ENT_COMPRESSED_GZ:
+		return "zlib.deflate";
+	case PHAR_ENT_COMPRESSED_BZ2:
+		return "bzip2.compress";
+	default:
+		return return_unknown ? "unknown" : NULL;
+	}
+}
+/* }}} */
+
+/**
+ * Determine which stream decompression filter (if any) we need to read this file
+ */
+char * phar_decompress_filter(phar_entry_info * entry, int return_unknown) /* {{{ */
+{
+	php_uint32 flags;
+
+	if (entry->is_modified) {
+		flags = entry->old_flags;
+	} else {
+		flags = entry->flags;
+	}
+
+	switch (flags & PHAR_ENT_COMPRESSION_MASK) {
+		case PHAR_ENT_COMPRESSED_GZ:
+			return "zlib.inflate";
+		case PHAR_ENT_COMPRESSED_BZ2:
+			return "bzip2.decompress";
+		default:
+			return return_unknown ? "unknown" : NULL;
+	}
+}
+/* }}} */
+
+/**
+ * retrieve information on a file contained within a phar, or null if it ain't there
+ */
+phar_entry_info *phar_get_entry_info(phar_archive_data *phar, char *path, int path_len, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	return phar_get_entry_info_dir(phar, path, path_len, 0, error, security TSRMLS_CC);
+}
+/* }}} */
+/**
+ * retrieve information on a file or directory contained within a phar, or null if none found
+ * allow_dir is 0 for none, 1 for both empty directories in the phar and temp directories, and 2 for only
+ * valid pre-existing empty directory entries
+ */
+phar_entry_info *phar_get_entry_info_dir(phar_archive_data *phar, char *path, int path_len, char dir, char **error, int security TSRMLS_DC) /* {{{ */
+{
+	const char *pcr_error;
+	phar_entry_info *entry;
+	int is_dir;
+
+#ifdef PHP_WIN32
+	phar_unixify_path_separators(path, path_len);
+#endif
+
+	is_dir = (path_len && (path[path_len - 1] == '/')) ? 1 : 0;
+
+	if (error) {
+		*error = NULL;
+	}
+
+	if (security && path_len >= sizeof(".phar")-1 && !memcmp(path, ".phar", sizeof(".phar")-1)) {
+		if (error) {
+			spprintf(error, 4096, "phar error: cannot directly access magic \".phar\" directory or files within it");
+		}
+		return NULL;
+	}
+
+	if (!path_len && !dir) {
+		if (error) {
+			spprintf(error, 4096, "phar error: invalid path \"%s\" must not be empty", path);
+		}
+		return NULL;
+	}
+
+	if (phar_path_check(&path, &path_len, &pcr_error) > pcr_is_ok) {
+		if (error) {
+			spprintf(error, 4096, "phar error: invalid path \"%s\" contains %s", path, pcr_error);
+		}
+		return NULL;
+	}
+
+	if (!phar->manifest.arBuckets) {
+		return NULL;
+	}
+
+	if (is_dir) {
+		if (!path_len || path_len == 1) {
+			return NULL;
+		}
+		path_len--;
+	}
+
+	if (SUCCESS == zend_hash_find(&phar->manifest, path, path_len, (void**)&entry)) {
+		if (entry->is_deleted) {
+			/* entry is deleted, but has not been flushed to disk yet */
+			return NULL;
+		}
+		if (entry->is_dir && !dir) {
+			if (error) {
+				spprintf(error, 4096, "phar error: path \"%s\" is a directory", path);
+			}
+			return NULL;
+		}
+		if (!entry->is_dir && dir == 2) {
+			/* user requested a directory, we must return one */
+			if (error) {
+				spprintf(error, 4096, "phar error: path \"%s\" exists and is a not a directory", path);
+			}
+			return NULL;
+		}
+		return entry;
+	}
+
+	if (dir) {
+		if (zend_hash_exists(&phar->virtual_dirs, path, path_len)) {
+			/* a file or directory exists in a sub-directory of this path */
+			entry = (phar_entry_info *) ecalloc(1, sizeof(phar_entry_info));
+			/* this next line tells PharFileInfo->__destruct() to efree the filename */
+			entry->is_temp_dir = entry->is_dir = 1;
+			entry->filename = (char *) estrndup(path, path_len + 1);
+			entry->filename_len = path_len;
+			entry->phar = phar;
+			return entry;
+		}
+	}
+
+	if (phar->mounted_dirs.arBuckets && zend_hash_num_elements(&phar->mounted_dirs)) {
+		char *str_key;
+		ulong unused;
+		uint keylen;
+
+		zend_hash_internal_pointer_reset(&phar->mounted_dirs);
+		while (FAILURE != zend_hash_has_more_elements(&phar->mounted_dirs)) {
+			if (HASH_KEY_NON_EXISTENT == zend_hash_get_current_key_ex(&phar->mounted_dirs, &str_key, &keylen, &unused, 0, NULL)) {
+				break;
+			}
+
+			if ((int)keylen >= path_len || strncmp(str_key, path, keylen)) {
+				continue;
+			} else {
+				char *test;
+				int test_len;
+				php_stream_statbuf ssb;
+
+				if (SUCCESS != zend_hash_find(&phar->manifest, str_key, keylen, (void **) &entry)) {
+					if (error) {
+						spprintf(error, 4096, "phar internal error: mounted path \"%s\" could not be retrieved from manifest", str_key);
+					}
+					return NULL;
+				}
+
+				if (!entry->tmp || !entry->is_mounted) {
+					if (error) {
+						spprintf(error, 4096, "phar internal error: mounted path \"%s\" is not properly initialized as a mounted path", str_key);
+					}
+					return NULL;
+				}
+
+				test_len = spprintf(&test, MAXPATHLEN, "%s%s", entry->tmp, path + keylen);
+
+				if (SUCCESS != php_stream_stat_path(test, &ssb)) {
+					efree(test);
+					return NULL;
+				}
+
+				if (ssb.sb.st_mode & S_IFDIR && !dir) {
+					efree(test);
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" is a directory", path);
+					}
+					return NULL;
+				}
+
+				if ((ssb.sb.st_mode & S_IFDIR) == 0 && dir) {
+					efree(test);
+					/* user requested a directory, we must return one */
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" exists and is a not a directory", path);
+					}
+					return NULL;
+				}
+
+				/* mount the file just in time */
+				if (SUCCESS != phar_mount_entry(phar, test, test_len, path, path_len TSRMLS_CC)) {
+					efree(test);
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" exists as file \"%s\" and could not be mounted", path, test);
+					}
+					return NULL;
+				}
+
+				efree(test);
+
+				if (SUCCESS != zend_hash_find(&phar->manifest, path, path_len, (void**)&entry)) {
+					if (error) {
+						spprintf(error, 4096, "phar error: path \"%s\" exists as file \"%s\" and could not be retrieved after being mounted", path, test);
+					}
+					return NULL;
+				}
+				return entry;
+			}
+		}
+	}
+
+	return NULL;
+}
+/* }}} */
+
+static const char hexChars[] = "0123456789ABCDEF";
+
+static int phar_hex_str(const char *digest, size_t digest_len, char **signature TSRMLS_DC) /* {{{ */
+{
+	int pos = -1;
+	size_t len = 0;
+
+	*signature = (char*)safe_pemalloc(digest_len, 2, 1, PHAR_G(persist));
+
+	for (; len < digest_len; ++len) {
+		(*signature)[++pos] = hexChars[((const unsigned char *)digest)[len] >> 4];
+		(*signature)[++pos] = hexChars[((const unsigned char *)digest)[len] & 0x0F];
+	}
+	(*signature)[++pos] = '\0';
+	return pos;
+}
+/* }}} */
+
+#ifndef PHAR_HAVE_OPENSSL
+static int phar_call_openssl_signverify(int is_sign, php_stream *fp, off_t end, char *key, int key_len, char **signature, int *signature_len TSRMLS_DC) /* {{{ */
+{
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+	zval *zdata, *zsig, *zkey, *retval_ptr, **zp[3], *openssl;
+
+	MAKE_STD_ZVAL(zdata);
+	MAKE_STD_ZVAL(openssl);
+	ZVAL_STRINGL(openssl, is_sign ? "openssl_sign" : "openssl_verify", is_sign ? sizeof("openssl_sign")-1 : sizeof("openssl_verify")-1, 1);
+	MAKE_STD_ZVAL(zsig);
+	ZVAL_STRINGL(zsig, *signature, *signature_len, 1);
+	MAKE_STD_ZVAL(zkey);
+	ZVAL_STRINGL(zkey, key, key_len, 1);
+	zp[0] = &zdata;
+	zp[1] = &zsig;
+	zp[2] = &zkey;
+
+	php_stream_rewind(fp);
+	Z_TYPE_P(zdata) = IS_STRING;
+	Z_STRLEN_P(zdata) = end;
+
+	if (end != (off_t) php_stream_copy_to_mem(fp, &(Z_STRVAL_P(zdata)), (size_t) end, 0)) {
+		zval_dtor(zdata);
+		zval_dtor(zsig);
+		zval_dtor(zkey);
+		zval_dtor(openssl);
+		efree(openssl);
+		efree(zdata);
+		efree(zkey);
+		efree(zsig);
+		return FAILURE;
+	}
+
+	if (FAILURE == zend_fcall_info_init(openssl, 0, &fci, &fcc, NULL, NULL TSRMLS_CC)) {
+		zval_dtor(zdata);
+		zval_dtor(zsig);
+		zval_dtor(zkey);
+		zval_dtor(openssl);
+		efree(openssl);
+		efree(zdata);
+		efree(zkey);
+		efree(zsig);
+		return FAILURE;
+	}
+
+	fci.param_count = 3;
+	fci.params = zp;
+	Z_ADDREF_P(zdata);
+	if (is_sign) {
+		Z_SET_ISREF_P(zsig);
+	} else {
+		Z_ADDREF_P(zsig);
+	}
+	Z_ADDREF_P(zkey);
+
+	fci.retval_ptr_ptr = &retval_ptr;
+
+	if (FAILURE == zend_call_function(&fci, &fcc TSRMLS_CC)) {
+		zval_dtor(zdata);
+		zval_dtor(zsig);
+		zval_dtor(zkey);
+		zval_dtor(openssl);
+		efree(openssl);
+		efree(zdata);
+		efree(zkey);
+		efree(zsig);
+		return FAILURE;
+	}
+
+	zval_dtor(openssl);
+	efree(openssl);
+	Z_DELREF_P(zdata);
+
+	if (is_sign) {
+		Z_UNSET_ISREF_P(zsig);
+	} else {
+		Z_DELREF_P(zsig);
+	}
+	Z_DELREF_P(zkey);
+
+	zval_dtor(zdata);
+	efree(zdata);
+	zval_dtor(zkey);
+	efree(zkey);
+
+	switch (Z_TYPE_P(retval_ptr)) {
+		default:
+		case IS_LONG:
+			zval_dtor(zsig);
+			efree(zsig);
+			if (1 == Z_LVAL_P(retval_ptr)) {
+				efree(retval_ptr);
+				return SUCCESS;
+			}
+			efree(retval_ptr);
+			return FAILURE;
+		case IS_BOOL:
+			efree(retval_ptr);
+			if (Z_BVAL_P(retval_ptr)) {
+				*signature = estrndup(Z_STRVAL_P(zsig), Z_STRLEN_P(zsig));
+				*signature_len = Z_STRLEN_P(zsig);
+				zval_dtor(zsig);
+				efree(zsig);
+				return SUCCESS;
+			}
+			zval_dtor(zsig);
+			efree(zsig);
+			return FAILURE;
+	}
+}
+/* }}} */
+#endif /* #ifndef PHAR_HAVE_OPENSSL */
+
+int phar_verify_signature(php_stream *fp, size_t end_of_phar, php_uint32 sig_type, char *sig, int sig_len, char *fname, char **signature, int *signature_len, char **error TSRMLS_DC) /* {{{ */
+{
+	int read_size, len;
+	off_t read_len;
+	unsigned char buf[1024];
+
+	php_stream_rewind(fp);
+
+	switch (sig_type) {
+		case PHAR_SIG_OPENSSL: {
+#ifdef PHAR_HAVE_OPENSSL
+			BIO *in;
+			EVP_PKEY *key;
+			EVP_MD *mdtype = (EVP_MD *) EVP_sha1();
+			EVP_MD_CTX md_ctx;
+#else
+			int tempsig;
+#endif
+			php_uint32 pubkey_len;
+			char *pubkey = NULL, *pfile;
+			php_stream *pfp;
+#ifndef PHAR_HAVE_OPENSSL
+			if (!zend_hash_exists(&module_registry, "openssl", sizeof("openssl"))) {
+				if (error) {
+					spprintf(error, 0, "openssl not loaded");
+				}
+				return FAILURE;
+			}
+#endif
+			/* use __FILE__ . '.pubkey' for public key file */
+			spprintf(&pfile, 0, "%s.pubkey", fname);
+			pfp = php_stream_open_wrapper(pfile, "rb", 0, NULL);
+			efree(pfile);
+
+#if PHP_MAJOR_VERSION > 5
+			if (!pfp || !(pubkey_len = php_stream_copy_to_mem(pfp, (void **) &pubkey, PHP_STREAM_COPY_ALL, 0)) || !pubkey) {
+#else
+			if (!pfp || !(pubkey_len = php_stream_copy_to_mem(pfp, &pubkey, PHP_STREAM_COPY_ALL, 0)) || !pubkey) {
+#endif
+				if (pfp) {
+					php_stream_close(pfp);
+				}
+				if (error) {
+					spprintf(error, 0, "openssl public key could not be read");
+				}
+				return FAILURE;
+			}
+
+			php_stream_close(pfp);
+#ifndef PHAR_HAVE_OPENSSL
+			tempsig = sig_len;
+
+			if (FAILURE == phar_call_openssl_signverify(0, fp, end_of_phar, pubkey, pubkey_len, &sig, &tempsig TSRMLS_CC)) {
+				if (pubkey) {
+					efree(pubkey);
+				}
+
+				if (error) {
+					spprintf(error, 0, "openssl signature could not be verified");
+				}
+
+				return FAILURE;
+			}
+
+			if (pubkey) {
+				efree(pubkey);
+			}
+
+			sig_len = tempsig;
+#else
+			in = BIO_new_mem_buf(pubkey, pubkey_len);
+
+			if (NULL == in) {
+				efree(pubkey);
+				if (error) {
+					spprintf(error, 0, "openssl signature could not be processed");
+				}
+				return FAILURE;
+			}
+
+			key = PEM_read_bio_PUBKEY(in, NULL,NULL, NULL);
+			BIO_free(in);
+			efree(pubkey);
+
+			if (NULL == key) {
+				if (error) {
+					spprintf(error, 0, "openssl signature could not be processed");
+				}
+				return FAILURE;
+			}
+
+			EVP_VerifyInit(&md_ctx, mdtype);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			php_stream_seek(fp, 0, SEEK_SET);
+
+			while (read_size && (len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				EVP_VerifyUpdate (&md_ctx, buf, len);
+				read_len -= (off_t)len;
+
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			if (EVP_VerifyFinal(&md_ctx, (unsigned char *)sig, sig_len, key) != 1) {
+				/* 1: signature verified, 0: signature does not match, -1: failed signature operation */
+				EVP_MD_CTX_cleanup(&md_ctx);
+
+				if (error) {
+					spprintf(error, 0, "broken openssl signature");
+				}
+
+				return FAILURE;
+			}
+
+			EVP_MD_CTX_cleanup(&md_ctx);
+#endif
+
+			*signature_len = phar_hex_str((const char*)sig, sig_len, signature TSRMLS_CC);
+		}
+		break;
+#ifdef PHAR_HASH_OK
+		case PHAR_SIG_SHA512: {
+			unsigned char digest[64];
+			PHP_SHA512_CTX context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_SHA512Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_SHA512Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_SHA512Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+		case PHAR_SIG_SHA256: {
+			unsigned char digest[32];
+			PHP_SHA256_CTX context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_SHA256Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_SHA256Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_SHA256Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+#else
+		case PHAR_SIG_SHA512:
+		case PHAR_SIG_SHA256:
+			if (error) {
+				spprintf(error, 0, "unsupported signature");
+			}
+			return FAILURE;
+#endif
+		case PHAR_SIG_SHA1: {
+			unsigned char digest[20];
+			PHP_SHA1_CTX  context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_SHA1Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_SHA1Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_SHA1Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+		case PHAR_SIG_MD5: {
+			unsigned char digest[16];
+			PHP_MD5_CTX   context;
+
+			if (sig_len < sizeof(digest)) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			PHP_MD5Init(&context);
+			read_len = end_of_phar;
+
+			if (read_len > sizeof(buf)) {
+				read_size = sizeof(buf);
+			} else {
+				read_size = (int)read_len;
+			}
+
+			while ((len = php_stream_read(fp, (char*)buf, read_size)) > 0) {
+				PHP_MD5Update(&context, buf, len);
+				read_len -= (off_t)len;
+				if (read_len < read_size) {
+					read_size = (int)read_len;
+				}
+			}
+
+			PHP_MD5Final(digest, &context);
+
+			if (memcmp(digest, sig, sizeof(digest))) {
+				if (error) {
+					spprintf(error, 0, "broken signature");
+				}
+				return FAILURE;
+			}
+
+			*signature_len = phar_hex_str((const char*)digest, sizeof(digest), signature TSRMLS_CC);
+			break;
+		}
+		default:
+			if (error) {
+				spprintf(error, 0, "broken or unsupported signature");
+			}
+			return FAILURE;
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signature, int *signature_length, char **error TSRMLS_DC) /* {{{ */
+{
+	unsigned char buf[1024];
+	int sig_len;
+
+	php_stream_rewind(fp);
+
+	if (phar->signature) {
+		efree(phar->signature);
+		phar->signature = NULL;
+	}
+
+	switch(phar->sig_flags) {
+#ifdef PHAR_HASH_OK
+		case PHAR_SIG_SHA512: {
+			unsigned char digest[64];
+			PHP_SHA512_CTX context;
+
+			PHP_SHA512Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_SHA512Update(&context, buf, sig_len);
+			}
+
+			PHP_SHA512Final(digest, &context);
+			*signature = estrndup((char *) digest, 64);
+			*signature_length = 64;
+			break;
+		}
+		case PHAR_SIG_SHA256: {
+			unsigned char digest[32];
+			PHP_SHA256_CTX  context;
+
+			PHP_SHA256Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_SHA256Update(&context, buf, sig_len);
+			}
+
+			PHP_SHA256Final(digest, &context);
+			*signature = estrndup((char *) digest, 32);
+			*signature_length = 32;
+			break;
+		}
+#else
+		case PHAR_SIG_SHA512:
+		case PHAR_SIG_SHA256:
+			if (error) {
+				spprintf(error, 0, "unable to write to phar \"%s\" with requested hash type", phar->fname);
+			}
+
+			return FAILURE;
+#endif
+		case PHAR_SIG_OPENSSL: {
+			int siglen;
+			unsigned char *sigbuf;
+#ifdef PHAR_HAVE_OPENSSL
+			BIO *in;
+			EVP_PKEY *key;
+			EVP_MD_CTX *md_ctx;
+
+			in = BIO_new_mem_buf(PHAR_G(openssl_privatekey), PHAR_G(openssl_privatekey_len));
+
+			if (in == NULL) {
+				if (error) {
+					spprintf(error, 0, "unable to write to phar \"%s\" with requested openssl signature", phar->fname);
+				}
+				return FAILURE;
+			}
+
+			key = PEM_read_bio_PrivateKey(in, NULL,NULL, "");
+			BIO_free(in);
+
+			if (!key) {
+				if (error) {
+					spprintf(error, 0, "unable to process private key");
+				}
+				return FAILURE;
+			}
+
+			md_ctx = EVP_MD_CTX_create();
+
+			siglen = EVP_PKEY_size(key);
+			sigbuf = emalloc(siglen + 1);
+
+			if (!EVP_SignInit(md_ctx, EVP_sha1())) {
+				efree(sigbuf);
+				if (error) {
+					spprintf(error, 0, "unable to initialize openssl signature for phar \"%s\"", phar->fname);
+				}
+				return FAILURE;
+			}
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				if (!EVP_SignUpdate(md_ctx, buf, sig_len)) {
+					efree(sigbuf);
+					if (error) {
+						spprintf(error, 0, "unable to update the openssl signature for phar \"%s\"", phar->fname);
+					}
+					return FAILURE;
+				}
+			}
+
+			if (!EVP_SignFinal (md_ctx, sigbuf,(unsigned int *)&siglen, key)) {
+				efree(sigbuf);
+				if (error) {
+					spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", phar->fname);
+				}
+				return FAILURE;
+			}
+
+			sigbuf[siglen] = '\0';
+			EVP_MD_CTX_destroy(md_ctx);
+#else
+			sigbuf = NULL;
+			siglen = 0;
+			php_stream_seek(fp, 0, SEEK_END);
+
+			if (FAILURE == phar_call_openssl_signverify(1, fp, php_stream_tell(fp), PHAR_G(openssl_privatekey), PHAR_G(openssl_privatekey_len), (char **)&sigbuf, &siglen TSRMLS_CC)) {
+				if (error) {
+					spprintf(error, 0, "unable to write phar \"%s\" with requested openssl signature", phar->fname);
+				}
+				return FAILURE;
+			}
+#endif
+			*signature = (char *) sigbuf;
+			*signature_length = siglen;
+		}
+		break;
+		default:
+			phar->sig_flags = PHAR_SIG_SHA1;
+		case PHAR_SIG_SHA1: {
+			unsigned char digest[20];
+			PHP_SHA1_CTX  context;
+
+			PHP_SHA1Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_SHA1Update(&context, buf, sig_len);
+			}
+
+			PHP_SHA1Final(digest, &context);
+			*signature = estrndup((char *) digest, 20);
+			*signature_length = 20;
+			break;
+		}
+		case PHAR_SIG_MD5: {
+			unsigned char digest[16];
+			PHP_MD5_CTX   context;
+
+			PHP_MD5Init(&context);
+
+			while ((sig_len = php_stream_read(fp, (char*)buf, sizeof(buf))) > 0) {
+				PHP_MD5Update(&context, buf, sig_len);
+			}
+
+			PHP_MD5Final(digest, &context);
+			*signature = estrndup((char *) digest, 16);
+			*signature_length = 16;
+			break;
+		}
+	}
+
+	phar->sig_len = phar_hex_str((const char *)*signature, *signature_length, &phar->signature TSRMLS_CC);
+	return SUCCESS;
+}
+/* }}} */
+
+void phar_add_virtual_dirs(phar_archive_data *phar, char *filename, int filename_len TSRMLS_DC) /* {{{ */
+{
+	const char *s;
+
+	while ((s = zend_memrchr(filename, '/', filename_len))) {
+		filename_len = s - filename;
+		if (!filename_len || FAILURE == zend_hash_add_empty_element(&phar->virtual_dirs, filename, filename_len)) {
+			break;
+		}
+	}
+}
+/* }}} */
+
+static int phar_update_cached_entry(void *data, void *argument) /* {{{ */
+{
+	phar_entry_info *entry = (phar_entry_info *)data;
+	TSRMLS_FETCH();
+
+	entry->phar = (phar_archive_data *)argument;
+
+	if (entry->link) {
+		entry->link = estrdup(entry->link);
+	}
+
+	if (entry->tmp) {
+		entry->tmp = estrdup(entry->tmp);
+	}
+
+	entry->metadata_str.c = 0;
+	entry->filename = estrndup(entry->filename, entry->filename_len);
+	entry->is_persistent = 0;
+
+	if (entry->metadata) {
+		if (entry->metadata_len) {
+			char *buf = estrndup((char *) entry->metadata, entry->metadata_len);
+			/* assume success, we would have failed before */
+			phar_parse_metadata((char **) &buf, &entry->metadata, entry->metadata_len TSRMLS_CC);
+			efree(buf);
+		} else {
+			zval *t;
+
+			t = entry->metadata;
+			ALLOC_ZVAL(entry->metadata);
+			*entry->metadata = *t;
+			zval_copy_ctor(entry->metadata);
+			Z_SET_REFCOUNT_P(entry->metadata, 1);
+			entry->metadata_str.c = NULL;
+			entry->metadata_str.len = 0;
+		}
+	}
+	return ZEND_HASH_APPLY_KEEP;
+}
+/* }}} */
+
+static void phar_copy_cached_phar(phar_archive_data **pphar TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data *phar;
+	HashTable newmanifest;
+	char *fname;
+	phar_archive_object **objphar;
+
+	phar = (phar_archive_data *) emalloc(sizeof(phar_archive_data));
+	*phar = **pphar;
+	phar->is_persistent = 0;
+	fname = phar->fname;
+	phar->fname = estrndup(phar->fname, phar->fname_len);
+	phar->ext = phar->fname + (phar->ext - fname);
+
+	if (phar->alias) {
+		phar->alias = estrndup(phar->alias, phar->alias_len);
+	}
+
+	if (phar->signature) {
+		phar->signature = estrdup(phar->signature);
+	}
+
+	if (phar->metadata) {
+		/* assume success, we would have failed before */
+		if (phar->metadata_len) {
+			char *buf = estrndup((char *) phar->metadata, phar->metadata_len);
+			phar_parse_metadata(&buf, &phar->metadata, phar->metadata_len TSRMLS_CC);
+			efree(buf);
+		} else {
+			zval *t;
+
+			t = phar->metadata;
+			ALLOC_ZVAL(phar->metadata);
+			*phar->metadata = *t;
+			zval_copy_ctor(phar->metadata);
+			Z_SET_REFCOUNT_P(phar->metadata, 1);
+		}
+	}
+
+	zend_hash_init(&newmanifest, sizeof(phar_entry_info),
+		zend_get_hash_value, destroy_phar_manifest_entry, 0);
+	zend_hash_copy(&newmanifest, &(*pphar)->manifest, NULL, NULL, sizeof(phar_entry_info));
+	zend_hash_apply_with_argument(&newmanifest, (apply_func_arg_t) phar_update_cached_entry, (void *)phar TSRMLS_CC);
+	phar->manifest = newmanifest;
+	zend_hash_init(&phar->mounted_dirs, sizeof(char *),
+		zend_get_hash_value, NULL, 0);
+	zend_hash_init(&phar->virtual_dirs, sizeof(char *),
+		zend_get_hash_value, NULL, 0);
+	zend_hash_copy(&phar->virtual_dirs, &(*pphar)->virtual_dirs, NULL, NULL, sizeof(void *));
+	*pphar = phar;
+
+	/* now, scan the list of persistent Phar objects referencing this phar and update the pointers */
+	for (zend_hash_internal_pointer_reset(&PHAR_GLOBALS->phar_persist_map);
+	SUCCESS == zend_hash_get_current_data(&PHAR_GLOBALS->phar_persist_map, (void **) &objphar);
+	zend_hash_move_forward(&PHAR_GLOBALS->phar_persist_map)) {
+		if (objphar[0]->arc.archive->fname_len == phar->fname_len && !memcmp(objphar[0]->arc.archive->fname, phar->fname, phar->fname_len)) {
+			objphar[0]->arc.archive = phar;
+		}
+	}
+}
+/* }}} */
+
+int phar_copy_on_write(phar_archive_data **pphar TSRMLS_DC) /* {{{ */
+{
+	phar_archive_data **newpphar, *newphar = NULL;
+
+	if (SUCCESS != zend_hash_add(&(PHAR_GLOBALS->phar_fname_map), (*pphar)->fname, (*pphar)->fname_len, (void *)&newphar, sizeof(phar_archive_data *), (void **)&newpphar)) {
+		return FAILURE;
+	}
+
+	*newpphar = *pphar;
+	phar_copy_cached_phar(newpphar TSRMLS_CC);
+	/* invalidate phar cache */
+	PHAR_G(last_phar) = NULL;
+	PHAR_G(last_phar_name) = PHAR_G(last_alias) = NULL;
+
+	if (newpphar[0]->alias_len && FAILURE == zend_hash_add(&(PHAR_GLOBALS->phar_alias_map), newpphar[0]->alias, newpphar[0]->alias_len, (void*)newpphar, sizeof(phar_archive_data*), NULL)) {
+		zend_hash_del(&(PHAR_GLOBALS->phar_fname_map), (*pphar)->fname, (*pphar)->fname_len);
+		return FAILURE;
+	}
+
+	*pphar = *newpphar;
+	return SUCCESS;
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */


### PR DESCRIPTION
The chunks containing mixed line endings were related to the test files which PHPBrew doesn't use, so we can skip them.

```
===> Checking patches...
Checking patch for php5.3.29 multi-sapi
Checking patch for php5.3.x on 64bit machine when intl is enabled.
Checking patch for openssl dso linking patch
Checking patch for php5.6 with openssl 1.1.x patch.
---> Applying patch...
patching file ext/openssl/openssl.c
patching file ext/openssl/xp_ssl.c
patching file ext/phar/util.c
patching file ext/openssl/openssl.c
patch unexpectedly ends in middle of line
Hunk #1 succeeded at 651 with fuzz 1.
```