### PR TITLE
Improved building mbstring on PHP 7.4

### DIFF
--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -12,6 +12,7 @@ use PhpBrew\BuildSettings\BuildSettings;
  * @method array getEnabledVariants()
  * @method array getDisabledVariants()
  * @method bool isEnabledVariant(string $variant)
+ * @method bool isDisabledVariant(string $variant)
  * @method array getExtraOptions()
  * @method enableVariant(string $variant, string $value = null)
  * @method disableVariant(string $variant)

--- a/src/PhpBrew/BuildSettings/BuildSettings.php
+++ b/src/PhpBrew/BuildSettings/BuildSettings.php
@@ -88,6 +88,11 @@ class BuildSettings
         return array_key_exists($name, $this->enabledVariants);
     }
 
+    public function isDisabledVariant($name)
+    {
+        return array_key_exists($name, $this->disabledVariants);
+    }
+
     /**
      * Remove enabled variant.
      */

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -158,7 +158,25 @@ class VariantBuilder
         $this->variants['json'] = '--enable-json';
         $this->variants['hash'] = '--enable-hash';
         $this->variants['exif'] = '--enable-exif';
-        $this->variants['mbstring'] = '--enable-mbstring';
+
+        $this->variants['mbstring'] = function (ConfigureParameters $params, Build $build, $value) {
+            $params = $params->withOption('--enable-mbstring');
+
+            if ($build->compareVersion('5.4') >= 0 && !$build->isDisabledVariant('mbregex')) {
+                $prefix = Utils::findPrefix(array(
+                    new UserProvidedPrefix($value),
+                    new IncludePrefixFinder('oniguruma.h'),
+                    new BrewPrefixFinder('oniguruma'),
+                ));
+
+                if ($prefix !== null) {
+                    $params = $params->withOption('--with-onig', $prefix);
+                }
+            }
+
+            return $params;
+        };
+
         $this->variants['mbregex'] = '--enable-mbregex';
         $this->variants['libgcc'] = '--enable-libgcc';
 


### PR DESCRIPTION
As of [PHP 7.4][1], the oniguruma library is no longer bundled with PHP, instead libonig needs to be available on the system.

[1]: https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.mbstring