### PR TITLE
Downgraged corneltek/getoptionkit to v2.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         "ext-simplexml": "*",
         "symfony/yaml": "^2.8"
     },
+    "conflict": {
+        "corneltek/getoptionkit": ">=2.4.0"
+    },
     "require-dev": {
         "php-vcr/php-vcr": "^1.4",
         "phpunit/phpunit": "^4.8||^5.7||^6.5||^7.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fee49b44411d95594e733af8eb567e2b",
+    "content-hash": "7425f2ddf0325cd1496e13653ae66ef2",
     "packages": [
         {
             "name": "corneltek/class-template",
@@ -201,16 +201,16 @@
         },
         {
             "name": "corneltek/getoptionkit",
-            "version": "2.5.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/GetOptionKit.git",
-                "reference": "076cc41051d6417bf9304fe92f8d9793edac9910"
+                "reference": "4534eeef636ec20efb2908a215ad8481eaba7370"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/076cc41051d6417bf9304fe92f8d9793edac9910",
-                "reference": "076cc41051d6417bf9304fe92f8d9793edac9910",
+                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/4534eeef636ec20efb2908a215ad8481eaba7370",
+                "reference": "4534eeef636ec20efb2908a215ad8481eaba7370",
                 "shasum": ""
             },
             "require": {
@@ -218,12 +218,12 @@
             },
             "require-dev": {
                 "corneltek/phpunit-testmore": "dev-master",
-                "satooshi/php-coveralls": "^1"
+                "satooshi/php-coveralls": "dev-master"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -243,7 +243,7 @@
             ],
             "description": "Powerful command-line option toolkit",
             "homepage": "http://github.com/c9s/GetOptionKit",
-            "time": "2016-07-18T07:44:29+00:00"
+            "time": "2016-05-12T02:37:54+00:00"
         },
         {
             "name": "corneltek/pearx",


### PR DESCRIPTION
https://github.com/c9s/GetOptionKit/commit/e6bcd79f09426dcfd4383b659331f26d9cadbf6f (`v2.4.0`) renames `OptionPrinterInterface` to `OptionPrinter` which is incompatible with [c9s/CLIFramework](https://github.com/c9s/CLIFramework/tree/3.0) `3.0.x-dev`.