### PR TITLE
Fixed system interpreter leaked issue #1134.

### DIFF
--- a/src/PhpBrew/Command/ConfigCommand.php
+++ b/src/PhpBrew/Command/ConfigCommand.php
@@ -15,7 +15,7 @@ class ConfigCommand extends Command
 
     public function execute()
     {
-        $file = php_ini_loaded_file();
+        $file = $this->getCurrentPhpLoadedIniFile();
         if (!file_exists($file)) {
             $php = Config::getCurrentPhpName();
             $this->logger->warn("Sorry, I can't find the {$file} file for php {$php}.");
@@ -24,5 +24,21 @@ class ConfigCommand extends Command
         }
 
         Utils::editor($file);
+    }
+
+    private function getCurrentPhpLoadedIniFile()
+    {
+        $cmd  = Config::getCurrentPhpBin() . '/php';
+        $options = ' -r ';
+        $code = '"echo php_ini_loaded_file();"';
+
+        exec($cmd . $options . $code, $output, $retVal);
+        if ($retVal) {
+            return false;
+        }
+
+        $file = $output[0];
+
+        return $file;
     }
 }

--- a/src/PhpBrew/Command/ConfigCommand.php
+++ b/src/PhpBrew/Command/ConfigCommand.php
@@ -16,7 +16,9 @@ class ConfigCommand extends Command
 
     public function execute()
     {
-        UsePhpFunctionWrapper::execute('php_ini_loaded_file()', $output) ? $file = $output : $file = '';
+        UsePhpFunctionWrapper::execute('php_ini_loaded_file()', $output)
+            ? $file = $output
+            : $file = '';
         if (!file_exists($file)) {
             $php = Config::getCurrentPhpName();
             $this->logger->warn("Sorry, I can't find the {$file} file for php {$php}.");

--- a/src/PhpBrew/Command/ConfigCommand.php
+++ b/src/PhpBrew/Command/ConfigCommand.php
@@ -5,6 +5,7 @@ namespace PhpBrew\Command;
 use CLIFramework\Command;
 use PhpBrew\Config;
 use PhpBrew\Utils;
+use PhpBrew\UsePhpFunctionWrapper;
 
 class ConfigCommand extends Command
 {
@@ -15,7 +16,7 @@ class ConfigCommand extends Command
 
     public function execute()
     {
-        $file = $this->getCurrentPhpLoadedIniFile();
+        UsePhpFunctionWrapper::execute('php_ini_loaded_file()', $output) ? $file = $output : $file = '';
         if (!file_exists($file)) {
             $php = Config::getCurrentPhpName();
             $this->logger->warn("Sorry, I can't find the {$file} file for php {$php}.");
@@ -24,21 +25,5 @@ class ConfigCommand extends Command
         }
 
         Utils::editor($file);
-    }
-
-    private function getCurrentPhpLoadedIniFile()
-    {
-        $cmd  = Config::getCurrentPhpBin() . '/php';
-        $options = ' -r ';
-        $code = '"echo php_ini_loaded_file();"';
-
-        exec($cmd . $options . $code, $output, $retVal);
-        if ($retVal) {
-            return false;
-        }
-
-        $file = $output[0];
-
-        return $file;
     }
 }

--- a/src/PhpBrew/Command/InfoCommand.php
+++ b/src/PhpBrew/Command/InfoCommand.php
@@ -3,6 +3,7 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command;
+use PhpBrew\UsePhpFunctionWrapper;
 
 class InfoCommand extends Command
 {
@@ -25,10 +26,11 @@ class InfoCommand extends Command
     public function execute()
     {
         $this->header('Version');
-        echo 'PHP-', phpversion(), "\n\n";
+        UsePhpFunctionWrapper::execute('phpversion()', $output) ? $version = $output : $version = '';
+        echo 'PHP-', $version, "\n\n";
 
         $this->header('Constants');
-        $constants = get_defined_constants();
+        UsePhpFunctionWrapper::execute('get_defined_constants()', $output) ? $constants = $output : $constants = array();
 
         if (isset($constants['PHP_PREFIX'])) {
             echo 'PHP Prefix: ', $constants['PHP_PREFIX'], "\n";
@@ -39,7 +41,8 @@ class InfoCommand extends Command
         if (isset($constants['DEFAULT_INCLUDE_PATH'])) {
             echo 'PHP Default Include path: ', $constants['DEFAULT_INCLUDE_PATH'], "\n";
         }
-        echo 'PHP Include path: ', get_include_path(), "\n";
+        UsePhpFunctionWrapper::execute('get_include_path()', $output) ? $includePath = $output : $includePath = '';
+        echo 'PHP Include path: ', $includePath, "\n";
         echo "\n";
 
         // DEFAULT_INCLUDE_PATH
@@ -49,12 +52,13 @@ class InfoCommand extends Command
         // zend_version
 
         $this->header('General Info');
-        phpinfo(INFO_GENERAL);
+        UsePhpFunctionWrapper::execute('phpinfo(INFO_GENERAL)', $output, true) ? $info = $output : $info = '';
+        echo $info;
         echo "\n";
 
         $this->header('Extensions');
 
-        $extensions = get_loaded_extensions();
+        UsePhpFunctionWrapper::execute('get_loaded_extensions()', $output) ? $extensions = $output : $extensions = array();
         $this->logger->info(implode(', ', $extensions));
 
         echo "\n";

--- a/src/PhpBrew/Command/InfoCommand.php
+++ b/src/PhpBrew/Command/InfoCommand.php
@@ -26,11 +26,15 @@ class InfoCommand extends Command
     public function execute()
     {
         $this->header('Version');
-        UsePhpFunctionWrapper::execute('phpversion()', $output) ? $version = $output : $version = '';
+        UsePhpFunctionWrapper::execute('phpversion()', $output)
+            ? $version = $output
+            : $version = '';
         echo 'PHP-', $version, "\n\n";
 
         $this->header('Constants');
-        UsePhpFunctionWrapper::execute('get_defined_constants()', $output) ? $constants = $output : $constants = array();
+        UsePhpFunctionWrapper::execute('get_defined_constants()', $output)
+            ? $constants = $output
+            : $constants = array();
 
         if (isset($constants['PHP_PREFIX'])) {
             echo 'PHP Prefix: ', $constants['PHP_PREFIX'], "\n";
@@ -41,7 +45,9 @@ class InfoCommand extends Command
         if (isset($constants['DEFAULT_INCLUDE_PATH'])) {
             echo 'PHP Default Include path: ', $constants['DEFAULT_INCLUDE_PATH'], "\n";
         }
-        UsePhpFunctionWrapper::execute('get_include_path()', $output) ? $includePath = $output : $includePath = '';
+        UsePhpFunctionWrapper::execute('get_include_path()', $output)
+            ? $includePath = $output
+            : $includePath = '';
         echo 'PHP Include path: ', $includePath, "\n";
         echo "\n";
 
@@ -52,13 +58,17 @@ class InfoCommand extends Command
         // zend_version
 
         $this->header('General Info');
-        UsePhpFunctionWrapper::execute('phpinfo(INFO_GENERAL)', $output, true) ? $info = $output : $info = '';
+        UsePhpFunctionWrapper::execute('phpinfo(INFO_GENERAL)', $output, true)
+            ? $info = $output
+            : $info = '';
         echo $info;
         echo "\n";
 
         $this->header('Extensions');
 
-        UsePhpFunctionWrapper::execute('get_loaded_extensions()', $output) ? $extensions = $output : $extensions = array();
+        UsePhpFunctionWrapper::execute('get_loaded_extensions()', $output)
+            ? $extensions = $output
+            : $extensions = array();
         $this->logger->info(implode(', ', $extensions));
 
         echo "\n";

--- a/src/PhpBrew/Command/ListIniCommand.php
+++ b/src/PhpBrew/Command/ListIniCommand.php
@@ -3,7 +3,7 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command;
-use PhpBrew\Config;
+use PhpBrew\UsePhpFunctionWrapper;
 
 class ListIniCommand extends Command
 {
@@ -14,31 +14,15 @@ class ListIniCommand extends Command
 
     public function execute()
     {
-        if ($files = $this->getCurrentPhpScannedIniFiles()) {
+        UsePhpFunctionWrapper::execute('php_ini_scanned_files()', $output) ? $filelist = $output : $filelist = '';
+        if ($filelist) {
             echo "Loaded ini files:\n";
-            if (count($files) > 0) {
+            if (strlen($filelist) > 0) {
+                $files = explode(',', $filelist);
                 foreach ($files as $file) {
-                    echo ' - ' . $file . "\n";
+                    echo ' - ' . trim($file) . "\n";
                 }
             }
         }
-    }
-
-    private function getCurrentPhpScannedIniFiles()
-    {
-        $cmd  = Config::getCurrentPhpBin() . '/php';
-        $options = ' -r ';
-        $code = '"echo php_ini_scanned_files();"';
-
-        exec($cmd . $options . $code, $output, $retVal);
-        if ($retVal) {
-            return false;
-        }
-
-        foreach ($output as $file) {
-            $files[] = str_replace(',', '', $file);
-        }
-
-        return $files;
     }
 }

--- a/src/PhpBrew/Command/ListIniCommand.php
+++ b/src/PhpBrew/Command/ListIniCommand.php
@@ -14,7 +14,9 @@ class ListIniCommand extends Command
 
     public function execute()
     {
-        UsePhpFunctionWrapper::execute('php_ini_scanned_files()', $output) ? $filelist = $output : $filelist = '';
+        UsePhpFunctionWrapper::execute('php_ini_scanned_files()', $output)
+            ? $filelist = $output
+            : $filelist = '';
         if ($filelist) {
             echo "Loaded ini files:\n";
             if (strlen($filelist) > 0) {

--- a/src/PhpBrew/Command/ListIniCommand.php
+++ b/src/PhpBrew/Command/ListIniCommand.php
@@ -3,6 +3,7 @@
 namespace PhpBrew\Command;
 
 use CLIFramework\Command;
+use PhpBrew\Config;
 
 class ListIniCommand extends Command
 {
@@ -13,14 +14,31 @@ class ListIniCommand extends Command
 
     public function execute()
     {
-        if ($filelist = php_ini_scanned_files()) {
+        if ($files = $this->getCurrentPhpScannedIniFiles()) {
             echo "Loaded ini files:\n";
-            if (strlen($filelist) > 0) {
-                $files = explode(',', $filelist);
+            if (count($files) > 0) {
                 foreach ($files as $file) {
-                    echo ' - ' . trim($file) . "\n";
+                    echo ' - ' . $file . "\n";
                 }
             }
         }
+    }
+
+    private function getCurrentPhpScannedIniFiles()
+    {
+        $cmd  = Config::getCurrentPhpBin() . '/php';
+        $options = ' -r ';
+        $code = '"echo php_ini_scanned_files();"';
+
+        exec($cmd . $options . $code, $output, $retVal);
+        if ($retVal) {
+            return false;
+        }
+
+        foreach ($output as $file) {
+            $files[] = str_replace(',', '', $file);
+        }
+
+        return $files;
     }
 }

--- a/src/PhpBrew/UsePhpFunctionWrapper.php
+++ b/src/PhpBrew/UsePhpFunctionWrapper.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace PhpBrew;
+
 use PhpBrew\Config;
 
 class UsePhpFunctionWrapper
@@ -20,9 +21,9 @@ class UsePhpFunctionWrapper
         $process = proc_open($command, $descriptorspec, $pipes);
 
         if ($passthru) {
-            $code = '<?php ' . $func  .'; ?>';
+            $code = '<?php ' . $func  . '; ?>';
         } else {
-            $code = '<?php echo serialize(' . $func  .'); ?>';
+            $code = '<?php echo serialize(' . $func  . '); ?>';
         }
 
         if (is_resource($process)) {

--- a/src/PhpBrew/UsePhpFunctionWrapper.php
+++ b/src/PhpBrew/UsePhpFunctionWrapper.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PhpBrew;
+use PhpBrew\Config;
+
+class UsePhpFunctionWrapper
+{
+    public static function execute($func, &$output = null, $passthru = false)
+    {
+        $retVal = false;
+
+        $command = Config::getCurrentPhpBin() . '/php';
+
+        $descriptorspec = array(
+           0 => array("pipe", "r"),
+           1 => array("pipe", "w"),
+           2 => array("pipe", "w")
+        );
+
+        $process = proc_open($command, $descriptorspec, $pipes);
+
+        if ($passthru) {
+            $code = '<?php ' . $func  .'; ?>';
+        } else {
+            $code = '<?php echo serialize(' . $func  .'); ?>';
+        }
+
+        if (is_resource($process)) {
+            fwrite($pipes[0], $code);
+            fclose($pipes[0]);
+
+            $output = stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+
+            $retVal = proc_close($process);
+
+            if ($retVal === 0) {
+                if (!$passthru) {
+                    $output = unserialize($output);
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Use exec() to run php code with used interpreter instead of system interpreter.