### PR TITLE
Get the ini info from the currently used PHP instead of the PHPBrew interpreter

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -373,6 +373,9 @@ function phpbrew ()
                     ;;
             esac
             ;;
+        info)
+            __phpbrew_php_exec info | php
+            ;;
         off)
             unset PHPBREW_PHP
             unset PHPBREW_PATH

--- a/shell/bashrc
+++ b/shell/bashrc
@@ -180,9 +180,20 @@ function __phpbrew_set_lookup_prefix ()
     esac
 }
 
+# Edit the current PHP's php.ini in $EDITOR
+function __phpbrew_edit_ini()
+{
+    local ini="$(php -r "echo php_ini_loaded_file();")"
+
+    if [[ $? -ne 0 ]] ; then
+        return 1
+    fi
+
+    command "${EDITOR:-nano}" "$ini"
+}
+
 function phpbrew ()
 {
-    local exit_status
     local short_option
     if [[ `echo $1 | awk 'BEGIN{FS=""}{print $1}'` = '-' ]]
     then
@@ -218,6 +229,9 @@ function phpbrew ()
             if [[ -d $SOURCE_DIR ]] ; then
                 builtin cd $SOURCE_DIR
             fi
+            ;;
+        config)
+            __phpbrew_edit_ini
             ;;
         switch)
             if [[ -z "$2" ]]; then
@@ -264,7 +278,6 @@ function phpbrew ()
         each)
             shift
             __phpbrew_each "$@"
-            exit_status=$?
             ;;
         fpm)
             if ! [[ -z $3 ]]; then
@@ -316,7 +329,6 @@ function phpbrew ()
                     ;;
                 setup)
                     __phpbrew_php_exec $short_option "$@"
-                    exit_status=$?
                     ;;
                 restart)
                     fpm_stop
@@ -409,16 +421,20 @@ function phpbrew ()
             else
                 shift
                 __phpbrew_purge "$@"
-                exit_status=$?
             fi
             ;;
         *)
             __phpbrew_php_exec $short_option "$@"
-            exit_status=$?
             ;;
     esac
+
+    local status=$?
+
+    if [[ $status -ne 0 ]]; then
+        return $status
+    fi
+
     hash -r
-    return ${exit_status:-0}
 }
 
 function __phpbrew_update_config ()

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -330,6 +330,9 @@ function phpbrew
                     echo "Usage: phpbrew fpm [start|stop|restart|module|test|help|config]"
             end
 
+        case info
+            __phpbrew_php_exec info | php
+
         case off
             set -e PHPBREW_PHP
             set -e PHPBREW_PATH

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -168,8 +168,18 @@ function __phpbrew_set_lookup_prefix
     end
 end
 
+# Edit the current PHP's php.ini in $EDITOR
+function __phpbrew_edit_ini
+    set -l ini (php -r "echo php_ini_loaded_file();");
+    or return 1
+
+    set -q EDITOR;
+    or set -l EDITOR nano
+
+    command $EDITOR $ini
+end
+
 function phpbrew
-    set exit_status
     set short_option
     # export SHELL
     if [ (echo $argv[1] | awk 'BEGIN{FS=""}{print $1}') = '-' ]
@@ -204,6 +214,8 @@ function phpbrew
             if [ -d $SOURCE_DIR ]
                 cd $SOURCE_DIR
             end
+        case config
+            __phpbrew_edit_ini
         case 'switch'
             if [ (count $argv) -eq 1 ]
                 echo "Please specify the php version."
@@ -370,11 +382,8 @@ function phpbrew
             else
                 __phpbrew_php_exec $short_option $argv
             end
-            set exit_status $status
             ;;
     end
-
-    return $exit_status
 end
 
 function __phpbrew_update_config

--- a/src/PhpBrew/Command/ConfigCommand.php
+++ b/src/PhpBrew/Command/ConfigCommand.php
@@ -2,27 +2,10 @@
 
 namespace PhpBrew\Command;
 
-use CLIFramework\Command;
-use PhpBrew\Config;
-use PhpBrew\Utils;
-
-class ConfigCommand extends Command
+class ConfigCommand extends VirtualCommand
 {
     public function brief()
     {
         return 'Edit your current php.ini in your favorite $EDITOR';
-    }
-
-    public function execute()
-    {
-        $file = php_ini_loaded_file();
-        if (!file_exists($file)) {
-            $php = Config::getCurrentPhpName();
-            $this->logger->warn("Sorry, I can't find the {$file} file for php {$php}.");
-
-            return;
-        }
-
-        Utils::editor($file);
     }
 }

--- a/src/PhpBrew/Command/ExtensionCommand/ConfigCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/ConfigCommand.php
@@ -39,9 +39,10 @@ class ConfigCommand extends BaseCommand
                     "Sorry, I can't find the ini file for the requested extension: \"{$extensionName}\"."
                 );
 
-                return;
+                return false;
             }
         }
-        Utils::editor($file);
+
+        return Utils::editor($file) === 0;
     }
 }

--- a/src/PhpBrew/Command/InfoCommand.php
+++ b/src/PhpBrew/Command/InfoCommand.php
@@ -8,7 +8,7 @@ class InfoCommand extends Command
 {
     public function brief()
     {
-        return 'Show current php information';
+        return 'Show current PHP information';
     }
 
     public function usage()
@@ -16,73 +16,65 @@ class InfoCommand extends Command
         return 'phpbrew info';
     }
 
-    public function header($text)
-    {
-        $f = $this->logger->formatter;
-        echo $f->format($text . "\n", 'strong_white');
-    }
-
     public function execute()
     {
-        $this->header('Version');
-        echo 'PHP-', phpversion(), "\n\n";
+        echo <<<'EOF'
+<?php
 
-        $this->header('Constants');
-        $constants = get_defined_constants();
+echo "Version\n";
+echo 'PHP-', phpversion(), "\n\n";
 
-        if (isset($constants['PHP_PREFIX'])) {
-            echo 'PHP Prefix: ', $constants['PHP_PREFIX'], "\n";
+echo "Constants\n";
+$constants = get_defined_constants();
+
+if (defined('PHP_PREFIX')) {
+    echo 'PHP Prefix: ', PHP_PREFIX, "\n";
+}
+
+if (defined('PHP_BINARY')) {
+    echo 'PHP Binary: ', PHP_BINARY, "\n";
+}
+
+if (defined('DEFAULT_INCLUDE_PATH')) {
+    echo 'PHP Default Include path: ', DEFAULT_INCLUDE_PATH, "\n";
+}
+
+echo 'PHP Include path: ', get_include_path(), "\n\n";
+
+echo "General Info\n";
+phpinfo(INFO_GENERAL);
+echo "\n";
+
+echo "Extensions\n";
+$extensions = get_loaded_extensions();
+echo implode(', ', $extensions), "\n";
+echo "\n";
+
+echo "Database Extensions\n";
+foreach (
+    array_filter(
+        $extensions,
+        function ($n) {
+            return in_array(
+                $n,
+                array(
+                'PDO',
+                'pdo_mysql',
+                'pdo_pgsql',
+                'pdo_sqlite',
+                'pgsql',
+                'mysqli',
+                'mysql',
+                'oci8',
+                'sqlite3',
+                'mysqlnd',
+                )
+            );
         }
-        if (isset($constants['PHP_BINARY'])) {
-            echo 'PHP Binary: ', $constants['PHP_BINARY'], "\n";
-        }
-        if (isset($constants['DEFAULT_INCLUDE_PATH'])) {
-            echo 'PHP Default Include path: ', $constants['DEFAULT_INCLUDE_PATH'], "\n";
-        }
-        echo 'PHP Include path: ', get_include_path(), "\n";
-        echo "\n";
-
-        // DEFAULT_INCLUDE_PATH
-        // PEAR_INSTALL_DIR
-        // PEAR_EXTENSION_DIR
-        // ZEND_THREAD_SAFE
-        // zend_version
-
-        $this->header('General Info');
-        phpinfo(INFO_GENERAL);
-        echo "\n";
-
-        $this->header('Extensions');
-
-        $extensions = get_loaded_extensions();
-        $this->logger->info(implode(', ', $extensions));
-
-        echo "\n";
-
-        $this->header('Database Extensions');
-        foreach (
-            array_filter(
-                $extensions,
-                function ($n) {
-                    return in_array(
-                        $n,
-                        array(
-                        'PDO',
-                        'pdo_mysql',
-                        'pdo_pgsql',
-                        'pdo_sqlite',
-                        'pgsql',
-                        'mysqli',
-                        'mysql',
-                        'oci8',
-                        'sqlite3',
-                        'mysqlnd',
-                        )
-                    );
-                }
-            ) as $extName
-        ) {
-            $this->logger->info($extName, 1);
-        }
+    ) as $extName
+) {
+    echo $extName, "\n";
+}
+EOF;
     }
 }

--- a/src/PhpBrew/Utils.php
+++ b/src/PhpBrew/Utils.php
@@ -273,6 +273,8 @@ class Utils
     {
         $tty = exec('tty');
         $editor = escapeshellarg(getenv('EDITOR') ?: 'nano');
-        exec("{$editor} {$file} > {$tty}");
+        exec("{$editor} {$file} > {$tty}", $_, $ret);
+
+        return $ret;
     }
 }


### PR DESCRIPTION
Additionally, cleaned up handling exit codes in shell wrappers and fixed the exit code in `phpbrew ext config`.

Fixes #1134.