### PR TITLE
Restored the accidentally removed initialization of $PHPBREW_ROOT in shell wrappers

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -12,6 +12,7 @@
 # PHPBREW_PATH: the bin path of the current php.
 # PHPBREW_SYSTEM_PHP: the path to the system php binary.
 
+[[ -z "$PHPBREW_ROOT" ]] && export PHPBREW_ROOT="$HOME/.phpbrew"
 [[ -z "$PHPBREW_HOME" ]] && export PHPBREW_HOME="$HOME/.phpbrew"
 
 # The minimal PHP version that PhpBrew supports as interpreter
@@ -117,7 +118,7 @@ function __phpbrew_set_path()
 
     local PATH_WITHOUT_PHPBREW
 
-    if [[ -n $PHPBREW_ROOT ]] ; then
+    if [[ -n "$PHPBREW_ROOT" ]] ; then
         PATH_WITHOUT_PHPBREW=$(p=$(echo $PATH | tr ":" "\n" | grep -v "^$PHPBREW_ROOT" | tr "\n" ":"); echo ${p%:})
     else
         PATH_WITHOUT_PHPBREW=$PATH
@@ -144,8 +145,8 @@ if [[ -z "$PHPBREW_SKIP_INIT" ]]; then
     __phpbrew_load_user_config
 fi
 
-[[ -e "$PHPBREW_ROOT" ]] || mkdir $PHPBREW_ROOT
-[[ -e "$PHPBREW_HOME" ]] || mkdir $PHPBREW_HOME
+[[ -e "$PHPBREW_ROOT" ]] || mkdir "$PHPBREW_ROOT"
+[[ -e "$PHPBREW_HOME" ]] || mkdir "$PHPBREW_HOME"
 
 # When setting lookup prefix, the alias name will be translated into the real
 # path.

--- a/shell/bashrc
+++ b/shell/bashrc
@@ -19,6 +19,12 @@
 MIN_PHP_VERSION="7.2.0"
 MIN_PHP_VERSION_ID=70200
 
+# Returns the absolute path corresponding to the command excluding the alias
+function __phpbrew_which()
+{
+    command which "$1"
+}
+
 # Executes the given command via the PHP implementation
 function __phpbrew_php_exec()
 {
@@ -28,13 +34,7 @@ function __phpbrew_php_exec()
     if [[ -e bin/phpbrew ]] ; then
         cmd=bin/phpbrew
     else
-        # If in Zsh, use the `whence' builtin instead of `which' to avoid
-        # the resolution of `phpbrew' to the function declared in this file
-        if command -v whence > /dev/null ; then
-            cmd=$(whence -p phpbrew)
-        else
-            cmd=$(which phpbrew)
-        fi
+        cmd="$(__phpbrew_which phpbrew)"
     fi
 
     # Force the usage of the system PHP interpreter if it's set
@@ -114,8 +114,6 @@ function __phpbrew_can_use_build()
 
 function __phpbrew_set_path()
 {
-    [[ -n $(alias php 2>/dev/null) ]] && unalias php 2> /dev/null
-
     local PATH_WITHOUT_PHPBREW
 
     if [[ -n "$PHPBREW_ROOT" ]] ; then
@@ -409,7 +407,7 @@ function phpbrew ()
             fi
             ;;
         system-off)
-            __phpbrew_validate_interpreter "$(which php)"
+            __phpbrew_validate_interpreter "$(__phpbrew_which php)"
 
             if [[ $? -ne 0 ]] ; then
                 echo "The currently used PHP build $PHPBREW_PHP cannot be used as PhpBrew interpreter"

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -606,6 +606,7 @@ function __fish_phpbrew_arg_meta
     __phpbrew_php_exec meta --flat $argv[1] arg $argv[2] $argv[3] | grep -v "^#"
 end
 
+[ -z "$PHPBREW_ROOT" ]; and set -gx PHPBREW_ROOT "$HOME/.phpbrew"
 [ -z "$PHPBREW_HOME" ]; and set -gx PHPBREW_HOME "$HOME/.phpbrew"
 
 if [ -z "$PHPBREW_SKIP_INIT" ]

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -67,6 +67,11 @@ end
 set MIN_PHP_VERSION    "7.2.0"
 set MIN_PHP_VERSION_ID 70200
 
+# Returns the absolute path corresponding to the command excluding the alias
+function __phpbrew_which
+    command which $argv
+end
+
 # Executes the given command via the PHP implementation
 function __phpbrew_php_exec
     # Force the usage of the system PHP interpreter if it's set
@@ -78,7 +83,7 @@ function __phpbrew_php_exec
     if [ -e bin/phpbrew ]
         set -a cmd bin/phpbrew
     else
-        set -a cmd (which phpbrew)
+        set -a cmd (__phpbrew_which phpbrew)
     end
 
     command $cmd $argv
@@ -359,7 +364,7 @@ function phpbrew
             end
 
         case system-off
-            if not __phpbrew_validate_interpreter (which php)
+            if not __phpbrew_validate_interpreter (__phpbrew_which php)
                 echo "The currently used PHP build $PHPBREW_PHP cannot be used as PhpBrew interpreter"
                 echo "Please execute `phpbrew switch` using PHP $MIN_PHP_VERSION or newer before switching the system interpreter off"
                 return 1


### PR DESCRIPTION
The initialization of `$PHPBREW_ROOT` was accidentally removed in #1098.