### PR TITLE
Use PKG_CONFIG_PATH instead of --with-onig to configure mbstring

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -169,7 +169,7 @@ class VariantBuilder
                 ));
 
                 if ($prefix !== null) {
-                    $params = $params->withOption('--with-onig', $prefix);
+                    $params = $params->withPkgConfigPath($prefix . '/lib/pkgconfig');
                 }
             }
 


### PR DESCRIPTION
Building PHP with the `mbstring` variant produces the following:

> configure: WARNING: unrecognized options: --with-onig

See https://www.php.net/manual/en/migration74.other-changes.php

> `--with-onig` has been removed.