### PR TITLE
Support fish v2

### DIFF
--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -259,7 +259,9 @@ function phpbrew
             return 0
 
         case each
-            __phpbrew_each $argv[2..-1]
+	    if [ (count $argv) -gt 1 ]
+                __phpbrew_each $argv[2..-1]
+	    end
 
         case fpm
             if [ (count $argv) -ge 3 ]

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -410,7 +410,7 @@ function __phpbrew_update_config
 end
 
 function __phpbrew_reinit
-    __phpbrew_update_config $argv && __phpbrew_set_path
+    __phpbrew_update_config $argv; and __phpbrew_set_path
 end
 
 function __phpbrew_each
@@ -423,7 +423,7 @@ function __phpbrew_each
     for build in $PHPBREW_ROOT/php/*
         if test -x $build/bin/php
             phpbrew use (basename $build)
-            eval $argv || set result $status
+            eval $argv; or set result $status
         end
     end;
 

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -86,7 +86,7 @@ function __phpbrew_php_exec
         set cmd $cmd (__phpbrew_which phpbrew)
     end
 
-    command $cmd $argv
+    eval $cmd $argv
 end
 
 # Normalizes a PHP build by adding the "php-" prefix if it's missing
@@ -125,7 +125,7 @@ function __phpbrew_validate_interpreter
         return 1
     end
 
-    set PHP_VERSION_ID (command $argv[1] -r "echo PHP_VERSION_ID;")
+    set PHP_VERSION_ID (eval $argv[1] -r "\"echo PHP_VERSION_ID;\"")
     or return 1
 
     if [ $PHP_VERSION_ID -lt $MIN_PHP_VERSION_ID ]
@@ -181,7 +181,7 @@ function __phpbrew_edit_ini
     set -q EDITOR;
     or set -l EDITOR nano
 
-    command $EDITOR $ini
+    eval $EDITOR $ini
 end
 
 function phpbrew

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -207,7 +207,7 @@ function phpbrew
             end
 
             set -l IFS
-            if not set -l output (__phpbrew_php_exec env (__phpbrew_normalize_build $argv[2]))
+            if not set output (__phpbrew_php_exec env (__phpbrew_normalize_build $argv[2]))
                 echo $output
                 return 1
             end
@@ -396,7 +396,7 @@ end
 
 function __phpbrew_update_config
     set -l IFS
-    if not set -l output (__phpbrew_php_exec env $argv)
+    if not set output (__phpbrew_php_exec env $argv)
         echo $output
         return 1
     end

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -81,9 +81,9 @@ function __phpbrew_php_exec
 
     # Check if we are in a PHPBrew source directory (this is only for development)
     if [ -e bin/phpbrew ]
-        set -a cmd bin/phpbrew
+        set cmd $cmd bin/phpbrew
     else
-        set -a cmd (__phpbrew_which phpbrew)
+        set cmd $cmd (__phpbrew_which phpbrew)
     end
 
     command $cmd $argv
@@ -556,7 +556,7 @@ function __fish_phpbrew_command
         switch $token
             case "-*"
             case "*"
-                set -a command "$token"
+                set command $command "$token"
         end
     end
 
@@ -583,7 +583,7 @@ function __fish_phpbrew_using_command
             case "--multiple"
                 set multiple yes
             case "*"
-                set -a expected "$arg"
+                set expected $expected "$arg"
         end
     end
 


### PR DESCRIPTION
## Purpose
Support fish v2 for CentOS and so on.
(In CentOS7, version of fish which is installed by yum is 2.3.1)

If it is not necessary to support fish v2, I'll close this PR...

## Changes
- Use `and` & `or` instead of `&&` & `||`
- Halt the use of `-a` option in `set`
- Use `eval` instead of `command`, because it is not supported by fish2 to execute variable.
- Add validation of arguments at `each`
