### PR TITLE
Simplify Box configuration

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -6,8 +6,7 @@
         "KevinGH\\Box\\Compactor\\Php"
     ],
     "check-requirements": false,
-    "force-autodiscovery": true,
-    "directories": [
+    "directories-bin": [
         "shell"
     ]
 }


### PR DESCRIPTION
To be double checked but that should be strictly equivalent.

There difference with the `*-bin` settings is that the files content is left untouched, which is what is desired here (at the very least until we have a Bash compactor) and doing so remove the need to specify the `force-autodiscovery`