### PR TITLE
Use custom OpenSSL libs for OpenSSLDSOPatch

### DIFF
--- a/src/PhpBrew/Patches/OpenSSLDSOPatch.php
+++ b/src/PhpBrew/Patches/OpenSSLDSOPatch.php
@@ -24,6 +24,10 @@ class OpenSSLDSOPatch extends Patch
     public function rules()
     {
         /*
+        Custom
+         /usr/local/opt/phpbrew/openssl/lib/libssl.dylib
+         /usr/local/opt/phpbrew/openssl/lib/libcrypto.dylib
+
         Macports
          -lssl /opt/local/lib/libssl.dylib
          -lcrypto /opt/local/lib/libcrypto.dylib
@@ -35,7 +39,8 @@ class OpenSSLDSOPatch extends Patch
         $dylibssl = null;
         $dylibcrypto = null;
 
-        $paths = array('/opt/local/lib/libssl.dylib',
+        $paths = array('/usr/local/opt/phpbrew/openssl/lib/libssl.dylib',
+            '/opt/local/lib/libssl.dylib',
             '/usr/local/opt/openssl/lib/libssl.dylib',
             '/usr/local/lib/libssl.dylib', '/usr/lib/libssl.dylib', );
         foreach ($paths as $path) {
@@ -45,7 +50,8 @@ class OpenSSLDSOPatch extends Patch
             }
         }
 
-        $paths = array('/opt/local/lib/libcrypto.dylib',
+        $paths = array('/usr/local/opt/phpbrew/openssl/lib/libcrypto.dylib',
+            '/opt/local/lib/libcrypto.dylib',
             '/usr/local/opt/openssl/lib/libcrypto.dylib',
             '/usr/local/lib/libcrypto.dylib', '/usr/lib/libcrypto.dylib', );
         foreach ($paths as $path) {


### PR DESCRIPTION
I had a funny case recently:

- Have already installed `php-7.3.6`, which uses `OpenSSL 1.0.2s`:
    ```
    $ ls -l /usr/local/opt/openssl
    XXX  24 Jun  9 20:58 /usr/local/opt/openssl -> ../Cellar/openssl/1.0.2s
    ```

- Wanted to install `php-7.4.6`, which requires `OpenSSL 1.1.1g`. I was getting following errors during the build when `OpenSSL 1.0.2s` was used:
    ```
    Undefined symbols for architecture x86_64:
      "_ASN1_STRING_get0_data", referenced from:
          _zif_openssl_spki_export_challenge in openssl.o
          _php_openssl_add_assoc_name_entry in openssl.o
          _php_openssl_asn1_time_to_time_t in openssl.o
          _openssl_x509v3_subjectAltName in openssl.o
      "_BN_is_zero", referenced from:
          _php_openssl_pkey_init_dsa in openssl.o
      "_BN_with_flags", referenced from:
          _php_openssl_dh_pub_from_priv in openssl.o
    ```

I wasn't able just to update `/usr/local/opt/openssl` as it was breaking my current `php-7.3.6`. So I compiled `OpenSSL 1.0.2s` at `/usr/local/openssl/1.1.1g`, and was using `export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/openssl/1.1.1g/lib/pkgconfig` before `phpbrew install...` call. But it still was causing the same error during the build. After some debugging I found out that `OpenSSLDSOPatch` is causing it.

So this PR allows to:
Use custom OpenSSL libs for `OpenSSLDSOPatch`, they just need to be linked to `/usr/local/opt/phpbrew/openssl/lib`. And maybe it worth to add some notice message when this patch is applied?