### PR TITLE
Rework the +pgsql variant

### DIFF
--- a/src/PhpBrew/PrefixFinder/ExecutablePrefixFinder.php
+++ b/src/PhpBrew/PrefixFinder/ExecutablePrefixFinder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpBrew\PrefixFinder;
+
+use PhpBrew\PrefixFinder;
+use PhpBrew\Utils;
+
+/**
+ * The strategy of finding prefix by an executable file.
+ */
+final class ExecutablePrefixFinder implements PrefixFinder
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name Executable name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findPrefix()
+    {
+        $bin = Utils::findBin('pg_config');
+
+        if ($bin === null) {
+            return null;
+        }
+
+        return dirname($bin);
+    }
+}


### PR DESCRIPTION
1. Generalize the logic of finding a prefix by executable
2. Add support for building the `pgsql` and `pdo_pgsql` extensions with Homebrew-managed `libpq`.