### PR TITLE
Improve IMAP support on macOS

### DIFF
--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -75,8 +75,8 @@ class Build implements Buildable
      */
     public function __construct($version, $name = null, $installPrefix = null)
     {
-        $this->version = $version;
-        $this->name = $name ? $name : Utils::canonicalizeBuildName($version);
+        $this->setVersion($version);
+        $this->name = $name ? $name : $this->version;
 
         if ($installPrefix) {
             $this->setInstallPrefix($installPrefix);

--- a/src/PhpBrew/ConfigureParameters.php
+++ b/src/PhpBrew/ConfigureParameters.php
@@ -65,6 +65,30 @@ final class ConfigureParameters
     }
 
     /**
+     * Creates a new object with the given option. When building PHP 7.3 or older, the non-NULL value
+     * is passed as the option value. When building PHP 7.4 or newer, the value is added as a PKG_CONFIG_PATH prefix.
+     *
+     * @param string      $option
+     * @param string|null $value
+     *
+     * @return self
+     */
+    public function withOptionOrPkgConfigPath(Build $build, $option, $value)
+    {
+        if ($build->compareVersion('7.4') < 0) {
+            return $this->withOption($option, $value);
+        }
+
+        $new = $this->withOption($option);
+
+        if ($value !== null) {
+            $new = $new->withPkgConfigPath($value . '/lib/pkgconfig');
+        }
+
+        return $new;
+    }
+
+    /**
      * @return array<string,string|null>
      */
     public function getOptions()

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -46,12 +46,6 @@ class ConfigureTask extends BaseTask
         }
 
         if (!$this->options->dryrun) {
-            $pkgConfigPaths = $parameters->getPkgConfigPaths();
-
-            if (count($pkgConfigPaths) > 0) {
-                putenv('PKG_CONFIG_PATH=' . implode(PATH_SEPARATOR, $pkgConfigPaths));
-            }
-
             $code = $cmd->execute($lastline);
             if ($code !== 0) {
                 throw new SystemCommandException("Configure failed: $lastline", $build, $buildLogPath);
@@ -72,6 +66,12 @@ class ConfigureTask extends BaseTask
             }
 
             $args[] = $arg;
+        }
+
+        $pkgConfigPaths = $parameters->getPkgConfigPaths();
+
+        if (count($pkgConfigPaths) > 0) {
+            $args[] = 'PKG_CONFIG_PATH=' . implode(PATH_SEPARATOR, $pkgConfigPaths);
         }
 
         return $args;

--- a/src/PhpBrew/Utils.php
+++ b/src/PhpBrew/Utils.php
@@ -23,15 +23,6 @@ class Utils
         return false;
     }
 
-    public static function canonicalizeBuildName($version)
-    {
-        if (!preg_match('/^php-/', $version)) {
-            return 'php-' . $version;
-        }
-
-        return $version;
-    }
-
     public static function support64bit()
     {
         $int = '9223372036854775807';

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -209,7 +209,26 @@ class VariantBuilder
 
         $this->variants['opcache'] = '--enable-opcache';
 
-        $this->variants['imap'] = '--with-imap-ssl';
+        $this->variants['imap'] = function (ConfigureParameters $params, Build $build, $value) {
+            $imapPrefix = Utils::findPrefix(array(
+                new UserProvidedPrefix($value),
+                new BrewPrefixFinder('imap-uw'),
+            ));
+
+            $kerberosPrefix = Utils::findPrefix(array(
+                new BrewPrefixFinder('krb5'),
+            ));
+
+            $opensslPrefix = Utils::findPrefix(array(
+                new BrewPrefixFinder('openssl'),
+                new PkgConfigPrefixFinder('openssl'),
+                new IncludePrefixFinder('openssl/opensslv.h'),
+            ));
+
+            return $params->withOption('--with-imap', $imapPrefix)
+                ->withOptionOrPkgConfigPath($build, '--with-kerberos', $kerberosPrefix)
+                ->withOptionOrPkgConfigPath($build, '--with-imap-ssl', $opensslPrefix);
+        };
 
         $this->variants['ldap'] = function (ConfigureParameters $params, Build $_, $value) {
             $prefix = Utils::findPrefix(array(

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -290,15 +290,7 @@ class VariantBuilder
                 new IncludePrefixFinder('zlib.h'),
             ));
 
-            if ($build->compareVersion('7.4') < 0) {
-                return $params->withOption('--with-zlib', $prefix);
-            }
-
-            if ($prefix !== null) {
-                $params = $params->withPkgConfigPath($prefix . '/lib/pkgconfig');
-            }
-
-            return $params->withOption('--with-zlib');
+            return $params->withOptionOrPkgConfigPath($build, '--with-zlib', $prefix);
         };
 
         $this->variants['curl'] = function (ConfigureParameters $params, Build $build, $value) {
@@ -309,15 +301,7 @@ class VariantBuilder
                 new IncludePrefixFinder('curl/curl.h'),
             ));
 
-            if ($build->compareVersion('7.4') < 0) {
-                return $params->withOption('--with-curl', $prefix);
-            }
-
-            if ($prefix !== null) {
-                $params = $params->withPkgConfigPath($prefix . '/lib/pkgconfig');
-            }
-
-            return $params->withOption('--with-curl');
+            return $params->withOptionOrPkgConfigPath($build, '--with-curl', $prefix);
         };
 
         /*
@@ -520,15 +504,7 @@ class VariantBuilder
                 new IncludePrefixFinder('openssl/opensslv.h'),
             ));
 
-            if ($build->compareVersion('7.4') < 0) {
-                return $parameters->withOption('--with-openssl', $prefix);
-            }
-
-            if ($prefix !== null) {
-                $parameters = $parameters->withPkgConfigPath($prefix . '/lib/pkgconfig');
-            }
-
-            return $parameters->withOption('--with-openssl');
+            return $parameters->withOptionOrPkgConfigPath($build, '--with-openssl', $prefix);
         };
 
         /*


### PR DESCRIPTION
1. Pass `PKG_CONFIG_PATH` via `./configure`. Otherwise, the environment variable is set globally and isn't displayed in debug mode.
2. Add `ConfigureParameters::withOptionOrPkgConfigPath()` since it seems to be a pattern depending on the PHP version.
3. Collect all the needed dependencies for IMAP on macOS from Homebrew.
4. Canonicalize version in the Build constructor. Otherwise, `php-7.3.24RC1` is not less than `7.4`.