### PR TITLE
Fetch PHP 8 releases from the website

### DIFF
--- a/completion/zsh/_phpbrew
+++ b/completion/zsh/_phpbrew
@@ -383,7 +383,7 @@ local ret=1
         ;;
         (update)
             _arguments -w -S -s \
-              '(-o --old)'{-o,--old}'[List old phps (less than 5.3)]' \
+              '(-o --old)'{-o,--old}'[List versions older than PHP 7.0]' \
               '--downloader=[Use alternative downloader.]' \
               '--continue[Continue getting a partially downloaded file.]' \
               '--http-proxy=[HTTP proxy address]' \

--- a/src/PhpBrew/Command/UpdateCommand.php
+++ b/src/PhpBrew/Command/UpdateCommand.php
@@ -15,7 +15,7 @@ class UpdateCommand extends Command
 
     public function options($opts)
     {
-        $opts->add('o|old', 'List old phps (less than 5.3)');
+        $opts->add('o|old', 'List versions older than PHP 7.0');
 
         DownloadFactory::addOptionsForCommand($opts);
     }
@@ -26,7 +26,7 @@ class UpdateCommand extends Command
         $releases = $fetchTask->fetch();
 
         foreach ($releases as $majorVersion => $versions) {
-            if (strpos($majorVersion, '5.2') !== false && !$this->options->old) {
+            if (version_compare($majorVersion, '5.2', '<=')) {
                 continue;
             }
             $versionList = array_keys($versions);

--- a/src/PhpBrew/Testing/CommandTestCase.php
+++ b/src/PhpBrew/Testing/CommandTestCase.php
@@ -14,7 +14,7 @@ abstract class CommandTestCase extends BaseCommandTestCase
 
     private $previousPhpBrewHome;
 
-    public $primaryVersion = '5.5.37';
+    public $primaryVersion = '7.0.33';
 
     /**
      * You need to set this to true in each subclass you want to use VCR in.

--- a/tests/PhpBrew/Command/DownloadCommandTest.php
+++ b/tests/PhpBrew/Command/DownloadCommandTest.php
@@ -15,8 +15,8 @@ class DownloadCommandTest extends CommandTestCase
     public function versionDataProvider()
     {
         return array(
-            array('5.5'),
-            array('5.5.15'),
+            array('7.0'),
+            array('7.0.33'),
         );
     }
 


### PR DESCRIPTION
Additionally, all builds older than PHP 7 are moved under the `--old` category.