### PR TITLE
Fix ExecutablePrefixFinder executable name

### DIFF
--- a/src/PhpBrew/PrefixFinder/ExecutablePrefixFinder.php
+++ b/src/PhpBrew/PrefixFinder/ExecutablePrefixFinder.php
@@ -28,7 +28,7 @@ final class ExecutablePrefixFinder implements PrefixFinder
      */
     public function findPrefix()
     {
-        $bin = Utils::findBin('pg_config');
+        $bin = Utils::findBin($this->name);
 
         if ($bin === null) {
             return null;

--- a/tests/PhpBrew/PrefixFinder/ExecutablePrefixFinderTest.php
+++ b/tests/PhpBrew/PrefixFinder/ExecutablePrefixFinderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PhpBrew\Tests;
+
+use PhpBrew\PrefixFinder\ExecutablePrefixFinder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group prefixfinder
+ */
+class ExecutablePrefixFinderTest extends TestCase
+{
+    public function testFindValid()
+    {
+        $epf = new ExecutablePrefixFinder('ls');
+        $this->assertNotNull($epf->findPrefix());
+    }
+
+    public function testFindInvalid()
+    {
+        $epf = new ExecutablePrefixFinder('inexistent-binary');
+        $this->assertNull($epf->findPrefix());
+    }
+}


### PR DESCRIPTION
This PR replaces a static `pg_config` parameter with the expected `$this->name` in the ExecutablePrefixFinder code.

(Introduced by #1200)