### PR TITLE
Explicit PATH_WITHOUT_PHPBREW variable

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -117,7 +117,7 @@ function __phpbrew_set_path()
     local PATH_WITHOUT_PHPBREW
 
     if [[ -n "$PHPBREW_ROOT" ]] ; then
-        PATH_WITHOUT_PHPBREW=$(p=$(echo $PATH | tr ":" "\n" | grep -v "^$PHPBREW_ROOT" | tr "\n" ":"); echo ${p%:})
+        PATH_WITHOUT_PHPBREW=$(p=$(echo $PATH | tr ":" "\n" | grep -v "^$PHPBREW_ROOT/php" | tr "\n" ":"); echo ${p%:})
     else
         PATH_WITHOUT_PHPBREW=$PATH
     fi

--- a/shell/phpbrew.fish
+++ b/shell/phpbrew.fish
@@ -39,7 +39,7 @@ function __phpbrew_set_path
 
     if set -q PHPBREW_ROOT
         for i in $PATH
-            if [ (expr $i : $PHPBREW_ROOT) -eq 0 ]
+            if [ (expr $i : "$PHPBREW_ROOT/php") -eq 0 ]
                 set PATH_WITHOUT_PHPBREW $PATH_WITHOUT_PHPBREW $i
             end
         end


### PR DESCRIPTION
`PATH_WITHOUT_PHPBREW` will be only remove`$PHPBREW_ROOT/php` from `$PATH`.

For example, Install phpbrew to `$HOME/.phpbrew/bin/phpbrew`.
Will not be able to find phpbrew after running `__phpbrew_set_path`.

I think appropriate to remove `$PHPBREW_ROOT/php`. Because `PATH_WITHOUT_PHPBREW` is expect to only exclude the path to the installed PHP.
