### PR TITLE
Validate the new version during self-update

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -4,7 +4,6 @@
         "KevinGH\\Box\\Compactor\\Json",
         "KevinGH\\Box\\Compactor\\Php"
     ],
-    "check-requirements": false,
     "force-autodiscovery": true,
     "directories": [
         "shell"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "bin/phpbrew"
     ],
     "require": {
+        "php": "^5.3.9||^7.0||^8.0",
         "corneltek/cliframework": "3.0.x-dev#2650a53433854d43b91955e8f967c62ce07869d7",
         "corneltek/pearx": "^1.3.5",
         "corneltek/curlkit": "^1.0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af4c0c14b2f53dd2db7aa06a00bc70cc",
+    "content-hash": "e69a569ec798bc094362754ccaf1886e",
     "packages": [
         {
             "name": "corneltek/class-template",
@@ -2066,6 +2066,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
+        "php": "^5.3.9||^7.0||^8.0",
         "ext-simplexml": "*"
     },
     "platform-dev": [],

--- a/src/PhpBrew/Command/SelfUpdateCommand.php
+++ b/src/PhpBrew/Command/SelfUpdateCommand.php
@@ -56,6 +56,12 @@ class SelfUpdateCommand extends Command
         chmod($tempFile, 0755);
         //todo we can check the hash here in order to make sure we have download the phar successfully
 
+        if (!$this->checkRequirements($tempFile)) {
+            unlink($tempFile);
+
+            throw new RuntimeException('Update failed');
+        }
+
         //move the tmp file to executable path
         if (!rename($tempFile, $script)) {
             throw new RuntimeException('Update Failed', 3);
@@ -63,6 +69,21 @@ class SelfUpdateCommand extends Command
 
         $this->logger->info('Version updated.');
         system($script . ' init');
-        system($script . ' --version');
+    }
+
+    /**
+     * Check if the new version is compatible with the current runtime.
+     *
+     * This assumes that the binary will check the runtime requirements for any sub-command including `--version`.
+     *
+     * @param string $binary The path to the new PHPBrew version binary
+     *
+     * @return bool
+     */
+    private function checkRequirements($binary)
+    {
+        system(escapeshellcmd($binary) . ' --version', $code);
+
+        return $code === 0;
     }
 }


### PR DESCRIPTION
It is possible that during the upgrade, the new PHPBrew version has the requirements incompatible with the current runtime. It could be a PHP version or required extensions. In such a case, the upgrade will effectively break PHPBrew.

Since we use Box for packaging the binary, we can use its "Check Requirements" feature and validate the downloaded binary before switching to the new version.

If the validation fails, the upgrade will fail as well like follows:
```
$ phpbrew self-update

Updating phpbrew /Users/smorozov/.local/bin/phpbrew...
downloading via curl command
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    67  100    67    0     0   7444      0 --:--:-- --:--:-- --:--:--  7444
Box Requirements Checker
========================

> Using PHP 8.0.1
> PHP is using the following php.ini file:
  /Users/smorozov/.phpbrew/php/php-8.0.1/etc/php.ini

> Checking Box requirements:
  E.


 [ERROR] Your system is not ready to run the application.


Fix the following mandatory requirements:
=========================================

 * The application requires the version "^9.0" or greater.
Update failed
```