### PR TITLE
Update ReleaseList.php

### DIFF
--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -167,7 +167,11 @@ class ReleaseList
 
         $file = DownloadFactory::getInstance(Logger::getInstance(), $options)->download($url);
         $json = file_get_contents($file);
-
+        
+        if (preg_match('/^HTTP/i', $json)) {
+            list($headers, $json) = explode("\r\n\r\n", $json, 2);
+        }
+        
         return json_decode($json, true);
     }
 


### PR DESCRIPTION
Warning: array_merge(): Expected parameter 1 to be an array, null given in phar:///Users/zhiyuan/www/test/phpbrew/phpbrew/src/PhpBrew/ReleaseList.php on line 178
Warning: Invalid argument supplied for foreach() in phar:///Users/zhiyuan/www/test/phpbrew/phpbrew/src/PhpBrew/ReleaseList.php on line 186
默认使用的PhpCurlDownloader的输出带了头信息,导致json_decode失败,从而触发上面的错误,这里把读到的头信息删掉就正常了