### PR TITLE
For issue_#1211

### DIFF
--- a/src/PhpBrew/Patches/Apache2ModuleNamePatch.php
+++ b/src/PhpBrew/Patches/Apache2ModuleNamePatch.php
@@ -43,21 +43,61 @@ class Apache2ModuleNamePatch extends Patch
 
         SAPI_SHARED=libs/libphp5.so
         */
-        $rules[] = RegExpPatchRule::files(array('configure'))
-            ->always()
-            ->replaces(
-                '#libphp\$PHP_MAJOR_VERSION\.#',
-                'libphp$PHP_VERSION.'
-            );
+        if (version_compare($this->targetPhpVersion, '8.0') < 0) {
+            $rules[] = RegExpPatchRule::files(array('configure'))
+                ->always()
+                ->replaces(
+                    '#libphp\$PHP_MAJOR_VERSION\.#',
+                    'libphp$PHP_VERSION.'
+                );
 
-        $rules[] = RegExpPatchRule::files(array('configure'))
-            ->always()
-            ->replaces(
-                '#libs/libphp[57].(so|la)#',
-                'libs/libphp\$PHP_VERSION.$1'
-            );
+
+            $rules[] = RegExpPatchRule::files(array('configure'))
+                ->always()
+                ->replaces(
+                    '#libs/libphp[57].(so|la)#',
+                    'libs/libphp\$PHP_VERSION.$1'
+                );
+        } else {
+            $rules[] = RegExpPatchRule::files(array('configure'))
+                ->always()
+                ->replaces(
+                    '#libphp.(a|so|la|bundle)#',
+                    'libphp$PHP_VERSION.$1'
+                );
+
+            $rules[] = RegExpPatchRule::files(array('configure'))
+                ->always()
+                ->replaces(
+                    '#libs/libphp.(a|so|la|bundle)#',
+                    'libs/libphp\$PHP_VERSION.$1'
+                );
+            $rules[] = RegExpPatchRule::files(array('configure'))
+                ->always()
+                ->replaces(
+                    '#libs/libphp.\$SHLIB_DL_SUFFIX_NAME#',
+                    'libs/libphp\$PHP_VERSION.$SHLIB_DL_SUFFIX_NAME'
+                );
+        }
 
         $makefile = 'Makefile.global';
+
+        if (version_compare($this->targetPhpVersion, '8.0') >= 0) {
+            $makefile = 'build/Makefile.global';
+            $rules[] = RegExpPatchRule::files(array($makefile))
+                 ->always()
+                 ->replaces(
+                     '#libphp.(a|so|la|bundle)#',
+                     'libphp$(PHP_VERSION).$1'
+                 );
+
+            $rules[] = RegExpPatchRule::files(array($makefile))
+                 ->always()
+                 ->replaces(
+                     '#libphp.\$\(SHLIB_DL_SUFFIX_NAME\)#',
+                     'libphp$(PHP_VERSION).$(SHLIB_DL_SUFFIX_NAME)'
+                 );
+        }
 
         if (version_compare($this->targetPhpVersion, '7.4') >= 0) {
             $makefile = 'build/Makefile.global';


### PR DESCRIPTION
# Changed log

- Fix the #1211 and #1221.
- Since the `PHP-8.0` version is released, it seems that the patterns in `configure` and `build/Makefile.global` files are changed. And it should modify pattern in `src/PhpBrew/Patches/Apache2ModuleNamePatch.php` file to let the Apache2 module for `PHP 8.x` can have the version information.
- This PR is the hot patch and it doesn't have the test, but it has the following steps to verify this PR.
- The detailed explanation is available [here](https://github.com/phpbrew/phpbrew/issues/1211#issuecomment-1148534412).

## The PR Verification

- Prepare the clean and fresh `Ubuntu 20.04` Linux distribution.
- Switch the user to be the `root` user.
- Installing the required packages to run the `PHPBrew`. Please refer [here](https://github.com/phpbrew/phpbrew/wiki/Requirement#ubuntu-2004).
- Running the `sudo apt-get install libonig-dev` command for compiling `mbstring` extension.
- Running the `git clone https://github.com/peter279k/phpbrew --branch issue_#1211` command.
- Running the `cd phpbrew/`.
- Download the `composer.phar` with running the `curl -sS https://getcomposer.org/installer | php` command.
- Running the `php ./composer.phar install -n` command.
- Running the `cp ./bin/phpbrew /usr/local/bin/phpbrew` command.
- Running the `phpbrew init` and `echo "[[ -e ~/.phpbrew/bashrc ]] && source ~/.phpbrew/bashrc" >> ~/.bashrc` commands.
- Running the `source ~/.phpbrew/bashrc` command.
- Running the `phpbrew update` command.
- Running the `phpbrew install 8.0 +default +apxs2=/usr/bin/apxs2` command.

## Related building log

After running above steps, it can see that the Apache2 module for PHP 8 has the version info.

Here are some building logs about compiling the `PHP 8.0.19` version:

- The running PHPBrew log is available [here](https://gist.github.com/peter279k/8ed3285e2370402e32fceed24de87df6).
- The `PHP 8.0.19` compiling log is available [here](https://gist.github.com/peter279k/43f98afeb50d69bfb3e616c1866c4e53).