### PR TITLE
Resolves issue #1216

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, zip, xml
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Update PHPUnit
+        run: composer update phpunit/phpunit --with-dependencies
+
+      - name: Run test suite
+        run: vendor/bin/phpunit --exclude-group mayignore --coverage-clover build/logs/clover.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 .phpbrew
 .phpcs.cache
+/build


### PR DESCRIPTION
# Changed log

- It's related to issue #1216.
- Migrating to the GitHub actions.
- I also organize original works in Travis CI:
  - Install the required dependencies and development dependencies via `composer install` command.
  - Running the test suites with the PHPUnit.
  - After running the PHPUnit successfully, it will download the `coveralls` to upload the code coverage.
  - Uploading the phpbrew Phar binary to the Amazon S3.
  - After PHPBrew uploading is successful, send the notification to the Gitter.
- And I migrate part of things. They're as follows:
   - Setup the from the `PHP 5.3` to `PHP 7.4` versions for running the PHPUnit test suites.
   - In the future, it will add the `PHP 8.0` and `PHP 8.1` versions after [related PR](https://github.com/phpbrew/phpbrew/pull/1264) is merged/resolved.
- Just notify that other works in Travis CI will be migrated to GitHub actions in upcoming PRs.

@c9s, please review this PR and I also ask two questions:

- Is it necessary to upload the PHPBrew? Or uploading the PHPBrew to the [released page](https://github.com/phpbrew/phpbrew/releases) directly?
- Is it still be necessary to send the notification to the Gitter?