### PR TITLE
Upgrade composer.lock with the PHP 7.2 version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -218,25 +218,28 @@
         },
         {
             "name": "corneltek/getoptionkit",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/GetOptionKit.git",
-                "reference": "1121ee17f304cd7e2d8d2b818df86b6af5f07485"
+                "reference": "8f79aa38a90f1c0e66e712ed72fbc259130e6be9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/1121ee17f304cd7e2d8d2b818df86b6af5f07485",
-                "reference": "1121ee17f304cd7e2d8d2b818df86b6af5f07485",
+                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/8f79aa38a90f1c0e66e712ed72fbc259130e6be9",
+                "reference": "8f79aa38a90f1c0e66e712ed72fbc259130e6be9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6.x-dev"
+                    "dev-master": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -258,9 +261,9 @@
             "homepage": "http://github.com/c9s/GetOptionKit",
             "support": {
                 "issues": "https://github.com/c9s/GetOptionKit/issues",
-                "source": "https://github.com/c9s/GetOptionKit/tree/2.6.1"
+                "source": "https://github.com/c9s/GetOptionKit/tree/2.7.0"
             },
-            "time": "2021-11-22T09:15:28+00:00"
+            "time": "2022-12-15T05:55:38+00:00"
         },
         {
             "name": "corneltek/pearx",


### PR DESCRIPTION
# Changed log

- Upgrading the `composer.lock` file with the `PHP 7.2` version, and the command outputs are as follows:

```sh
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading corneltek/getoptionkit (2.6.1 => 2.7.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading corneltek/getoptionkit (2.7.0)
  - Upgrading corneltek/getoptionkit (2.6.1 => 2.7.0): Extracting archive
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
27 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found
```