### PR TITLE
Migrate ignored tests Travis CI to GitHub action

### DIFF
--- a/tests/PhpBrew/Command/DownloadCommandTest.php
+++ b/tests/PhpBrew/Command/DownloadCommandTest.php
@@ -26,7 +26,7 @@ class DownloadCommandTest extends CommandTestCase
      */
     public function testDownloadCommand($versionName)
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('GITHUB_ACTIONS')) {
             $this->markTestSkipped('Skip heavy test on Travis');
         }
 

--- a/tests/PhpBrew/Command/InstallCommandTest.php
+++ b/tests/PhpBrew/Command/InstallCommandTest.php
@@ -27,7 +27,7 @@ class InstallCommandTest extends CommandTestCase
      */
     public function testInstallCommand()
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('GITHUB_ACTIONS')) {
             $this->markTestSkipped('Skip heavy test on Travis');
         }
 
@@ -64,7 +64,7 @@ class InstallCommandTest extends CommandTestCase
      */
     public function testGitHubInstallCommand()
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('GITHUB_ACTIONS')) {
             $this->markTestSkipped('Skip heavy test on Travis');
         }
 

--- a/tests/PhpBrew/Command/KnownCommandTest.php
+++ b/tests/PhpBrew/Command/KnownCommandTest.php
@@ -32,6 +32,7 @@ class KnownCommandTest extends CommandTestCase
 
     /**
      * @outputBuffering enabled
+     * @group mayignore
      */
     public function testOldMoreOption()
     {

--- a/tests/PhpBrew/Command/UpdateCommandTest.php
+++ b/tests/PhpBrew/Command/UpdateCommandTest.php
@@ -14,6 +14,7 @@ class UpdateCommandTest extends CommandTestCase
 
     /**
      * @outputBuffering enabled
+     * @group mayignore
      */
     public function testUpdateCommand()
     {

--- a/tests/PhpBrew/Extension/ExtensionInstallerTest.php
+++ b/tests/PhpBrew/Extension/ExtensionInstallerTest.php
@@ -32,7 +32,7 @@ class ExtensionInstallerTest extends CommandTestCase
      */
     public function testPackageUrl()
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('GITHUB_ACTIONS')) {
             $this->markTestSkipped('Skipping since VCR cannot properly record this request');
         }
 

--- a/tests/PhpBrew/Extension/KnownCommandTest.php
+++ b/tests/PhpBrew/Extension/KnownCommandTest.php
@@ -32,7 +32,7 @@ class KnownCommandTest extends CommandTestCase
 
     public function testGithubPackage()
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('GITHUB_ACTIONS')) {
             $this->markTestSkipped('Avoid bugging GitHub on Travis since the test is likely to fail because of a 403');
         }
 

--- a/tests/PhpBrew/VariantBuilderTest.php
+++ b/tests/PhpBrew/VariantBuilderTest.php
@@ -129,8 +129,8 @@ class VariantBuilderTest extends TestCase
     {
         $build = new Build('5.5.0');
         foreach ($variants as $variant) {
-            if (getenv('TRAVIS') && in_array($variant, array("apxs2", "gd", "editline"))) {
-                $this->markTestSkipped("Travis CI doesn't support $variant}.");
+            if (getenv('GITHUB_ACTIONS') && in_array($variant, array("apxs2", "gd", "editline"))) {
+                $this->markTestSkipped("GitHub actions doesn't support $variant}.");
             }
 
             $build->enableVariant($variant);


### PR DESCRIPTION
# Changed log

- Since migrating to the GitHub actions, some ignored tests in the CI should be migrated, too.
- According to the [default environment variables for the GitHub action](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables), we can use the `GITHUB_ACTIONS` to ignore some tests during GitHub action running.