### PR TITLE
Fix file_exists deprecated null arg passing

### DIFF
--- a/src/PhpBrew/Console.php
+++ b/src/PhpBrew/Console.php
@@ -128,7 +128,7 @@ class Console extends Application
             $buildLog = $e->getLogFile();
             $this->logger->error('Error: ' . trim($e->getMessage()));
 
-            if (file_exists($buildLog)) {
+            if ($buildLog !== null && file_exists($buildLog)) {
                 $this->logger->error('The last 5 lines in the log file:');
                 $lines = array_slice(file($buildLog), -5);
                 foreach ($lines as $line) {


### PR DESCRIPTION
# Changed log

- It's related to issue #1301.

Fixing the following deprecated message:

```
PHP Deprecated:  file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in phar:///usr/local/bin/phpbrew/src/PhpBrew/Console.php on line 131
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/phpbrew:0
PHP   2. require() /usr/local/bin/phpbrew:14
PHP   3. PhpBrew\Console->runWithTry($argv = [0 => '/usr/local/bin/phpbrew', 1 => 'ext', 2 => 'install', 3 => 'imagick']) phar:///usr/local/bin/phpbrew/bin/phpbrew:26
PHP   4. file_exists($filename = NULL) phar:///usr/local/bin/phpbrew/src/PhpBrew/Console.php:131

Deprecated: file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in phar:///usr/local/bin/phpbrew/src/PhpBrew/Console.php on line 131

Call Stack:
    0.0057    2078784   1. {main}() /usr/local/bin/phpbrew:0
    0.0414    2812112   2. require('phar:///usr/local/bin/phpbrew/bin/phpbrew') /usr/local/bin/phpbrew:14
    0.0461    3453480   3. PhpBrew\Console->runWithTry($argv = [0 => '/usr/local/bin/phpbrew', 1 => 'ext', 2 => 'install', 3 => 'imagick']) phar:///usr/local/bin/phpbrew/bin/phpbrew:26
    6.8791    5951512   4. file_exists($filename = NULL) phar:///usr/local/bin/phpbrew/src/PhpBrew/Console.php:131
```