### PR TITLE
Replace "\n" with PHP_EOL for consistency

### DIFF
--- a/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/KnownCommand.php
@@ -53,10 +53,10 @@ class KnownCommand extends Command
         if ($provider) {
             $extensionDownloader = new ExtensionDownloader($this->logger, $this->options);
             $versionList = $extensionDownloader->knownReleases($provider);
-            $this->logger->info("\n");
-            $this->logger->writeln(wordwrap(implode(', ', $versionList), 80, "\n"));
+            $this->logger->info(PHP_EOL);
+            $this->logger->writeln(wordwrap(implode(', ', $versionList), 80, PHP_EOL));
         } else {
-            $this->logger->info("Can not determine host or unsupported of $extensionName \n");
+            $this->logger->info("Can not determine host or unsupported of $extensionName " . PHP_EOL);
         }
     }
 }

--- a/src/PhpBrew/Command/FpmCommand/SetupCommand.php
+++ b/src/PhpBrew/Command/FpmCommand/SetupCommand.php
@@ -55,7 +55,7 @@ class SetupCommand extends Command
         fprintf(
             STDERR,
             "*WARNING* php-fpm --pid option requires php >= 5.6. "
-            . "You need to update your php-fpm.conf for the pid file location.\n"
+            . "You need to update your php-fpm.conf for the pid file location." . PHP_EOL
         );
 
         $root = Config::getRoot();

--- a/src/PhpBrew/Command/InfoCommand.php
+++ b/src/PhpBrew/Command/InfoCommand.php
@@ -26,36 +26,36 @@ class InfoCommand extends Command
         echo <<<'EOF'
 <?php
 
-echo "Version\n";
-echo 'PHP-', phpversion(), "\n\n";
+echo "Version" . PHP_EOL;
+echo 'PHP-', phpversion(), PHP_EOL, PHP_EOL;
 
-echo "Constants\n";
+echo "Constants", PHP_EOL;
 $constants = get_defined_constants();
 
 if (defined('PHP_PREFIX')) {
-    echo 'PHP Prefix: ', PHP_PREFIX, "\n";
+    echo 'PHP Prefix: ', PHP_PREFIX, PHP_EOL;
 }
 
 if (defined('PHP_BINARY')) {
-    echo 'PHP Binary: ', PHP_BINARY, "\n";
+    echo 'PHP Binary: ', PHP_BINARY, PHP_EOL;
 }
 
 if (defined('DEFAULT_INCLUDE_PATH')) {
-    echo 'PHP Default Include path: ', DEFAULT_INCLUDE_PATH, "\n";
+    echo 'PHP Default Include path: ', DEFAULT_INCLUDE_PATH, PHP_EOL;
 }
 
-echo 'PHP Include path: ', get_include_path(), "\n\n";
+echo 'PHP Include path: ', get_include_path(), PHP_EOL, PHP_EOL;
 
-echo "General Info\n";
+echo "General Info", PHP_EOL;
 phpinfo(INFO_GENERAL);
-echo "\n";
+echo PHP_EOL;
 
-echo "Extensions\n";
+echo "Extensions", PHP_EOL;
 $extensions = get_loaded_extensions();
-echo implode(', ', $extensions), "\n";
-echo "\n";
+echo implode(', ', $extensions), PHP_EOL;
+echo PHP_EOL;
 
-echo "Database Extensions\n";
+echo "Database Extensions", PHP_EOL;
 foreach (
     array_filter(
         $extensions,
@@ -78,7 +78,7 @@ foreach (
         }
     ) as $extName
 ) {
-    echo $extName, "\n";
+    echo $extName, PHP_EOL;
 }
 EOF;
     }

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -311,7 +311,7 @@ class InstallCommand extends Command
             );
             $builder = new VariantBuilder();
             $this->logger->notice('[' . implode(', ', $builder->virtualVariants['default']) . ']');
-            $this->logger->notice("Please run 'phpbrew variants' for more information.\n");
+            $this->logger->notice("Please run 'phpbrew variants' for more information." . PHP_EOL);
         }
 
         if (preg_match('/5\.3\./', $version)) {
@@ -525,7 +525,7 @@ class InstallCommand extends Command
                             // See http://php.net/manual/en/install.fpm.configuration.php for more details
                             $ini = file_get_contents($patchingFile);
                             $this->logger->info("---> Patching default fpm pool listen path to $fpmUnixSocket");
-                            $ini = preg_replace('/^listen = .*$/m', "listen = $fpmUnixSocket\n", $ini);
+                            $ini = preg_replace('/^listen = .*$/m', "listen = $fpmUnixSocket" . PHP_EOL, $ini);
                             file_put_contents($patchingFile, $ini);
                             break;
                         }
@@ -701,7 +701,7 @@ EOT;
             // turn off detect_encoding for 5.3
             if ($build->compareVersion('5.4') < 0) {
                 $this->logger->info("---> Turn off detect_encoding for php 5.3.*");
-                $configContent = $configContent . "\ndetect_unicode = Off\n";
+                $configContent = $configContent . PHP_EOL . "detect_unicode = Off" . PHP_EOL;
             }
 
             file_put_contents($targetConfigPath, $configContent);

--- a/src/PhpBrew/Command/KnownCommand.php
+++ b/src/PhpBrew/Command/KnownCommand.php
@@ -63,7 +63,7 @@ class KnownCommand extends Command
             }
             $this->logger->writeln(
                 $this->formatter->format("{$majorVersion}: ", 'yellow')
-                . wordwrap(implode(', ', $versionList), 80, "\n" . str_repeat(' ', 5))
+                . wordwrap(implode(', ', $versionList), 80, PHP_EOL . str_repeat(' ', 5))
                 . (!$this->options->more ? ' ...' : '')
             );
         }

--- a/src/PhpBrew/Command/ListCommand.php
+++ b/src/PhpBrew/Command/ListCommand.php
@@ -55,7 +55,7 @@ class ListCommand extends Command
                 $info = unserialize(file_get_contents($versionPrefix . DIRECTORY_SEPARATOR . 'phpbrew.variants'));
                 echo '    Variants: ';
                 echo wordwrap(VariantParser::revealCommandArguments($info), 75, " \\\n              ");
-                echo "\n";
+                echo PHP_EOL;
             }
         }
     }

--- a/src/PhpBrew/Command/ListIniCommand.php
+++ b/src/PhpBrew/Command/ListIniCommand.php
@@ -19,11 +19,11 @@ class ListIniCommand extends Command
         );
 
         if ($filelist = php_ini_scanned_files()) {
-            echo "Loaded ini files:\n";
+            echo "Loaded ini files:" . PHP_EOL;
             if (strlen($filelist) > 0) {
                 $files = explode(',', $filelist);
                 foreach ($files as $file) {
-                    echo ' - ' . trim($file) . "\n";
+                    echo ' - ' . trim($file) . PHP_EOL;
                 }
             }
         }

--- a/src/PhpBrew/Command/VariantsCommand.php
+++ b/src/PhpBrew/Command/VariantsCommand.php
@@ -27,7 +27,7 @@ class VariantsCommand extends Command
             $newLine .= $c;
 
             if ($lineX > 68 && $c === ' ') {
-                $newLine .= "\n" . $indent;
+                $newLine .= PHP_EOL . $indent;
                 $lineX = 0;
             }
         }
@@ -41,24 +41,24 @@ class VariantsCommand extends Command
         $list = $variants->getVariantNames();
         sort($list);
 
-        echo "Variants: \n";
-        echo $this->wrapLine(implode(', ', $list)) , "\n";
-        echo "\n\n";
+        echo "Variants: " . PHP_EOL;
+        echo $this->wrapLine(implode(', ', $list)) , PHP_EOL;
+        echo PHP_EOL, PHP_EOL;
 
-        echo "Virtual variants: \n";
+        echo "Virtual variants: ", PHP_EOL;
 
         foreach ($variants->virtualVariants as $name => $subvars) {
-            echo $this->wrapLine("$name: " . implode(', ', $subvars)) , "\n";
+            echo $this->wrapLine("$name: " . implode(', ', $subvars)) , PHP_EOL;
         }
 
-        echo "\n\n";
+        echo PHP_EOL, PHP_EOL;
 
-        echo "Using variants to build PHP:\n";
-        echo "\n";
-        echo "  phpbrew install php-5.3.10 +default\n";
-        echo "  phpbrew install php-5.3.10 +mysql +pdo\n";
-        echo "  phpbrew install php-5.3.10 +mysql +pdo +apxs2\n";
-        echo "  phpbrew install php-5.3.10 +mysql +pdo +apxs2=/usr/bin/apxs2\n";
-        echo "\n\n";
+        echo "Using variants to build PHP:", PHP_EOL;
+        echo PHP_EOL;
+        echo "  phpbrew install php-5.3.10 +default", PHP_EOL;
+        echo "  phpbrew install php-5.3.10 +mysql +pdo", PHP_EOL;
+        echo "  phpbrew install php-5.3.10 +mysql +pdo +apxs2", PHP_EOL;
+        echo "  phpbrew install php-5.3.10 +mysql +pdo +apxs2=/usr/bin/apxs2", PHP_EOL;
+        echo PHP_EOL, PHP_EOL;
     }
 }

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -34,9 +34,9 @@ class ConfigureTask extends BaseTask
         $cmd->setStdout($this->options->{'stdout'});
 
         if (!$this->options->{'stdout'}) {
-            $this->logger->info("\n");
+            $this->logger->info(PHP_EOL);
             $this->logger->info("Use tail command to see what's going on:");
-            $this->logger->info('   $ tail -F ' . escapeshellarg($buildLogPath) . "\n\n");
+            $this->logger->info('   $ tail -F ' . escapeshellarg($buildLogPath) . PHP_EOL . PHP_EOL);
         }
 
         $this->debug($cmd->buildCommand());

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -819,7 +819,7 @@ class VariantBuilder
                     $build->disableVariant($c);
                 }
 
-                echo implode("\n", $msgs) . "\n";
+                echo implode(PHP_EOL, $msgs) . PHP_EOL;
             }
         }
 


### PR DESCRIPTION
# Changed log

- To be consistency, it should replace all `\n` with the `PHP_EOL` to represent the EOL char.