### PR TITLE
Upgrading GetOptionKit to 2.7.1 version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -218,16 +218,16 @@
         },
         {
             "name": "corneltek/getoptionkit",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/GetOptionKit.git",
-                "reference": "8f79aa38a90f1c0e66e712ed72fbc259130e6be9"
+                "reference": "9a433c6cc5f9299f120f59820b8ee6cb0eb7e0f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/8f79aa38a90f1c0e66e712ed72fbc259130e6be9",
-                "reference": "8f79aa38a90f1c0e66e712ed72fbc259130e6be9",
+                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/9a433c6cc5f9299f120f59820b8ee6cb0eb7e0f6",
+                "reference": "9a433c6cc5f9299f120f59820b8ee6cb0eb7e0f6",
                 "shasum": ""
             },
             "require": {
@@ -261,9 +261,9 @@
             "homepage": "http://github.com/c9s/GetOptionKit",
             "support": {
                 "issues": "https://github.com/c9s/GetOptionKit/issues",
-                "source": "https://github.com/c9s/GetOptionKit/tree/2.7.0"
+                "source": "https://github.com/c9s/GetOptionKit/tree/2.7.1"
             },
-            "time": "2022-12-15T05:55:38+00:00"
+            "time": "2023-04-13T03:23:55+00:00"
         },
         {
             "name": "corneltek/pearx",

--- a/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
@@ -56,9 +56,16 @@ class InstallCommand extends BaseCommand
         $options = array();
 
         if (count($args) > 0) {
-            $pos = array_search('--', $args);
+            $pos = false;
+            for ($index=0; $index<count($args); $index++) {
+                if (substr($args[$index], 0, 2) === '--') {
+                    $pos = $index;
+                    break;
+                }
+            }
+
             if ($pos !== false) {
-                $options = array_slice($args, $pos + 1);
+                $options = array_slice($args, $pos);
             }
 
             if ($pos === false || $pos == 1) {

--- a/src/PhpBrew/VariantParser.php
+++ b/src/PhpBrew/VariantParser.php
@@ -28,7 +28,7 @@ class VariantParser
                 throw new InvalidVariantSyntaxException('Variant cannot be empty');
             }
 
-            if ($arg === '--') {
+            if (substr($arg, 0, 2) === '--') {
                 $extra = $args;
                 break;
             }


### PR DESCRIPTION
# Changed log

- Using the `php ~/composer.phar update corneltek/getoptionkit` command to upgrade the `corneltek/getoptionkit` to `2.7.1` version.
- Since upgrading above dependency, using the `substr` function to check `$arg` variable is extra argument.
- Fix extension installing option searching and parsing.
- It's related to the #1316.