### PR TITLE
Resolve #1337 to check OS when enabling FPM option

### DIFF
--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -439,8 +439,12 @@ class InstallCommand extends Command
                 );
             }
             if ($build->isEnabledVariant('fpm')) {
+                $addedOptions = array('--enable-fpm');
+                if (PHP_OS === 'Linux') {
+                    $addedOptions[] = '--with-fpm-systemd';
+                }
                 $sapis['fpm'] = array(
-                    'enable' => array('--enable-fpm', '--with-fpm-systemd'),
+                    'enable' => $addedOptions,
                     'disable' => array(),
                 );
             }


### PR DESCRIPTION
# Changed log

- It's related to issue #1337.
- The `--with-fpm-systemd` option is added for running configure script command when the current operating system is `Linux`.
  - Other operating systems use other background process manager to manage processes.