### PR TITLE
Add snmp variant support

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -767,6 +767,28 @@ class VariantBuilder
             return $parameters->withOption('--with-pear', $value);
         };
 
+        /*
+         * --with-snmp option
+         *
+         * --with-snmp=[dir]
+         *
+         * On macOS, you need to use the brew to install the net-snmp
+         *
+         * On ubuntu you need to install libsnmp-dev
+         * On Ubuntu 18.04+, it should ensure the /usr/include/net-snmp/net-snmp-config.h is available.
+         * On Ubuntu 20.04+, it should ensure the pkg-config --variable=prefix netsnmp can find the net-snmp prefix.
+         */
+        $this->variants['snmp'] = function (ConfigureParameters $parameters, Build $build, $value) {
+            $prefix = Utils::findPrefix(array(
+                new UserProvidedPrefix($value),
+                new BrewPrefixFinder('net-snmp'),
+                new PkgConfigPrefixFinder('netsnmp'),
+                new IncludePrefixFinder('net-snmp/net-snmp-config.h'),
+            ));
+
+            return $parameters->withOptionOrPkgConfigPath($build, '--with-snmp', $prefix);
+        };
+
         // merge virtual variants with config file
         $customVirtualVariants = Config::getConfigParam('variants');
         $customVirtualVariantsToAdd = array();

--- a/tests/PhpBrew/VariantBuilderTest.php
+++ b/tests/PhpBrew/VariantBuilderTest.php
@@ -119,6 +119,10 @@ class VariantBuilderTest extends TestCase
                 array('zlib'),
                 array('--with-zlib'),
             ),
+            'snmp' => array(
+                array('snmp'),
+                array('--with-snmp'),
+            ),
         );
     }
 
@@ -324,6 +328,35 @@ class VariantBuilderTest extends TestCase
             array('7.3.0', '--enable-maintainer-zts'),
             array('7.4.0', '--enable-maintainer-zts'),
             array('8.0.0', '--enable-zts'),
+        );
+    }
+
+    /**
+     * @param string $version
+     * @param string $expected
+     *
+     * @dataProvider snmpProvider
+     */
+    public function testSnmp($version, $expected)
+    {
+        $build = new Build($version);
+        $build->enableVariant('snmp');
+
+        $builder = new VariantBuilder();
+        $options = $builder->build($build)->getOptions();
+
+        $this->assertArrayHasKey($expected, $options);
+    }
+
+    public static function snmpProvider()
+    {
+        return array(
+            array('5.6.0', '--with-snmp'),
+            array('7.0.0', '--with-snmp'),
+            array('7.1.0', '--with-snmp'),
+            array('7.3.0', '--with-snmp'),
+            array('7.4.0', '--with-snmp'),
+            array('8.0.0', '--with-snmp'),
         );
     }
 }


### PR DESCRIPTION
# Changed log

- Adding the `snmp` variant and the reference is available [here](https://www.php.net/manual/en/book.snmp.php).
- The `snmp` extension requires the `net-snmp` package. And it's available in the macOS and Linux-like distributions.