### PR TITLE
Resolves #1346

### DIFF
--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -168,7 +168,7 @@ class ReleaseList
         $file = DownloadFactory::getInstance(Logger::getInstance(), $options)->download($url);
         $json = file_get_contents($file);
 
-        return json_decode($json, true);
+        return json_decode($json, true) ?? [];
     }
 
     private static function buildReleaseListFromOfficialSite(OptionResult $options)


### PR DESCRIPTION
# Changed log

- Resolves #1346.
- Letting `json_decode` be empty array when the decoded result is `null`. And it can also avoid `array_merge` warning.