### PR TITLE
Fix: Prevent extra-options from being overwritten

### DIFF
--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -8,12 +8,12 @@ use PhpBrew\BuildSettings\BuildSettings;
  * A build object contains version information,
  * variant configuration,
  * paths and an build identifier (BuildId).
- *
  * @method array getEnabledVariants()
  * @method array getDisabledVariants()
  * @method bool isEnabledVariant(string $variant)
  * @method bool isDisabledVariant(string $variant)
  * @method array getExtraOptions()
+ * @method array getExtraOptionsProcessed()
  * @method enableVariant(string $variant, string $value = null)
  * @method disableVariant(string $variant)
  * @method removeVariant(string $variant)

--- a/src/PhpBrew/BuildSettings/BuildSettings.php
+++ b/src/PhpBrew/BuildSettings/BuildSettings.php
@@ -123,6 +123,25 @@ class BuildSettings
     }
 
     /**
+     * Get all extra options.
+     *
+     * @return array    [option => value]
+     */
+    public function getExtraOptionsProcessed(): array
+    {
+        $extraOptions = [];
+        foreach ($this->getExtraOptions() as $option) {
+            if (preg_match('/^(.*?)=(.*?)$/', $option, $matches)) {
+                $extraOptions[$matches[1]] = $matches[2];
+            } else {
+                $extraOptions[$option] = null;
+            }
+        }
+
+        return $extraOptions;
+    }
+
+    /**
      * Load and return the variant info from file.
      */
     public function loadVariantInfoFile($variantFile)

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -464,9 +464,15 @@ class InstallCommand extends Command
                     );
                 }
 
-                $parameters = $parameters
-                    ->withOption('--with-config-file-path', $prefix . '/etc/' . $sapi)
-                    ->withOption('--with-config-file-scan-dir', $prefix . '/var/db/' . $sapi);
+                if (!array_key_exists('--with-config-file-path', $options)) {
+                    $parameters = $parameters
+                        ->withOption('--with-config-file-path', $prefix.'/etc/'.$sapi);
+                }
+
+                if (!array_key_exists('--with-config-file-scan-dir', $options)) {
+                    $parameters = $parameters
+                        ->withOption('--with-config-file-scan-dir', $prefix.'/var/db/'.$sapi);
+                }
 
                 $this->build($build, $parameters);
 

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -1047,8 +1047,8 @@ class VariantBuilder
             $parameters = $this->buildDisabledVariant($build, $variant, $parameters);
         }
 
-        foreach ($build->getExtraOptions() as $option) {
-            $parameters = $parameters->withOption($option);
+        foreach ($build->getExtraOptionsProcessed() as $option => $value) {
+            $parameters = $parameters->withOption($option, $value);
         }
 
         return $parameters;


### PR DESCRIPTION
The extraoptions get partially overwritten:
--with-config-file-path
--with-config-file-scan-dir

This means that the additional inis are no longer loaded from the correct directory. If you have set up many php versions, then the config-file-scan-dir per version is not practical.

In version 1.27 the path was not yet overwritten and worked because it was appended at the end of the Makefile. Since v.1.28 the path is fixed in the code and there is no possibility to overwrite it.

With the patch, the extraoptions are split if necessary and then set correctly via withOption(option,value). Before the build, the system checks whether the two options are set.