### PR TITLE
fix: Resolve readline patch attempting to apply to php >7.1 due to OR instead of AND

### DIFF
--- a/src/PhpBrew/Patches/ReadlinePatch.php
+++ b/src/PhpBrew/Patches/ReadlinePatch.php
@@ -19,8 +19,8 @@ class ReadlinePatch extends Patch
 
     public function match(Buildable $build, Logger $logger)
     {
-        return version_compare($build->getVersion(), '5.4', '>=')
-            || version_compare($build->getVersion(), '7.1', '<=');
+        return version_compare($build->getVersion(), '5.3', '>=')
+            && version_compare($build->getVersion(), '7.1', '<=');
     }
 
     /**


### PR DESCRIPTION
This resolves a patch failure (that interestingly gets ignored) when installing PHP > 7.1
There's an OR so effectively match() always returns true - since it will always either be higher or equal to 5.3 or lower or equal to 7.1