### PR TITLE
fix: Resolve build failure on Apple Silicon of PHP 8.0 due to old bundled pcre2

### DIFF
--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -64,6 +64,8 @@ class Build implements Buildable
 
     public $osRelease;
 
+    public $osArch;
+
     /**
      * Construct a Build object,.
      *
@@ -93,6 +95,7 @@ class Build implements Buildable
         $this->setBuildSettings(new BuildSettings());
         $this->osName = php_uname('s');
         $this->osRelease = php_uname('r');
+        $this->osArch = php_uname('m');
     }
 
     public function getName()


### PR DESCRIPTION
On macOS on Apple Silicon you get an Allocation of JIT memory failure error at the end of the build of PHP 8.0. This is due to a bug in the bundled PCRE2 library. It's fixed in the bundled version in PHP 8.1, and I think lower versions don't bundle it so you're highly likely to link to a version with the fix.

I wasn't sure how this can be best fixed, and wanted to be able to make it "seamless" and more "intuitive" by detecting Apple Silicon and PHP 8.0 and then forcing it to link to a newer PCRE2 externally, and report if it can't find it, rather than blindly continuing only to fail.

I know there's no other code in phpbrew that appears to check the environment. Happy to discuss a better approach. In an ideal world phpbrew would actually be able to verify the environment before building so it can say "You are missing X" so maybe this is a good discussion area to get something in place as throwing Exception is not my greatest idea here!