### PR TITLE
fix: Resolve build failure due to using OpenSSL@3 instead of OpenSSL@1.1 on macOS for PHP < 8.1

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -529,6 +529,15 @@ class VariantBuilder
                 new IncludePrefixFinder('openssl/opensslv.h'),
             ));
 
+            // OpenSSL 3 removes RSA_SSLV23_PADDING and so is not compatible with PHP < 8.1, and Homebrew defaults to openssl@3
+            // If we detect homebrew openssl@3, which is the default, change it to openssl@1.1
+            if ($prefix !== null && $build->compareVersion('8.1') < 0 && $prefix === (new BrewPrefixFinder('openssl@3'))->findPrefix()) {
+                $prefix = (new BrewPrefixFinder('openssl@1.1'))->findPrefix();
+                if ($prefix === null) {
+                    throw new Exception('PHP < 8.1 requires openssl@1.1.');
+                }
+            }
+
             return $parameters->withOptionOrPkgConfigPath($build, '--with-openssl', $prefix);
         };
 

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -231,6 +231,16 @@ class VariantBuilder
                 new IncludePrefixFinder('openssl/opensslv.h'),
             ));
 
+            // OpenSSL 3 removes RSA_SSLV23_PADDING and so is not compatible with PHP < 8.1, and Homebrew defaults to openssl@3
+            // If we detect homebrew openssl@3, which is the default, change it to openssl@1.1
+            // Fixed in PHP since 8.1.0: https://github.com/php/php-src/commit/a0972deb0f441fc7991001cb51efc994b70a3b51
+            if ($opensslPrefix !== null && $build->compareVersion('8.1') < 0 && $opensslPrefix === (new BrewPrefixFinder('openssl@3'))->findPrefix()) {
+                $opensslPrefix = (new BrewPrefixFinder('openssl@1.1'))->findPrefix();
+                if ($opensslPrefix === null) {
+                    throw new Exception('PHP < 8.1 requires openssl@1.1.');
+                }
+            }
+
             return $params->withOption('--with-imap', $imapPrefix)
                 ->withOptionOrPkgConfigPath($build, '--with-kerberos', $kerberosPrefix)
                 ->withOptionOrPkgConfigPath($build, '--with-imap-ssl', $opensslPrefix);
@@ -531,6 +541,7 @@ class VariantBuilder
 
             // OpenSSL 3 removes RSA_SSLV23_PADDING and so is not compatible with PHP < 8.1, and Homebrew defaults to openssl@3
             // If we detect homebrew openssl@3, which is the default, change it to openssl@1.1
+            // Fixed in PHP since 8.1.0: https://github.com/php/php-src/commit/a0972deb0f441fc7991001cb51efc994b70a3b51
             if ($prefix !== null && $build->compareVersion('8.1') < 0 && $prefix === (new BrewPrefixFinder('openssl@3'))->findPrefix()) {
                 $prefix = (new BrewPrefixFinder('openssl@1.1'))->findPrefix();
                 if ($prefix === null) {


### PR DESCRIPTION
When building PHP < 8.1 on macOS and you have openssl@3 installed via Homebrew, you can get an error about SSL padding because it tries to link to openssl@3 and it's not compatible as it removes old SSL constants. You need openssl@1.1. I didn't want to uninstall openssl@3 though (it breaks things and starts removing other recipes!).

This detects the scenario of openssl@3 which we know simply won't work, and checks for openssl@1.1.

Similarly to the other PR I did I wasn't sure how to approach this as there's no real environment checking. Perhaps if there's environment checking for openssl@1.1 before continuing then this check here wouldn't be needed and you can just change the brew prefix to @1.1.

Issue with doing that now is that if you change it to @1.1 - it won't fail - because the PkgConfig kicks in and locates openssl@3 from Homebrew again 😆 - so you have to ensure that openssl@1.1 is installed. Hopefully this helps users anyway.