### PR TITLE
Change 2.1.0 version cont to 2.2.0

### DIFF
--- a/src/PhpBrew/Console.php
+++ b/src/PhpBrew/Console.php
@@ -14,7 +14,7 @@ use PhpBrew\Exception\SystemCommandException;
 class Console extends Application
 {
     const NAME = 'phpbrew';
-    const VERSION = '2.1.0';
+    const VERSION = '2.2.0';
 
     public function options($opts)
     {


### PR DESCRIPTION
# Changed log

- It's my fault. I forgot to modify the version const before releasing the `2.2.0` version :(.