### PR TITLE
Use `whence -p` instead of `which` for Zsh

### DIFF
--- a/shell/bashrc
+++ b/shell/bashrc
@@ -22,7 +22,13 @@ MIN_PHP_VERSION_ID=70200
 # Returns the absolute path corresponding to the command excluding the alias
 function __phpbrew_which()
 {
-    command which "$1"
+    # If in Zsh, use the `whence' builtin instead of `which' to avoid
+    # the resolution of `phpbrew' to the function declared in this file
+    if command -v whence > /dev/null ; then
+        command whence -p "$1"
+    else
+        command which "$1"
+    fi
 }
 
 # Executes the given command via the PHP implementation


### PR DESCRIPTION
This is to address a regression to an issue outlined in #1140, and addressed with PR #1142. The fix to the issue was removed in commit 729420dadd2d034ef5b5cdcc87c0018d78209b19.

To my understanding, `which` incorrectly resolves to the phpbrew shell function instead of the binary when using Zsh. Instead, `whence -p` should be used to resolve the binary.