### PR TITLE
ci: Add an AutoReview workflow

### DIFF
--- a/.github/workflows/auto-review.yaml
+++ b/.github/workflows/auto-review.yaml
@@ -1,0 +1,42 @@
+name: AutoReview
+
+on:
+    push:
+        branches: [ main, master ]
+    pull_request: ~
+
+jobs:
+    composer-validate:
+        runs-on: ubuntu-latest
+        name: Composer Validate
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v4
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.2'
+                    tools: composer
+                    coverage: none
+
+            -   run: make composer_validate
+
+
+    # This is a "trick", a meta task which does not change, and we can use in
+    # the protected branch rules as opposed to the tests one above which
+    # may change regularly.
+    validate-autoreview:
+        name: AutoReview tests status
+        runs-on: ubuntu-latest
+        needs:
+            - composer-validate
+        if: always()
+        steps:
+            - name: Successful run
+              if: ${{ !(contains(needs.*.result, 'failure')) }}
+              run: exit 0
+
+            - name: Failing run
+              if: ${{ contains(needs.*.result, 'failure') }}
+              run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ $(TARGET): vendor $(shell find bin/ shell/ src/ -type f) box.json.dist .git/HEAD
 	box compile
 	touch -c $@
 
+.PHONY: composer_validate
+composer_validate:
+	composer validate --strict --ansi
+
 vendor: composer.lock
 	composer install
 	touch $@


### PR DESCRIPTION
Introduces a workflow for the purpose of validating and reviewing the code. This where I would typically include:

- Static analysis
- Various validations, e.g. that the `composer.json` is valid (the only check currently implemented in this PR)
- Code linting
- Any unit tests that aim at checking the codebase architecture/structure/conventions, i.e. anything that is not testing the source code behaviour.