### PR TITLE
fix: Do not add the enable JSON variant for PHP 8.0

### DIFF
--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -161,7 +161,13 @@ class VariantBuilder
             return $params->withOption('--enable-zts');
         };
 
-        $this->variants['json'] = '--enable-json';
+        $this->variants['json'] = function (ConfigureParameters $params, Build $build) {
+            if ($build->compareVersion('8.0') < 0) {
+                return $params->withOption('--enable-json');
+            }
+
+            return $params;
+        };
         $this->variants['hash'] = '--enable-hash';
         $this->variants['exif'] = '--enable-exif';
 


### PR DESCRIPTION
Closes #1278.

Note that this is not a perfect solution as the default variant still defines `json`, but this requires more refactoring as it is used as a public property and the information used is not available when instantiation the `VariantBuilder`.