### PR TITLE
build: Fix composer.lock not up to date

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0122eaa7927d9d203c014d9be531f26",
+    "content-hash": "fdc4592d3ee14556c91772d97a37b009",
     "packages": [
         {
             "name": "corneltek/class-template",
@@ -2896,7 +2896,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.5 || <9.0",
+        "php": "^7.2.5 || ^8.0",
         "ext-simplexml": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
Extracted from #1375.

Currently:

```shell
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
- The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update` or `composer update <package name>`.
- The package "corneltek/cliframework" is pointing to a commit-ref, this is bad practice and can cause unforeseen issues.
- require.corneltek/cliframework : exact version constraints (3.0.x-dev#0e69e4d9d8ee6c8b5abb7ebf0cf846e47d93b656) should be avoided if the package follows semantic versioning
```

The two warnings cannot be fixed, but they only make `composer validate` fail if the `--strict` option is passed.

I fixed this by running `composer update --lock`.