### PR TITLE
build(tools): Introduce Rector

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,25 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 10
-  reviewers:
-  - c9s
-  - morozov
-  assignees:
-  - morozov
-  labels:
-  - Dependencies
-  versioning-strategy: increase
+    -   package-ecosystem: composer
+        directory: "/"
+        schedule:
+            interval: daily
+            time: "10:00"
+        open-pull-requests-limit: 10
+        reviewers:
+            - c9s
+            - morozov
+        assignees:
+            - morozov
+        labels:
+            - Dependencies
+        versioning-strategy: increase
+
+    -   package-ecosystem: "composer"
+        directory: "vendor-bin/*/"
+        schedule:
+            interval: "weekly"
+        groups:
+            dependencies:
+                patterns:
+                    - "*"

--- a/.github/workflows/auto-review.yaml
+++ b/.github/workflows/auto-review.yaml
@@ -1,0 +1,69 @@
+name: AutoReview
+
+on:
+    push:
+        branches: [ main, master ]
+    pull_request: ~
+
+jobs:
+    composer-validate:
+        runs-on: ubuntu-latest
+        name: Composer Validate
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v4
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.2'
+                    tools: composer
+                    coverage: none
+
+            -   run: make composer_validate
+
+    rector_lint:
+        runs-on: ubuntu-latest
+        name: Composer Validate
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v4
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.3'
+                    tools: composer
+                    coverage: none
+
+            -   name: Install dependencies
+                uses: ramsey/composer-install@v2
+
+            -   name: Install Rector dependencies
+                uses: ramsey/composer-install@v2
+                with:
+                    working-directory: vendor-bin/rector
+
+            -   name: Ensure the make targets are up to date
+                run: make rector_install
+
+            -   run: make rector_lint
+
+
+    # This is a "trick", a meta task which does not change, and we can use in
+    # the protected branch rules as opposed to the tests one above which
+    # may change regularly.
+    validate-autoreview:
+        name: AutoReview tests status
+        runs-on: ubuntu-latest
+        needs:
+            - composer-validate
+        if: always()
+        steps:
+            - name: Successful run
+              if: ${{ !(contains(needs.*.result, 'failure')) }}
+              run: exit 0
+
+            - name: Failing run
+              if: ${{ contains(needs.*.result, 'failure') }}
+              run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .phpbrew
 .phpcs.cache
 /build
+/vendor-bin/*/vendor/

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ CP            = cp
 INSTALL_PATH  = /usr/local/bin
 TEST          = phpunit
 
+RECTOR_BIN = vendor-bin/rector/vendor/bin/rector
+RECTOR = $(RECTOR_BIN)
+
 $(TARGET): vendor $(shell find bin/ shell/ src/ -type f) box.json.dist .git/HEAD
 	box compile
 	touch -c $@
@@ -25,8 +28,28 @@ update/completion:
 	bin/phpbrew zsh --bind phpbrew --program phpbrew > completion/zsh/_phpbrew
 	bin/phpbrew bash --bind phpbrew --program phpbrew > completion/bash/_phpbrew
 
+.PHONY: rector
+rector: $(RECTOR_BIN)
+	$(RECTOR)
+
+.PHONY: rector_lint
+rector_lint: $(RECTOR_BIN)
+	$(RECTOR) --dry-run
+
 test:
 	$(TEST)
 
 clean:
 	git checkout -- $(TARGET)
+
+.PHONY: rector_install
+rector_install: $(RECTOR_BIN)
+
+$(RECTOR_BIN): vendor-bin/rector/vendor
+	touch -c $@
+vendor-bin/rector/vendor: vendor-bin/rector/composer.lock $(COMPOSER_BIN_PLUGIN_VENDOR)
+	composer bin rector install --ansi
+	touch -c $@
+vendor-bin/rector/composer.lock: vendor-bin/rector/composer.json
+	composer bin rector update --lock --ansi
+	touch -c $@

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     "config" : {
         "platform": {
             "php": "7.2.5"
+        },
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
         }
     },
     "bin": [
@@ -33,11 +36,16 @@
     },
     "require-dev": {
         "php-vcr/php-vcr": "^1.5.4",
-        "phpunit/phpunit": "^8.5.33"
+        "phpunit/phpunit": "^8.5.33",
+        "bamarni/composer-bin-plugin": "^1.8"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev"
+        },
+        "bamarni-bin": {
+            "bin-links": false,
+            "forward-command": false
         }
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0122eaa7927d9d203c014d9be531f26",
+    "content-hash": "06fd8011aae1fe5081017ff42ac9bef2",
     "packages": [
         {
             "name": "corneltek/class-template",
@@ -1049,6 +1049,63 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "bamarni/composer-bin-plugin",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bamarni/composer-bin-plugin.git",
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "ext-json": "*",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.5",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Bamarni\\Composer\\Bin\\BamarniBinPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Bamarni\\Composer\\Bin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "No conflicts for your bin dependencies",
+            "keywords": [
+                "composer",
+                "conflict",
+                "dependency",
+                "executable",
+                "isolation",
+                "tool"
+            ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.2"
+            },
+            "time": "2022-10-31T08:38:03+00:00"
+        },
         {
             "name": "beberlei/assert",
             "version": "v3.3.2",
@@ -2896,7 +2953,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.5 || <9.0",
+        "php": "^7.2.5 || ^8.0",
         "ext-simplexml": "*"
     },
     "platform-dev": [],

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\DowngradeLevelSetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        DowngradeLevelSetList::DOWN_TO_PHP_72,
+    ])
+    ->withImportNames(removeUnusedImports: true);

--- a/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
+++ b/src/PhpBrew/Command/ExtensionCommand/InstallCommand.php
@@ -10,7 +10,6 @@ use PhpBrew\Extension\ExtensionDownloader;
 use PhpBrew\Extension\ExtensionFactory;
 use PhpBrew\Extension\ExtensionManager;
 use PhpBrew\ExtensionList;
-use PhpBrew\Utils;
 
 class InstallCommand extends BaseCommand
 {

--- a/src/PhpBrew/Command/InstallCommand.php
+++ b/src/PhpBrew/Command/InstallCommand.php
@@ -2,6 +2,7 @@
 
 namespace PhpBrew\Command;
 
+use RuntimeException;
 use CLIFramework\Command;
 use CLIFramework\ValueCollection;
 use Exception;
@@ -27,7 +28,6 @@ use PhpBrew\Tasks\TestTask;
 use PhpBrew\VariantBuilder;
 use PhpBrew\VariantParser;
 use PhpBrew\VersionDslParser;
-use SplFileInfo;
 
 class InstallCommand extends Command
 {
@@ -267,7 +267,7 @@ class InstallCommand extends Command
         $installPrefix = Config::getInstallPrefix() . DIRECTORY_SEPARATOR . $build->getName();
         if (!file_exists($installPrefix)) {
             if (!mkdir($installPrefix, 0755, true) && !is_dir($installPrefix)) {
-                throw new \RuntimeException(sprintf('Directory "%s" was not created', $installPrefix));
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $installPrefix));
             }
         }
         $build->setInstallPrefix($installPrefix);
@@ -335,7 +335,7 @@ class InstallCommand extends Command
         $buildDir = $this->options->{'build-dir'} ?: Config::getBuildDir();
         if (!file_exists($buildDir)) {
             if (!mkdir($buildDir, 0755, true) && !is_dir($buildDir)) {
-                throw new \RuntimeException(sprintf('Directory "%s" was not created', $buildDir));
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $buildDir));
             }
         }
 

--- a/src/PhpBrew/Command/PurgeCommand.php
+++ b/src/PhpBrew/Command/PurgeCommand.php
@@ -2,10 +2,7 @@
 
 namespace PhpBrew\Command;
 
-use CLIFramework\Command;
-use Exception;
 use PhpBrew\BuildFinder;
-use PhpBrew\Config;
 
 /**
  * @codeCoverageIgnore

--- a/src/PhpBrew/Extension/ExtensionManager.php
+++ b/src/PhpBrew/Extension/ExtensionManager.php
@@ -2,6 +2,7 @@
 
 namespace PhpBrew\Extension;
 
+use RuntimeException;
 use CLIFramework\Logger;
 use Exception;
 use PhpBrew\Config;
@@ -92,7 +93,7 @@ class ExtensionManager
 
         if (!file_exists(dirname($ini))) {
             if (!mkdir($concurrentDirectory = dirname($ini), 0755, true) && !is_dir($concurrentDirectory)) {
-                throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
             }
         }
 

--- a/src/PhpBrew/ExtensionList.php
+++ b/src/PhpBrew/ExtensionList.php
@@ -2,6 +2,9 @@
 
 namespace PhpBrew;
 
+use PhpBrew\Extension\Provider\GithubProvider;
+use PhpBrew\Extension\Provider\BitbucketProvider;
+use PhpBrew\Extension\Provider\PeclProvider;
 use CLIFramework\Logger;
 use GetOptionKit\OptionResult;
 use PhpBrew\Extension\Provider\Provider;
@@ -29,9 +32,9 @@ class ExtensionList
             return $providers;
         }
         $providers = array(
-            new Extension\Provider\GithubProvider(),
-            new Extension\Provider\BitbucketProvider(),
-            new Extension\Provider\PeclProvider($this->logger, $this->options),
+            new GithubProvider(),
+            new BitbucketProvider(),
+            new PeclProvider($this->logger, $this->options),
         );
 
         return $providers;

--- a/src/PhpBrew/PatchKit/DiffPatchRule.php
+++ b/src/PhpBrew/PatchKit/DiffPatchRule.php
@@ -66,7 +66,7 @@ final class DiffPatchRule implements PatchRule
             $build->getSourceDirectory()
         );
 
-        if (fwrite($pipes[0], $this->patch) === false) {
+        if (!fwrite($pipes[0], $this->patch)) {
             return 0;
         }
 

--- a/src/PhpBrew/Tasks/ConfigureTask.php
+++ b/src/PhpBrew/Tasks/ConfigureTask.php
@@ -4,7 +4,6 @@ namespace PhpBrew\Tasks;
 
 use PhpBrew\Build;
 use PhpBrew\CommandBuilder;
-use PhpBrew\Config;
 use PhpBrew\ConfigureParameters;
 use PhpBrew\Exception\SystemCommandException;
 

--- a/src/PhpBrew/Testing/CommandTestCase.php
+++ b/src/PhpBrew/Testing/CommandTestCase.php
@@ -2,6 +2,7 @@
 
 namespace PhpBrew\Testing;
 
+use CurlKit\CurlException;
 use CLIFramework\Testing\CommandTestCase as BaseCommandTestCase;
 use GetOptionKit\Option;
 use PhpBrew\Console;
@@ -96,7 +97,7 @@ abstract class CommandTestCase extends BaseCommandTestCase
             ob_end_clean();
 
             $this->assertTrue($ret, $output);
-        } catch (\CurlKit\CurlException $e) {
+        } catch (CurlException $e) {
             $this->markTestIncomplete($e->getMessage());
         }
     }

--- a/tests/PhpBrew/ConfigTest.php
+++ b/tests/PhpBrew/ConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpBrew\Tests;
 
+use Exception;
 use PhpBrew\Config;
 use PHPUnit\Framework\TestCase;
 
@@ -233,7 +234,7 @@ class ConfigTest extends TestCase
         try {
             $callback($this);
             $this->resetEnv($oldEnv);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->resetEnv($oldEnv);
             throw $e;
         }

--- a/tests/PhpBrew/VariantParserTest.php
+++ b/tests/PhpBrew/VariantParserTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpBrew\Tests;
 
-use Cassandra\Exception\InvalidSyntaxException;
 use PhpBrew\VariantParser;
 use PHPUnit\Framework\TestCase;
 

--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+        "platform": {
+            "php": "8.3"
+        },
+        "sort-packages": true
+    },
+    "require-dev": {
+        "rector/rector": "^1.1"
+    }
+}

--- a/vendor-bin/rector/composer.lock
+++ b/vendor-bin/rector/composer.lock
@@ -1,0 +1,136 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "8fe65936ee2443d821ae272d14620733",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/490f0ae1c92b082f154681d7849aee776a7c1443",
+                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-06-17T15:10:54+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "c930cdb21294f10955ddfc31b720971e8333943d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c930cdb21294f10955ddfc31b720971e8333943d",
+                "reference": "c930cdb21294f10955ddfc31b720971e8333943d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.11"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-06-21T07:51:17+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/vendor-bin/rector/composer.lock
+++ b/vendor-bin/rector/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8fe65936ee2443d821ae272d14620733",
+    "content-hash": "ae033b4de1872ebd03cddb0c764f6fb1",
     "packages": [],
     "packages-dev": [
         {
@@ -132,5 +132,8 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.3"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This PR introduces [Rector](https://getrector.com).

It is a tool I've been using moderately for the past few years and IMO can help our either punctually for some migration tasks or for some menial tasks.

Here I configured it with:

- Import symbols when it can (i.e. make use of `use` statements instead of using a FQCN).
- Remove unneeded imports (IMO this is more a task of a CS-Fixer but it does not hurt to have it here either, and there is no CS fixer at the moment).
- Ensure the code is PHP 7.2 compatible. This way if you accidentally add a non PHP 7.2 compatible code, this will be flagged or fixed.

Locally you can use:

```
# Execute rector lint
make rector_lint

# Execute rector "fix"
make rector
```