### PR TITLE
Update release.yaml for CVE-2024-42471

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
             - build-phar
         if: github.event_name == 'release'
         steps:
-            -   uses: actions/download-artifact@v3
+            -   uses: actions/download-artifact@v4
                 with:
                     name: phpbrew-phar
                     path: .


### PR DESCRIPTION
Update `release.yaml` to upgrade the `actions/download-artifact`  for the `CVE-2024-42471`.