### PR TITLE
Php 8.4 deprecations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0122eaa7927d9d203c014d9be531f26",
+    "content-hash": "fdc4592d3ee14556c91772d97a37b009",
     "packages": [
         {
             "name": "corneltek/class-template",
@@ -218,16 +218,16 @@
         },
         {
             "name": "corneltek/getoptionkit",
-            "version": "2.7.2",
+            "version": "2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/GetOptionKit.git",
-                "reference": "aab2728de80175217cab0d7a4d078c3eb907e2c0"
+                "reference": "3d42c14251cfd8becbffc851852de3587d4e8eec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/aab2728de80175217cab0d7a4d078c3eb907e2c0",
-                "reference": "aab2728de80175217cab0d7a4d078c3eb907e2c0",
+                "url": "https://api.github.com/repos/c9s/GetOptionKit/zipball/3d42c14251cfd8becbffc851852de3587d4e8eec",
+                "reference": "3d42c14251cfd8becbffc851852de3587d4e8eec",
                 "shasum": ""
             },
             "require": {
@@ -261,9 +261,9 @@
             "homepage": "http://github.com/c9s/GetOptionKit",
             "support": {
                 "issues": "https://github.com/c9s/GetOptionKit/issues",
-                "source": "https://github.com/c9s/GetOptionKit/tree/2.7.2"
+                "source": "https://github.com/c9s/GetOptionKit/tree/2.7.3"
             },
-            "time": "2023-04-14T03:35:14+00:00"
+            "time": "2024-12-18T10:10:51+00:00"
         },
         {
             "name": "corneltek/pearx",
@@ -2896,10 +2896,10 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.5 || <9.0",
+        "php": "^7.2.5 || ^8.0",
         "ext-simplexml": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.2.5"
     },

--- a/src/PhpBrew/Build.php
+++ b/src/PhpBrew/Build.php
@@ -14,7 +14,7 @@ use PhpBrew\BuildSettings\BuildSettings;
  * @method bool isEnabledVariant(string $variant)
  * @method bool isDisabledVariant(string $variant)
  * @method array getExtraOptions()
- * @method enableVariant(string $variant, string $value = null)
+ * @method enableVariant(string $variant, ?string $value = null)
  * @method disableVariant(string $variant)
  * @method removeVariant(string $variant)
  * @method array resolveVariants()

--- a/src/PhpBrew/Exception/SystemCommandException.php
+++ b/src/PhpBrew/Exception/SystemCommandException.php
@@ -11,7 +11,7 @@ class SystemCommandException extends RuntimeException
 
     protected $build;
 
-    public function __construct($message, Buildable $build = null, $logFile = null)
+    public function __construct($message, ?Buildable $build = null, $logFile = null)
     {
         parent::__construct($message);
         $this->build = $build;

--- a/src/PhpBrew/Extension/ExtensionInstaller.php
+++ b/src/PhpBrew/Extension/ExtensionInstaller.php
@@ -14,7 +14,7 @@ class ExtensionInstaller
 
     public $options;
 
-    public function __construct(Logger $logger, OptionResult $options = null)
+    public function __construct(Logger $logger, ?OptionResult $options = null)
     {
         $this->logger = $logger;
         $this->options = $options ?: new OptionResult();

--- a/src/PhpBrew/ReleaseList.php
+++ b/src/PhpBrew/ReleaseList.php
@@ -138,7 +138,7 @@ class ReleaseList
         $this->save();
     }
 
-    public static function getReadyInstance(OptionResult $options = null)
+    public static function getReadyInstance(?OptionResult $options = null)
     {
         static $instance;
 

--- a/src/PhpBrew/Tasks/BaseTask.php
+++ b/src/PhpBrew/Tasks/BaseTask.php
@@ -18,7 +18,7 @@ abstract class BaseTask
 
     public $finishedAt;
 
-    public function __construct(Logger $logger, OptionResult $options = null)
+    public function __construct(Logger $logger, ?OptionResult $options = null)
     {
         $this->startedAt = microtime(true);
         $this->logger = $logger;

--- a/src/PhpBrew/Tasks/PrepareDirectoryTask.php
+++ b/src/PhpBrew/Tasks/PrepareDirectoryTask.php
@@ -7,7 +7,7 @@ use PhpBrew\Config;
 
 class PrepareDirectoryTask extends BaseTask
 {
-    public function run(Build $build = null)
+    public function run(?Build $build = null)
     {
         $dirs = array();
         $dirs[] = Config::getRoot();

--- a/src/PhpBrew/VariantBuilder.php
+++ b/src/PhpBrew/VariantBuilder.php
@@ -990,7 +990,7 @@ class VariantBuilder
      *
      * @throws Exception
      */
-    public function build(Build $build, ConfigureParameters $parameters = null)
+    public function build(Build $build, ?ConfigureParameters $parameters = null)
     {
         $customVirtualVariants = Config::getConfigParam('variants');
         foreach (array_keys($build->getEnabledVariants()) as $variantName) {


### PR DESCRIPTION
There's still work to do on CLIFramework. GetOptionKit is already solved in `2.7.3` but the lock file isn't updated.

This PR updates lock file for the fixed GetOptionKit and also fixes the deprecations from the tool itself. Will need separate PR and release of https://github.com/c9s/CLIFramework and then a PR here for the final ones.

If `c9s` tooling is end of maintenance is it worth considering moving to Symfony CLI ?

Part fixes https://github.com/phpbrew/phpbrew/issues/1396